### PR TITLE
prevent to read coordinates repeatedly from Gaussian output

### DIFF
--- a/dpdata/gaussian/log.py
+++ b/dpdata/gaussian/log.py
@@ -26,8 +26,11 @@ def to_system_data(file_name):
                 energy = float(line.split()[4])
             elif line.startswith(" Center     Atomic                   Forces (Hartrees/Bohr)"):
                 flag = 1
+                forces = []
             elif line.startswith("                          Input orientation:"):
                 flag = 5
+                coords = []
+                atom_symbols = []
 
             if 1 <= flag <= 3 or 5 <= flag <= 9:
                 flag += 1
@@ -46,7 +49,7 @@ def to_system_data(file_name):
                     s = line.split()
                     coords.append([float(x) for x in s[3:6]])
                     atom_symbols.append(symbols[int(s[1])])
-        
+
     assert(coords), "cannot find coords"
     assert(energy), "cannot find energies"
     assert(forces), "cannot find forces"


### PR DESCRIPTION
This PR fixes a bug, which would read coordinates repeatedly from Gaussian output when coordinates appear for multiple times.