### PR TITLE
add MultiSystems and sort data when appending

### DIFF
--- a/dpdata/__init__.py
+++ b/dpdata/__init__.py
@@ -3,4 +3,5 @@ from . import lammps
 from . import md
 from .system import System
 from .system import LabeledSystem
+from .system import MultiSystems
 

--- a/dpdata/deepmd/comp.py
+++ b/dpdata/deepmd/comp.py
@@ -29,7 +29,7 @@ def to_system_data(folder, type_map = None) :
         all_coords.append(np.reshape(coords, [nframes,-1,3]))
         all_eners.append(np.reshape(eners, [nframes]))
         all_forces.append(np.reshape(forces, [nframes,-1,3]))
-        if len(virs) > 0:
+        if virs is not None and len(virs) > 0:
             virs = all_virs.append(np.reshape(virs, [nframes,3,3]))
     data['cells'] = np.concatenate(all_cells, axis = 0)
     data['coords'] = np.concatenate(all_coords, axis = 0)

--- a/tests/gaussian/methane_reordered.gaussianlog
+++ b/tests/gaussian/methane_reordered.gaussianlog
@@ -1,0 +1,342 @@
+ Entering Gaussian System, Link 0=g16
+ Initial command:
+ /home/jzzeng/soft/g16/l1.exe "/home/jzzeng/test/Gau-15026.inp" -scrdir="/home/jzzeng/test/"
+ Entering Link 1 = /home/jzzeng/soft/g16/l1.exe PID=     15028.
+  
+ Copyright (c) 1988,1990,1992,1993,1995,1998,2003,2009,2016,
+            Gaussian, Inc.  All Rights Reserved.
+  
+ This is part of the Gaussian(R) 16 program.  It is based on
+ the Gaussian(R) 09 system (copyright 2009, Gaussian, Inc.),
+ the Gaussian(R) 03 system (copyright 2003, Gaussian, Inc.),
+ the Gaussian(R) 98 system (copyright 1998, Gaussian, Inc.),
+ the Gaussian(R) 94 system (copyright 1995, Gaussian, Inc.),
+ the Gaussian 92(TM) system (copyright 1992, Gaussian, Inc.),
+ the Gaussian 90(TM) system (copyright 1990, Gaussian, Inc.),
+ the Gaussian 88(TM) system (copyright 1988, Gaussian, Inc.),
+ the Gaussian 86(TM) system (copyright 1986, Carnegie Mellon
+ University), and the Gaussian 82(TM) system (copyright 1983,
+ Carnegie Mellon University). Gaussian is a federally registered
+ trademark of Gaussian, Inc.
+  
+ This software contains proprietary and confidential information,
+ including trade secrets, belonging to Gaussian, Inc.
+  
+ This software is provided under written license and may be
+ used, copied, transmitted, or stored only in accord with that
+ written license.
+  
+ The following legend is applicable only to US Government
+ contracts under FAR:
+  
+                    RESTRICTED RIGHTS LEGEND
+  
+ Use, reproduction and disclosure by the US Government is
+ subject to restrictions as set forth in subparagraphs (a)
+ and (c) of the Commercial Computer Software - Restricted
+ Rights clause in FAR 52.227-19.
+  
+ Gaussian, Inc.
+ 340 Quinnipiac St., Bldg. 40, Wallingford CT 06492
+  
+  
+ ---------------------------------------------------------------
+ Warning -- This program may not be used in any manner that
+ competes with the business of Gaussian, Inc. or will provide
+ assistance to any competitor of Gaussian, Inc.  The licensee
+ of this program is prohibited from giving any competitor of
+ Gaussian, Inc. access to this program.  By using this program,
+ the user acknowledges that Gaussian, Inc. is engaged in the
+ business of creating and licensing software in the field of
+ computational chemistry and represents and warrants to the
+ licensee that it is not a competitor of Gaussian, Inc. and that
+ it will not use this program in any manner prohibited above.
+ ---------------------------------------------------------------
+  
+
+ Cite this work as:
+ Gaussian 16, Revision A.03,
+ M. J. Frisch, G. W. Trucks, H. B. Schlegel, G. E. Scuseria, 
+ M. A. Robb, J. R. Cheeseman, G. Scalmani, V. Barone, 
+ G. A. Petersson, H. Nakatsuji, X. Li, M. Caricato, A. V. Marenich, 
+ J. Bloino, B. G. Janesko, R. Gomperts, B. Mennucci, H. P. Hratchian, 
+ J. V. Ortiz, A. F. Izmaylov, J. L. Sonnenberg, D. Williams-Young, 
+ F. Ding, F. Lipparini, F. Egidi, J. Goings, B. Peng, A. Petrone, 
+ T. Henderson, D. Ranasinghe, V. G. Zakrzewski, J. Gao, N. Rega, 
+ G. Zheng, W. Liang, M. Hada, M. Ehara, K. Toyota, R. Fukuda, 
+ J. Hasegawa, M. Ishida, T. Nakajima, Y. Honda, O. Kitao, H. Nakai, 
+ T. Vreven, K. Throssell, J. A. Montgomery, Jr., J. E. Peralta, 
+ F. Ogliaro, M. J. Bearpark, J. J. Heyd, E. N. Brothers, K. N. Kudin, 
+ V. N. Staroverov, T. A. Keith, R. Kobayashi, J. Normand, 
+ K. Raghavachari, A. P. Rendell, J. C. Burant, S. S. Iyengar, 
+ J. Tomasi, M. Cossi, J. M. Millam, M. Klene, C. Adamo, R. Cammi, 
+ J. W. Ochterski, R. L. Martin, K. Morokuma, O. Farkas, 
+ J. B. Foresman, and D. J. Fox, Gaussian, Inc., Wallingford CT, 2016.
+ 
+ ******************************************
+ Gaussian 16:  ES64L-G16RevA.03 25-Dec-2016
+                25-Jun-2019 
+ ******************************************
+ %nproc=28
+ Will use up to   28 processors via shared memory.
+ --------------------
+ #force b3lyp/6-31g**
+ --------------------
+ 1/10=7,30=1,38=1/1,3;
+ 2/12=2,17=6,18=5,40=1/2;
+ 3/5=1,6=6,7=101,11=2,25=1,30=1,71=1,74=-5/1,2,3;
+ 4//1;
+ 5/5=2,38=5/2;
+ 6/7=2,8=2,9=2,10=2,28=1/1;
+ 7/29=1/1,2,3,16;
+ 1/10=7,30=1/3;
+ 99//99;
+ -------
+ methane
+ -------
+ Symbolic Z-matrix:
+ Charge =  0 Multiplicity = 1
+ H                     2.16642  -0.06034   0.02917 
+ C                     1.07422  -0.06034   0.02917 
+ H                     0.71015  -0.92887  -0.52401 
+ H                     0.71015   0.85299  -0.44641 
+ H                     0.71015  -0.10514   1.05793 
+ 
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Initialization pass.
+ Trust Radius=3.00D-01 FncErr=1.00D-07 GrdErr=1.00D-07 EigMax=2.50D+02 EigMin=1.00D-04
+ Number of steps in this run=      2 maximum allowed number of steps=      2.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          1           0        2.166420   -0.060340    0.029170
+      2          6           0        1.074220   -0.060340    0.029170
+      3          1           0        0.710150   -0.928870   -0.524010
+      4          1           0        0.710150    0.852990   -0.446410
+      5          1           0        0.710150   -0.105140    1.057930
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  C    0.000000
+     2  H    1.092200   0.000000
+     3  H    1.092199   1.783557   0.000000
+     4  H    1.092197   1.783556   1.783549   0.000000
+     5  H    1.092200   1.783557   1.783554   1.783550   0.000000
+ Stoichiometry    CH4
+ Framework group  C1[X(CH4)]
+ Deg. of freedom     9
+ Full point group                 C1      NOp   1
+ Largest Abelian subgroup         C1      NOp   1
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0       -0.000001    0.000000    0.000000
+      2          1           0       -1.092201    0.000000    0.000000
+      3          1           0        0.364069   -0.813864   -0.630855
+      4          1           0        0.364069   -0.139406    1.020252
+      5          1           0        0.364069    0.953270   -0.389397
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):         157.6380023         157.6375616         157.6370163
+ Standard basis: 6-31G(d,p) (6D, 7F)
+ There are    35 symmetry adapted cartesian basis functions of A   symmetry.
+ There are    35 symmetry adapted basis functions of A   symmetry.
+    35 basis functions,    56 primitive gaussians,    35 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy        13.4083363407 Hartrees.
+ NAtoms=    5 NActive=    5 NUniq=    5 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    35 RedAO= T EigKep=  1.79D-02  NBF=    35
+ NBsUse=    35 1.00D-06 EigRej= -1.00D+00 NBFU=    35
+ ExpMin= 1.61D-01 ExpMax= 3.05D+03 ExpMxC= 4.57D+02 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ Harris functional with IExCor=  402 and IRadAn=       5 diagonalized for initial guess.
+ HarFok:  IExCor=  402 AccDes= 0.00D+00 IRadAn=         5 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Keep R1 ints in memory in canonical form, NReq=24354403.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(RB3LYP) =  -40.5240137309     A.U. after    8 cycles
+            NFock=  8  Conv=0.23D-08     -V/T= 2.0111
+
+ **********************************************************************
+
+            Population analysis using the SCF density.
+
+ **********************************************************************
+
+ Orbital symmetries:
+       Occupied  (A) (A) (A) (A) (A)
+       Virtual   (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A)
+ The electronic state is 1-A.
+ Alpha  occ. eigenvalues --  -10.16717  -0.69034  -0.38827  -0.38827  -0.38827
+ Alpha virt. eigenvalues --    0.11818   0.17670   0.17670   0.17670   0.52921
+ Alpha virt. eigenvalues --    0.52921   0.52921   0.87424   0.87424   0.87424
+ Alpha virt. eigenvalues --    0.92208   1.10023   1.36345   1.36345   2.04806
+ Alpha virt. eigenvalues --    2.04806   2.04806   2.05141   2.05142   2.05142
+ Alpha virt. eigenvalues --    2.62952   2.62953   2.62953   2.91074   2.91074
+ Alpha virt. eigenvalues --    3.11458   3.41994   3.41994   3.41994   4.42248
+          Condensed to atoms (all electrons):
+               1          2          3          4          5
+     1  C    4.899051   0.392830   0.392830   0.392830   0.392830
+     2  H    0.392830   0.573073  -0.027832  -0.027832  -0.027832
+     3  H    0.392830  -0.027832   0.573075  -0.027833  -0.027832
+     4  H    0.392830  -0.027832  -0.027833   0.573074  -0.027833
+     5  H    0.392830  -0.027832  -0.027832  -0.027833   0.573075
+ Mulliken charges:
+               1
+     1  C   -0.470371
+     2  H    0.117593
+     3  H    0.117593
+     4  H    0.117593
+     5  H    0.117593
+ Sum of Mulliken charges =   0.00000
+ Mulliken charges with hydrogens summed into heavy atoms:
+               1
+     1  C    0.000000
+ Electronic spatial extent (au):  <R**2>=             35.4329
+ Charge=              0.0000 electrons
+ Dipole moment (field-independent basis, Debye):
+    X=              0.0000    Y=             -0.0000    Z=              0.0000  Tot=              0.0000
+ Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=             -8.2465   YY=             -8.2465   ZZ=             -8.2465
+   XY=             -0.0000   XZ=              0.0000   YZ=              0.0000
+ Traceless Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=              0.0000   YY=             -0.0000   ZZ=             -0.0000
+   XY=             -0.0000   XZ=              0.0000   YZ=              0.0000
+ Octapole moment (field-independent basis, Debye-Ang**2):
+  XXX=             -0.7604  YYY=              0.2130  ZZZ=              0.4937  XYY=              0.3802
+  XXY=             -0.0000  XXZ=              0.0000  XZZ=              0.3802  YZZ=             -0.2130
+  YYZ=             -0.4937  XYZ=              0.0000
+ Hexadecapole moment (field-independent basis, Debye-Ang**3):
+ XXXX=            -14.9429 YYYY=            -15.1704 ZZZZ=            -15.1704 XXXY=             -0.0000
+ XXXZ=              0.0000 YYYX=              0.1275 YYYZ=              0.0000 ZZZX=              0.2954
+ ZZZY=             -0.0000 XXYY=             -5.2843 XXZZ=             -5.2843 YYZZ=             -5.0568
+ XXYZ=              0.0000 YYXZ=             -0.2954 ZZXY=             -0.1275
+ N-N= 1.340833634068D+01 E-N=-1.198747475070D+02  KE= 4.007727827872D+01
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        1          -0.000215948   -0.000000016   -0.000000010
+      2        6          -0.000000623   -0.000000654    0.000000794
+      3        1           0.000072325    0.000170842    0.000109258
+      4        1           0.000071925   -0.000178640    0.000093176
+      5        1           0.000072322    0.000008469   -0.000203220
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.000215948 RMS     0.000111163
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   1 out of a maximum of    2
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Second derivative matrix not updated -- first step.
+ The second derivative matrix:
+                          X1        Y1        Z1        X2        Y2
+           X1           0.66422
+           Y1          -0.00000   0.66422
+           Z1           0.00000  -0.00000   0.66422
+           X2          -0.34560  -0.00000   0.00000   0.34560
+           Y2          -0.00000  -0.07628  -0.00000   0.00000   0.05678
+           Z2           0.00000  -0.00000  -0.07628  -0.00000   0.00000
+           X3          -0.10621  -0.07139  -0.04547  -0.00000  -0.02998
+           Y3          -0.07139  -0.24659  -0.10847   0.00000   0.00907
+           Z3          -0.04547  -0.10847  -0.14537   0.00000   0.00550
+           X4          -0.10621   0.07507  -0.03909  -0.00000   0.03153
+           Y4           0.07507  -0.26461   0.09806  -0.00000   0.00998
+           Z4          -0.03909   0.09806  -0.12735   0.00000  -0.00497
+           X5          -0.10621  -0.00368   0.08456   0.00000  -0.00155
+           Y5          -0.00368  -0.07674   0.01040  -0.00000   0.00046
+           Z5           0.08456   0.01041  -0.31522   0.00000  -0.00053
+                          Z2        X3        Y3        Z3        X4
+           Z2           0.05678
+           X3          -0.01910   0.08887
+           Y3           0.00550   0.07656   0.23942
+           Z3           0.00394   0.04876   0.11633   0.13087
+           X4          -0.01642   0.00867  -0.01076   0.01119   0.08887
+           Y4          -0.00497   0.00975  -0.01251   0.01323  -0.08051
+           Z4           0.00302   0.01208  -0.01579   0.01685   0.04192
+           X5           0.03551   0.00867   0.00559  -0.01448   0.00867
+           Y5          -0.00053   0.01507   0.01062  -0.02659  -0.01533
+           Z5           0.01255   0.00372   0.00244  -0.00628   0.00240
+                          Y4        Z4        X5        Y5        Z5
+           Y4           0.25875
+           Z4          -0.10517   0.11154
+           X5          -0.00431  -0.01491   0.08887
+           Y5           0.00840   0.02787   0.00395   0.05726
+           Z5          -0.00116  -0.00406  -0.09068  -0.01116   0.31302
+ ITU=  0
+     Eigenvalues ---    0.11268   0.11268   0.13515   0.13515   0.13515
+     Eigenvalues ---    0.34560   0.81139   0.81139   0.81140
+ Angle between quadratic step and forces=   0.37 degrees.
+ Linear search not attempted -- first point.
+ B after Tr=    -0.000001    0.000000   -0.000000
+         Rot=    1.000000    0.000000   -0.000000   -0.000000 Ang=   0.00 deg.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    X1        2.02998  -0.00000   0.00000  -0.00000  -0.00000   2.02998
+    Y1       -0.11403  -0.00000   0.00000   0.00000   0.00000  -0.11403
+    Z1        0.05512   0.00000   0.00000  -0.00000  -0.00000   0.05512
+    X2        4.09394  -0.00022   0.00000  -0.00063  -0.00063   4.09331
+    Y2       -0.11403  -0.00000   0.00000  -0.00000  -0.00000  -0.11403
+    Z2        0.05512  -0.00000   0.00000   0.00000  -0.00000   0.05512
+    X3        1.34199   0.00007   0.00000   0.00021   0.00021   1.34220
+    Y3       -1.75531   0.00017   0.00000   0.00049   0.00049  -1.75482
+    Z3       -0.99024   0.00011   0.00000   0.00032   0.00032  -0.98992
+    X4        1.34199   0.00007   0.00000   0.00021   0.00021   1.34220
+    Y4        1.61192  -0.00018   0.00000  -0.00051  -0.00051   1.61140
+    Z4       -0.84359   0.00009   0.00000   0.00027   0.00027  -0.84332
+    X5        1.34199   0.00007   0.00000   0.00021   0.00021   1.34220
+    Y5       -0.19869   0.00001   0.00000   0.00002   0.00002  -0.19866
+    Z5        1.99920  -0.00020   0.00000  -0.00059  -0.00059   1.99861
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000216     0.000450     YES
+ RMS     Force            0.000111     0.000300     YES
+ Maximum Displacement     0.000628     0.001800     YES
+ RMS     Displacement     0.000322     0.001200     YES
+ Predicted change in Energy=-2.681743D-07
+ Optimization completed.
+    -- Stationary point found.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ 1\1\GINC-LOCALHOST\Force\RB3LYP\6-31G(d,p)\C1H4\JZZENG\25-Jun-2019\0\\
+ #force b3lyp/6-31g**\\methane\\0,1\C,1.07422,-0.06034,0.02917\H,2.1664
+ 2,-0.06034,0.02917\H,0.71015,-0.92887,-0.52401\H,0.71015,0.85299,-0.44
+ 641\H,0.71015,-0.10514,1.05793\\Version=ES64L-G16RevA.03\State=1-A\HF=
+ -40.5240137\RMSD=2.291e-09\RMSF=1.112e-04\Dipole=-0.0000018,0.0000007,
+ -0.0000007\Quadrupole=0.0000105,-0.0000083,-0.0000022,-0.000001,0.0000
+ 01,0.0000025\PG=C01 [X(C1H4)]\\@
+
+
+ SEE YOU NOW,
+ YOUR BAIT OF FALSEHOOD TAKES THIS CARP OF TRUTH.
+ AND THUS DO WE OF WISDOM AND OF REACH...
+ BY INDIRECTIONS FIND DIRECTIONS OUT.    -- HAMLET, II, 1
+ Job cpu time:       0 days  0 hours  1 minutes 11.1 seconds.
+ Elapsed time:       0 days  0 hours  0 minutes  3.2 seconds.
+ File lengths (MBytes):  RWF=      6 Int=      0 D2E=      0 Chk=      1 Scr=      1
+ Normal termination of Gaussian 16 at Tue Jun 25 00:14:07 2019.

--- a/tests/gaussian/methane_sub.gaussianlog
+++ b/tests/gaussian/methane_sub.gaussianlog
@@ -1,0 +1,339 @@
+ Entering Gaussian System, Link 0=g16
+ Initial command:
+ /home/jzzeng/soft/g16/l1.exe "/home/jzzeng/test/Gau-15026.inp" -scrdir="/home/jzzeng/test/"
+ Entering Link 1 = /home/jzzeng/soft/g16/l1.exe PID=     15028.
+  
+ Copyright (c) 1988,1990,1992,1993,1995,1998,2003,2009,2016,
+            Gaussian, Inc.  All Rights Reserved.
+  
+ This is part of the Gaussian(R) 16 program.  It is based on
+ the Gaussian(R) 09 system (copyright 2009, Gaussian, Inc.),
+ the Gaussian(R) 03 system (copyright 2003, Gaussian, Inc.),
+ the Gaussian(R) 98 system (copyright 1998, Gaussian, Inc.),
+ the Gaussian(R) 94 system (copyright 1995, Gaussian, Inc.),
+ the Gaussian 92(TM) system (copyright 1992, Gaussian, Inc.),
+ the Gaussian 90(TM) system (copyright 1990, Gaussian, Inc.),
+ the Gaussian 88(TM) system (copyright 1988, Gaussian, Inc.),
+ the Gaussian 86(TM) system (copyright 1986, Carnegie Mellon
+ University), and the Gaussian 82(TM) system (copyright 1983,
+ Carnegie Mellon University). Gaussian is a federally registered
+ trademark of Gaussian, Inc.
+  
+ This software contains proprietary and confidential information,
+ including trade secrets, belonging to Gaussian, Inc.
+  
+ This software is provided under written license and may be
+ used, copied, transmitted, or stored only in accord with that
+ written license.
+  
+ The following legend is applicable only to US Government
+ contracts under FAR:
+  
+                    RESTRICTED RIGHTS LEGEND
+  
+ Use, reproduction and disclosure by the US Government is
+ subject to restrictions as set forth in subparagraphs (a)
+ and (c) of the Commercial Computer Software - Restricted
+ Rights clause in FAR 52.227-19.
+  
+ Gaussian, Inc.
+ 340 Quinnipiac St., Bldg. 40, Wallingford CT 06492
+  
+  
+ ---------------------------------------------------------------
+ Warning -- This program may not be used in any manner that
+ competes with the business of Gaussian, Inc. or will provide
+ assistance to any competitor of Gaussian, Inc.  The licensee
+ of this program is prohibited from giving any competitor of
+ Gaussian, Inc. access to this program.  By using this program,
+ the user acknowledges that Gaussian, Inc. is engaged in the
+ business of creating and licensing software in the field of
+ computational chemistry and represents and warrants to the
+ licensee that it is not a competitor of Gaussian, Inc. and that
+ it will not use this program in any manner prohibited above.
+ ---------------------------------------------------------------
+  
+
+ Cite this work as:
+ Gaussian 16, Revision A.03,
+ M. J. Frisch, G. W. Trucks, H. B. Schlegel, G. E. Scuseria, 
+ M. A. Robb, J. R. Cheeseman, G. Scalmani, V. Barone, 
+ G. A. Petersson, H. Nakatsuji, X. Li, M. Caricato, A. V. Marenich, 
+ J. Bloino, B. G. Janesko, R. Gomperts, B. Mennucci, H. P. Hratchian, 
+ J. V. Ortiz, A. F. Izmaylov, J. L. Sonnenberg, D. Williams-Young, 
+ F. Ding, F. Lipparini, F. Egidi, J. Goings, B. Peng, A. Petrone, 
+ T. Henderson, D. Ranasinghe, V. G. Zakrzewski, J. Gao, N. Rega, 
+ G. Zheng, W. Liang, M. Hada, M. Ehara, K. Toyota, R. Fukuda, 
+ J. Hasegawa, M. Ishida, T. Nakajima, Y. Honda, O. Kitao, H. Nakai, 
+ T. Vreven, K. Throssell, J. A. Montgomery, Jr., J. E. Peralta, 
+ F. Ogliaro, M. J. Bearpark, J. J. Heyd, E. N. Brothers, K. N. Kudin, 
+ V. N. Staroverov, T. A. Keith, R. Kobayashi, J. Normand, 
+ K. Raghavachari, A. P. Rendell, J. C. Burant, S. S. Iyengar, 
+ J. Tomasi, M. Cossi, J. M. Millam, M. Klene, C. Adamo, R. Cammi, 
+ J. W. Ochterski, R. L. Martin, K. Morokuma, O. Farkas, 
+ J. B. Foresman, and D. J. Fox, Gaussian, Inc., Wallingford CT, 2016.
+ 
+ ******************************************
+ Gaussian 16:  ES64L-G16RevA.03 25-Dec-2016
+                25-Jun-2019 
+ ******************************************
+ %nproc=28
+ Will use up to   28 processors via shared memory.
+ --------------------
+ #force b3lyp/6-31g**
+ --------------------
+ 1/10=7,30=1,38=1/1,3;
+ 2/12=2,17=6,18=5,40=1/2;
+ 3/5=1,6=6,7=101,11=2,25=1,30=1,71=1,74=-5/1,2,3;
+ 4//1;
+ 5/5=2,38=5/2;
+ 6/7=2,8=2,9=2,10=2,28=1/1;
+ 7/29=1/1,2,3,16;
+ 1/10=7,30=1/3;
+ 99//99;
+ -------
+ methane
+ -------
+ Symbolic Z-matrix:
+ Charge =  0 Multiplicity = 1
+ H                     2.16642  -0.06034   0.02917 
+ C                     1.07422  -0.06034   0.02917 
+ H                     0.71015  -0.92887  -0.52401 
+ H                     0.71015   0.85299  -0.44641 
+ H                     0.71015  -0.10514   1.05793 
+ 
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Initialization pass.
+ Trust Radius=3.00D-01 FncErr=1.00D-07 GrdErr=1.00D-07 EigMax=2.50D+02 EigMin=1.00D-04
+ Number of steps in this run=      2 maximum allowed number of steps=      2.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          1           0        2.166420   -0.060340    0.029170
+      2          6           0        1.074220   -0.060340    0.029170
+      3          1           0        0.710150   -0.928870   -0.524010
+      4          1           0        0.710150    0.852990   -0.446410
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  C    0.000000
+     2  H    1.092200   0.000000
+     3  H    1.092199   1.783557   0.000000
+     4  H    1.092197   1.783556   1.783549   0.000000
+     5  H    1.092200   1.783557   1.783554   1.783550   0.000000
+ Stoichiometry    CH4
+ Framework group  C1[X(CH4)]
+ Deg. of freedom     9
+ Full point group                 C1      NOp   1
+ Largest Abelian subgroup         C1      NOp   1
+ Largest concise Abelian subgroup C1      NOp   1
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0       -0.000001    0.000000    0.000000
+      2          1           0       -1.092201    0.000000    0.000000
+      3          1           0        0.364069   -0.813864   -0.630855
+      4          1           0        0.364069   -0.139406    1.020252
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):         157.6380023         157.6375616         157.6370163
+ Standard basis: 6-31G(d,p) (6D, 7F)
+ There are    35 symmetry adapted cartesian basis functions of A   symmetry.
+ There are    35 symmetry adapted basis functions of A   symmetry.
+    35 basis functions,    56 primitive gaussians,    35 cartesian basis functions
+     5 alpha electrons        5 beta electrons
+       nuclear repulsion energy        13.4083363407 Hartrees.
+ NAtoms=    5 NActive=    5 NUniq=    5 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    35 RedAO= T EigKep=  1.79D-02  NBF=    35
+ NBsUse=    35 1.00D-06 EigRej= -1.00D+00 NBFU=    35
+ ExpMin= 1.61D-01 ExpMax= 3.05D+03 ExpMxC= 4.57D+02 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ Harris functional with IExCor=  402 and IRadAn=       5 diagonalized for initial guess.
+ HarFok:  IExCor=  402 AccDes= 0.00D+00 IRadAn=         5 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Keep R1 ints in memory in canonical form, NReq=24354403.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(RB3LYP) =  -40.5240137309     A.U. after    8 cycles
+            NFock=  8  Conv=0.23D-08     -V/T= 2.0111
+
+ **********************************************************************
+
+            Population analysis using the SCF density.
+
+ **********************************************************************
+
+ Orbital symmetries:
+       Occupied  (A) (A) (A) (A) (A)
+       Virtual   (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A) (A)
+                 (A) (A) (A) (A) (A) (A)
+ The electronic state is 1-A.
+ Alpha  occ. eigenvalues --  -10.16717  -0.69034  -0.38827  -0.38827  -0.38827
+ Alpha virt. eigenvalues --    0.11818   0.17670   0.17670   0.17670   0.52921
+ Alpha virt. eigenvalues --    0.52921   0.52921   0.87424   0.87424   0.87424
+ Alpha virt. eigenvalues --    0.92208   1.10023   1.36345   1.36345   2.04806
+ Alpha virt. eigenvalues --    2.04806   2.04806   2.05141   2.05142   2.05142
+ Alpha virt. eigenvalues --    2.62952   2.62953   2.62953   2.91074   2.91074
+ Alpha virt. eigenvalues --    3.11458   3.41994   3.41994   3.41994   4.42248
+          Condensed to atoms (all electrons):
+               1          2          3          4          5
+     1  C    4.899051   0.392830   0.392830   0.392830   0.392830
+     2  H    0.392830   0.573073  -0.027832  -0.027832  -0.027832
+     3  H    0.392830  -0.027832   0.573075  -0.027833  -0.027832
+     4  H    0.392830  -0.027832  -0.027833   0.573074  -0.027833
+     5  H    0.392830  -0.027832  -0.027832  -0.027833   0.573075
+ Mulliken charges:
+               1
+     1  C   -0.470371
+     2  H    0.117593
+     3  H    0.117593
+     4  H    0.117593
+     5  H    0.117593
+ Sum of Mulliken charges =   0.00000
+ Mulliken charges with hydrogens summed into heavy atoms:
+               1
+     1  C    0.000000
+ Electronic spatial extent (au):  <R**2>=             35.4329
+ Charge=              0.0000 electrons
+ Dipole moment (field-independent basis, Debye):
+    X=              0.0000    Y=             -0.0000    Z=              0.0000  Tot=              0.0000
+ Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=             -8.2465   YY=             -8.2465   ZZ=             -8.2465
+   XY=             -0.0000   XZ=              0.0000   YZ=              0.0000
+ Traceless Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=              0.0000   YY=             -0.0000   ZZ=             -0.0000
+   XY=             -0.0000   XZ=              0.0000   YZ=              0.0000
+ Octapole moment (field-independent basis, Debye-Ang**2):
+  XXX=             -0.7604  YYY=              0.2130  ZZZ=              0.4937  XYY=              0.3802
+  XXY=             -0.0000  XXZ=              0.0000  XZZ=              0.3802  YZZ=             -0.2130
+  YYZ=             -0.4937  XYZ=              0.0000
+ Hexadecapole moment (field-independent basis, Debye-Ang**3):
+ XXXX=            -14.9429 YYYY=            -15.1704 ZZZZ=            -15.1704 XXXY=             -0.0000
+ XXXZ=              0.0000 YYYX=              0.1275 YYYZ=              0.0000 ZZZX=              0.2954
+ ZZZY=             -0.0000 XXYY=             -5.2843 XXZZ=             -5.2843 YYZZ=             -5.0568
+ XXYZ=              0.0000 YYXZ=             -0.2954 ZZXY=             -0.1275
+ N-N= 1.340833634068D+01 E-N=-1.198747475070D+02  KE= 4.007727827872D+01
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 0 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        1          -0.000215948   -0.000000016   -0.000000010
+      2        6          -0.000000623   -0.000000654    0.000000794
+      3        1           0.000072325    0.000170842    0.000109258
+      4        1           0.000071925   -0.000178640    0.000093176
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.000215948 RMS     0.000111163
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Search for a local minimum.
+ Step number   1 out of a maximum of    2
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Second derivative matrix not updated -- first step.
+ The second derivative matrix:
+                          X1        Y1        Z1        X2        Y2
+           X1           0.66422
+           Y1          -0.00000   0.66422
+           Z1           0.00000  -0.00000   0.66422
+           X2          -0.34560  -0.00000   0.00000   0.34560
+           Y2          -0.00000  -0.07628  -0.00000   0.00000   0.05678
+           Z2           0.00000  -0.00000  -0.07628  -0.00000   0.00000
+           X3          -0.10621  -0.07139  -0.04547  -0.00000  -0.02998
+           Y3          -0.07139  -0.24659  -0.10847   0.00000   0.00907
+           Z3          -0.04547  -0.10847  -0.14537   0.00000   0.00550
+           X4          -0.10621   0.07507  -0.03909  -0.00000   0.03153
+           Y4           0.07507  -0.26461   0.09806  -0.00000   0.00998
+           Z4          -0.03909   0.09806  -0.12735   0.00000  -0.00497
+           X5          -0.10621  -0.00368   0.08456   0.00000  -0.00155
+           Y5          -0.00368  -0.07674   0.01040  -0.00000   0.00046
+           Z5           0.08456   0.01041  -0.31522   0.00000  -0.00053
+                          Z2        X3        Y3        Z3        X4
+           Z2           0.05678
+           X3          -0.01910   0.08887
+           Y3           0.00550   0.07656   0.23942
+           Z3           0.00394   0.04876   0.11633   0.13087
+           X4          -0.01642   0.00867  -0.01076   0.01119   0.08887
+           Y4          -0.00497   0.00975  -0.01251   0.01323  -0.08051
+           Z4           0.00302   0.01208  -0.01579   0.01685   0.04192
+           X5           0.03551   0.00867   0.00559  -0.01448   0.00867
+           Y5          -0.00053   0.01507   0.01062  -0.02659  -0.01533
+           Z5           0.01255   0.00372   0.00244  -0.00628   0.00240
+                          Y4        Z4        X5        Y5        Z5
+           Y4           0.25875
+           Z4          -0.10517   0.11154
+           X5          -0.00431  -0.01491   0.08887
+           Y5           0.00840   0.02787   0.00395   0.05726
+           Z5          -0.00116  -0.00406  -0.09068  -0.01116   0.31302
+ ITU=  0
+     Eigenvalues ---    0.11268   0.11268   0.13515   0.13515   0.13515
+     Eigenvalues ---    0.34560   0.81139   0.81139   0.81140
+ Angle between quadratic step and forces=   0.37 degrees.
+ Linear search not attempted -- first point.
+ B after Tr=    -0.000001    0.000000   -0.000000
+         Rot=    1.000000    0.000000   -0.000000   -0.000000 Ang=   0.00 deg.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    X1        2.02998  -0.00000   0.00000  -0.00000  -0.00000   2.02998
+    Y1       -0.11403  -0.00000   0.00000   0.00000   0.00000  -0.11403
+    Z1        0.05512   0.00000   0.00000  -0.00000  -0.00000   0.05512
+    X2        4.09394  -0.00022   0.00000  -0.00063  -0.00063   4.09331
+    Y2       -0.11403  -0.00000   0.00000  -0.00000  -0.00000  -0.11403
+    Z2        0.05512  -0.00000   0.00000   0.00000  -0.00000   0.05512
+    X3        1.34199   0.00007   0.00000   0.00021   0.00021   1.34220
+    Y3       -1.75531   0.00017   0.00000   0.00049   0.00049  -1.75482
+    Z3       -0.99024   0.00011   0.00000   0.00032   0.00032  -0.98992
+    X4        1.34199   0.00007   0.00000   0.00021   0.00021   1.34220
+    Y4        1.61192  -0.00018   0.00000  -0.00051  -0.00051   1.61140
+    Z4       -0.84359   0.00009   0.00000   0.00027   0.00027  -0.84332
+    X5        1.34199   0.00007   0.00000   0.00021   0.00021   1.34220
+    Y5       -0.19869   0.00001   0.00000   0.00002   0.00002  -0.19866
+    Z5        1.99920  -0.00020   0.00000  -0.00059  -0.00059   1.99861
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000216     0.000450     YES
+ RMS     Force            0.000111     0.000300     YES
+ Maximum Displacement     0.000628     0.001800     YES
+ RMS     Displacement     0.000322     0.001200     YES
+ Predicted change in Energy=-2.681743D-07
+ Optimization completed.
+    -- Stationary point found.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ 1\1\GINC-LOCALHOST\Force\RB3LYP\6-31G(d,p)\C1H4\JZZENG\25-Jun-2019\0\\
+ #force b3lyp/6-31g**\\methane\\0,1\C,1.07422,-0.06034,0.02917\H,2.1664
+ 2,-0.06034,0.02917\H,0.71015,-0.92887,-0.52401\H,0.71015,0.85299,-0.44
+ 641\H,0.71015,-0.10514,1.05793\\Version=ES64L-G16RevA.03\State=1-A\HF=
+ -40.5240137\RMSD=2.291e-09\RMSF=1.112e-04\Dipole=-0.0000018,0.0000007,
+ -0.0000007\Quadrupole=0.0000105,-0.0000083,-0.0000022,-0.000001,0.0000
+ 01,0.0000025\PG=C01 [X(C1H4)]\\@
+
+
+ SEE YOU NOW,
+ YOUR BAIT OF FALSEHOOD TAKES THIS CARP OF TRUTH.
+ AND THUS DO WE OF WISDOM AND OF REACH...
+ BY INDIRECTIONS FIND DIRECTIONS OUT.    -- HAMLET, II, 1
+ Job cpu time:       0 days  0 hours  1 minutes 11.1 seconds.
+ Elapsed time:       0 days  0 hours  0 minutes  3.2 seconds.
+ File lengths (MBytes):  RWF=      6 Int=      0 D2E=      0 Chk=      1 Scr=      1
+ Normal termination of Gaussian 16 at Tue Jun 25 00:14:07 2019.

--- a/tests/test_multisystems.py
+++ b/tests/test_multisystems.py
@@ -1,0 +1,71 @@
+import os
+import numpy as np
+import unittest
+from context import dpdata
+from comp_sys import CompSys
+from comp_sys import CompLabeledSys
+
+class TestMultiSystems(unittest.TestCase, CompLabeledSys):
+    def setUp(self):
+        self.places = 6
+        self.e_places = 6
+        self.f_places = 6
+        self.v_places = 6
+
+        system_1 = dpdata.LabeledSystem('gaussian/methane.gaussianlog', fmt='gaussian/log')
+        system_2 = dpdata.LabeledSystem('gaussian/methane_reordered.gaussianlog', fmt='gaussian/log')
+        system_3 = dpdata.LabeledSystem('gaussian/methane_sub.gaussianlog', fmt='gaussian/log')
+        system_4 = dpdata.LabeledSystem('gaussian/noncoveraged.gaussianlog', fmt='gaussian/log')
+
+        self.systems = dpdata.MultiSystems(system_1, system_3, system_4)
+        self.systems.append(system_2)
+        self.system_1 = self.systems['C1H3']
+        self.system_2 = system_3
+    
+    def test_systems_name(self):
+        system_names = ['C1H4', 'C1H3']
+        self.assertEqual(set(self.systems.systems), set(system_names))
+    
+    def test_systems_size(self):
+        system_sizes = {'C1H4':2, 'C1H3':1}
+        for name, size in system_sizes.items():
+            self.assertEqual(self.systems[name].get_nframes(), size)
+
+class TestMultiDeepmdDumpRaw(unittest.TestCase, CompLabeledSys):
+    def setUp (self) :
+        self.places = 6
+        self.e_places = 6
+        self.f_places = 6
+        self.v_places = 6
+
+        system_1 = dpdata.LabeledSystem('gaussian/methane.gaussianlog', fmt='gaussian/log')
+        system_2 = dpdata.LabeledSystem('gaussian/methane_reordered.gaussianlog', fmt='gaussian/log')
+        system_3 = dpdata.LabeledSystem('gaussian/methane_sub.gaussianlog', fmt='gaussian/log')
+        system_4 = dpdata.LabeledSystem('gaussian/noncoveraged.gaussianlog', fmt='gaussian/log')
+
+        systems = dpdata.MultiSystems(system_1, system_2, system_3, system_4)
+        path = "tmp.deepmd.multi"
+        systems.to_deepmd_raw(path)
+        self.system_1 = dpdata.LabeledSystem(os.path.join(path, 'C1H3'), fmt='deepmd/raw', type_map = ['C', 'H'])
+        self.system_2 = system_3
+
+class TestMultiDeepmdDumpComp(unittest.TestCase, CompLabeledSys):
+    def setUp (self) :
+        self.places = 6
+        self.e_places = 4
+        self.f_places = 6
+        self.v_places = 6
+
+        system_1 = dpdata.LabeledSystem('gaussian/methane.gaussianlog', fmt='gaussian/log')
+        system_2 = dpdata.LabeledSystem('gaussian/methane_reordered.gaussianlog', fmt='gaussian/log')
+        system_3 = dpdata.LabeledSystem('gaussian/methane_sub.gaussianlog', fmt='gaussian/log')
+        system_4 = dpdata.LabeledSystem('gaussian/noncoveraged.gaussianlog', fmt='gaussian/log')
+
+        systems = dpdata.MultiSystems(system_1, system_2, system_3, system_4)
+        path = "tmp.deepmd.npy.multi"
+        systems.to_deepmd_npy(path)
+        self.system_1 = dpdata.LabeledSystem(os.path.join(path, 'C1H3'), fmt='deepmd/npy', type_map = ['C', 'H'])
+        self.system_2 = system_3
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_system_append.py
+++ b/tests/test_system_append.py
@@ -23,5 +23,18 @@ class TestVaspXmlAppend(unittest.TestCase, CompLabeledSys):
         self.system_2 = dpdata.LabeledSystem('poscars/vasprun.h2o.md.10.xml').sub_system(np.arange(0,10,2))
 
 
+class TestDifferentOrderAppend(unittest.TestCase, CompLabeledSys):
+    def setUp (self) :
+        self.places = 6
+        self.e_places = 6
+        self.f_places = 6
+        self.v_places = 6
+
+        self.system_1 = dpdata.LabeledSystem('gaussian/methane.gaussianlog', fmt='gaussian/log')
+        system_2 = dpdata.LabeledSystem('gaussian/methane_reordered.gaussianlog', fmt='gaussian/log')
+        self.system_1.append(system_2)
+                
+        self.system_2 = self.system_1.sub_system([0, 0])
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- Add a property `formula` for class `System`, which returns the chemical formula like `C3H4O6`
- Add a class called `MultiSystems`, which contains systems with different formula
  - init: `systems = MultiSystems(system1, system2, system3)`
  - property: `systems.systems`: a dict contains systems with different formula, like `systems['C1H4']`
  - function:
    - `append`: append a `System` to `MultiSystems`
    - `to_deepmd_raw`, `to_deepmd_npy`: generate a folder containing folders for different systems
- Try to sort `atom_names` and `atom_types` in `append` function of `System`, if the `formula` of two systems are the same but either `atom_names` or `atom_types` is not equal
- Add unit tests for above
- Fix a bug in dpdata/deepmd/comp.py#L32, for `virs` may be `None`