### PR TITLE
make atom_names in all systems equal

### DIFF
--- a/tests/gaussian/oxygen.gaussianlog
+++ b/tests/gaussian/oxygen.gaussianlog
@@ -1,0 +1,1252 @@
+ Entering Gaussian System, Link 0=g16
+ Initial command:
+ /home/jzzeng/soft/g16/l1.exe "/home/jzzeng/test/Gau-6214.inp" -scrdir="/home/jzzeng/test/"
+ Entering Link 1 = /home/jzzeng/soft/g16/l1.exe PID=      6215.
+  
+ Copyright (c) 1988,1990,1992,1993,1995,1998,2003,2009,2016,
+            Gaussian, Inc.  All Rights Reserved.
+  
+ This is part of the Gaussian(R) 16 program.  It is based on
+ the Gaussian(R) 09 system (copyright 2009, Gaussian, Inc.),
+ the Gaussian(R) 03 system (copyright 2003, Gaussian, Inc.),
+ the Gaussian(R) 98 system (copyright 1998, Gaussian, Inc.),
+ the Gaussian(R) 94 system (copyright 1995, Gaussian, Inc.),
+ the Gaussian 92(TM) system (copyright 1992, Gaussian, Inc.),
+ the Gaussian 90(TM) system (copyright 1990, Gaussian, Inc.),
+ the Gaussian 88(TM) system (copyright 1988, Gaussian, Inc.),
+ the Gaussian 86(TM) system (copyright 1986, Carnegie Mellon
+ University), and the Gaussian 82(TM) system (copyright 1983,
+ Carnegie Mellon University). Gaussian is a federally registered
+ trademark of Gaussian, Inc.
+  
+ This software contains proprietary and confidential information,
+ including trade secrets, belonging to Gaussian, Inc.
+  
+ This software is provided under written license and may be
+ used, copied, transmitted, or stored only in accord with that
+ written license.
+  
+ The following legend is applicable only to US Government
+ contracts under FAR:
+  
+                    RESTRICTED RIGHTS LEGEND
+  
+ Use, reproduction and disclosure by the US Government is
+ subject to restrictions as set forth in subparagraphs (a)
+ and (c) of the Commercial Computer Software - Restricted
+ Rights clause in FAR 52.227-19.
+  
+ Gaussian, Inc.
+ 340 Quinnipiac St., Bldg. 40, Wallingford CT 06492
+  
+  
+ ---------------------------------------------------------------
+ Warning -- This program may not be used in any manner that
+ competes with the business of Gaussian, Inc. or will provide
+ assistance to any competitor of Gaussian, Inc.  The licensee
+ of this program is prohibited from giving any competitor of
+ Gaussian, Inc. access to this program.  By using this program,
+ the user acknowledges that Gaussian, Inc. is engaged in the
+ business of creating and licensing software in the field of
+ computational chemistry and represents and warrants to the
+ licensee that it is not a competitor of Gaussian, Inc. and that
+ it will not use this program in any manner prohibited above.
+ ---------------------------------------------------------------
+  
+
+ Cite this work as:
+ Gaussian 16, Revision A.03,
+ M. J. Frisch, G. W. Trucks, H. B. Schlegel, G. E. Scuseria, 
+ M. A. Robb, J. R. Cheeseman, G. Scalmani, V. Barone, 
+ G. A. Petersson, H. Nakatsuji, X. Li, M. Caricato, A. V. Marenich, 
+ J. Bloino, B. G. Janesko, R. Gomperts, B. Mennucci, H. P. Hratchian, 
+ J. V. Ortiz, A. F. Izmaylov, J. L. Sonnenberg, D. Williams-Young, 
+ F. Ding, F. Lipparini, F. Egidi, J. Goings, B. Peng, A. Petrone, 
+ T. Henderson, D. Ranasinghe, V. G. Zakrzewski, J. Gao, N. Rega, 
+ G. Zheng, W. Liang, M. Hada, M. Ehara, K. Toyota, R. Fukuda, 
+ J. Hasegawa, M. Ishida, T. Nakajima, Y. Honda, O. Kitao, H. Nakai, 
+ T. Vreven, K. Throssell, J. A. Montgomery, Jr., J. E. Peralta, 
+ F. Ogliaro, M. J. Bearpark, J. J. Heyd, E. N. Brothers, K. N. Kudin, 
+ V. N. Staroverov, T. A. Keith, R. Kobayashi, J. Normand, 
+ K. Raghavachari, A. P. Rendell, J. C. Burant, S. S. Iyengar, 
+ J. Tomasi, M. Cossi, J. M. Millam, M. Klene, C. Adamo, R. Cammi, 
+ J. W. Ochterski, R. L. Martin, K. Morokuma, O. Farkas, 
+ J. B. Foresman, and D. J. Fox, Gaussian, Inc., Wallingford CT, 2016.
+ 
+ ******************************************
+ Gaussian 16:  ES64L-G16RevA.03 25-Dec-2016
+                 7-Oct-2018 
+ ******************************************
+ %nproc=4
+ Will use up to    4 processors via shared memory.
+ --------------------------
+ # opt freq mn15/6-31g(d,p)
+ --------------------------
+ 1/18=20,19=15,26=3,38=1/1,3;
+ 2/9=110,12=2,17=6,18=5,40=1/2;
+ 3/5=1,6=6,7=101,11=2,25=1,30=1,71=1,74=-73/1,2,3;
+ 4//1;
+ 5/5=2,38=5/2;
+ 6/7=2,8=2,9=2,10=2,28=1/1;
+ 7//1,2,3,16;
+ 1/18=20,19=15,26=3/3(2);
+ 2/9=110/2;
+ 99//99;
+ 2/9=110/2;
+ 3/5=1,6=6,7=101,11=2,25=1,30=1,71=1,74=-73/1,2,3;
+ 4/5=5,16=3,69=1/1;
+ 5/5=2,38=5/2;
+ 7//1,2,3,16;
+ 1/18=20,19=15,26=3/3(-5);
+ 2/9=110/2;
+ 6/7=2,8=2,9=2,10=2,19=2,28=1/1;
+ 99/9=1/99;
+ -----------------------------------
+ Run automatically by GaussianRunner
+ -----------------------------------
+ Symbolic Z-matrix:
+ Charge =  0 Multiplicity = 3
+ O                     1.02939  -0.0946   -0.0307 
+ O                     2.31139  -0.0946   -0.0307 
+ 
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Initialization pass.
+                           ----------------------------
+                           !    Initial Parameters    !
+                           ! (Angstroms and Degrees)  !
+ --------------------------                            --------------------------
+ ! Name  Definition              Value          Derivative Info.                !
+ --------------------------------------------------------------------------------
+ ! R1    R(1,2)                  1.282          estimate D2E/DX2                !
+ --------------------------------------------------------------------------------
+ Trust Radius=3.00D-01 FncErr=1.00D-07 GrdErr=1.00D-06 EigMax=2.50D+02 EigMin=1.00D-04
+ Number of steps in this run=     20 maximum allowed number of steps=    100.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        1.029390   -0.094600   -0.030700
+      2          8           0        2.311390   -0.094600   -0.030700
+ ---------------------------------------------------------------------
+ Stoichiometry    O2(3)
+ Framework group  D*H[C*(O.O)]
+ Deg. of freedom     1
+ Full point group                 D*H     NOp   8
+ Largest Abelian subgroup         D2H     NOp   8
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.000000    0.000000    0.641000
+      2          8           0        0.000000    0.000000   -0.641000
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):           0.0000000          38.4493691          38.4493691
+ Standard basis: 6-31G(d,p) (6D, 7F)
+ There are     8 symmetry adapted cartesian basis functions of AG  symmetry.
+ There are     1 symmetry adapted cartesian basis functions of B1G symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B2G symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B3G symmetry.
+ There are     1 symmetry adapted cartesian basis functions of AU  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1U symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B2U symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B3U symmetry.
+ There are     8 symmetry adapted basis functions of AG  symmetry.
+ There are     1 symmetry adapted basis functions of B1G symmetry.
+ There are     3 symmetry adapted basis functions of B2G symmetry.
+ There are     3 symmetry adapted basis functions of B3G symmetry.
+ There are     1 symmetry adapted basis functions of AU  symmetry.
+ There are     8 symmetry adapted basis functions of B1U symmetry.
+ There are     3 symmetry adapted basis functions of B2U symmetry.
+ There are     3 symmetry adapted basis functions of B3U symmetry.
+    30 basis functions,    56 primitive gaussians,    30 cartesian basis functions
+     9 alpha electrons        7 beta electrons
+       nuclear repulsion energy        26.4175830724 Hartrees.
+ NAtoms=    2 NActive=    2 NUniq=    1 SFac= 4.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    30 RedAO= T EigKep=  8.86D-03  NBF=     8     1     3     3     1     8     3     3
+ NBsUse=    30 1.00D-06 EigRej= -1.00D+00 NBFU=     8     1     3     3     1     8     3     3
+ ExpMin= 2.70D-01 ExpMax= 5.48D+03 ExpMxC= 8.25D+02 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ Harris functional with IExCor= 1009 and IRadAn=       5 diagonalized for initial guess.
+ HarFok:  IExCor= 1009 AccDes= 0.00D+00 IRadAn=         5 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Initial guess orbital symmetries:
+ Alpha Orbitals:
+       Occupied  (SGG) (SGU) (SGG) (SGU) (SGG) (PIU) (PIU) (PIG)
+                 (PIG)
+       Virtual   (SGU) (SGG) (SGU) (PIU) (PIU) (SGG) (PIG) (PIG)
+                 (SGU) (PIU) (PIU) (DLTG) (DLTG) (DLTU) (DLTU)
+                 (SGG) (PIG) (PIG) (SGU) (SGG) (SGU)
+ Beta  Orbitals:
+       Occupied  (SGG) (SGU) (SGG) (SGU) (SGG) (PIU) (PIU)
+       Virtual   (PIG) (PIG) (SGU) (SGG) (SGU) (PIU) (PIU) (SGG)
+                 (PIG) (PIG) (SGU) (PIU) (PIU) (DLTG) (DLTG) (DLTU)
+                 (DLTU) (SGG) (PIG) (PIG) (SGU) (SGG) (SGU)
+ The electronic state of the initial guess is 3-SGG.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 1.0000 <S**2>= 2.0000 S= 1.0000
+ Keep R1 and R2 ints in memory in symmetry-blocked form, NReq=3563861.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(UMN15) =  -150.157143900     A.U. after   10 cycles
+            NFock= 10  Conv=0.36D-08     -V/T= 2.0116
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 1.0000 <S**2>= 2.0041 S= 1.0014
+ <L.S>=  0.00000000000    
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation     2.0041,   after     2.0000
+
+ **********************************************************************
+
+            Population analysis using the SCF density.
+
+ **********************************************************************
+
+ Orbital symmetries:
+ Alpha Orbitals:
+       Occupied  (SGG) (SGU) (SGG) (SGU) (PIU) (PIU) (SGG) (PIG)
+                 (PIG)
+       Virtual   (SGU) (SGG) (SGU) (PIU) (PIU) (SGG) (PIG) (PIG)
+                 (SGU) (PIU) (PIU) (DLTG) (DLTG) (DLTU) (DLTU)
+                 (SGG) (PIG) (PIG) (SGU) (SGG) (SGU)
+ Beta  Orbitals:
+       Occupied  (SGG) (SGU) (SGG) (SGU) (SGG) (PIU) (PIU)
+       Virtual   (PIG) (PIG) (SGU) (SGG) (SGU) (PIU) (PIU) (SGG)
+                 (PIG) (PIG) (SGU) (PIU) (PIU) (DLTG) (DLTG) (DLTU)
+                 (DLTU) (SGG) (PIG) (PIG) (SGU) (SGG) (SGU)
+ The electronic state is 3-SGG.
+ Alpha  occ. eigenvalues --  -19.01355 -19.01329  -1.28541  -0.88298  -0.58486
+ Alpha  occ. eigenvalues --   -0.58486  -0.58276  -0.36801  -0.36801
+ Alpha virt. eigenvalues --    0.17231   0.71387   0.75609   0.81540   0.81540
+ Alpha virt. eigenvalues --    0.91295   0.93428   0.93428   1.28960   1.49001
+ Alpha virt. eigenvalues --    1.49001   1.57353   1.57353   1.89613   1.89613
+ Alpha virt. eigenvalues --    2.28466   2.48128   2.48128   2.84385   3.17016
+ Alpha virt. eigenvalues --    3.48106
+  Beta  occ. eigenvalues --  -18.99138 -18.99086  -1.23106  -0.81478  -0.53676
+  Beta  occ. eigenvalues --   -0.48209  -0.48209
+  Beta virt. eigenvalues --   -0.09696  -0.09696   0.20257   0.72594   0.77116
+  Beta virt. eigenvalues --    0.86725   0.86725   0.91930   0.99452   0.99452
+  Beta virt. eigenvalues --    1.31784   1.51738   1.51738   1.61880   1.61880
+  Beta virt. eigenvalues --    1.95781   1.95781   2.29770   2.51020   2.51020
+  Beta virt. eigenvalues --    2.85101   3.19797   3.52794
+          Condensed to atoms (all electrons):
+               1          2
+     1  O    7.844338   0.155662
+     2  O    0.155662   7.844338
+          Atomic-Atomic Spin Densities.
+               1          2
+     1  O    1.275454  -0.275454
+     2  O   -0.275454   1.275454
+ Mulliken charges and spin densities:
+               1          2
+     1  O   -0.000000   1.000000
+     2  O   -0.000000   1.000000
+ Sum of Mulliken charges =  -0.00000   2.00000
+ Mulliken charges and spin densities with hydrogens summed into heavy atoms:
+               1          2
+     1  O   -0.000000   1.000000
+     2  O   -0.000000   1.000000
+ Electronic spatial extent (au):  <R**2>=             45.7128
+ Charge=             -0.0000 electrons
+ Dipole moment (field-independent basis, Debye):
+    X=              0.0000    Y=              0.0000    Z=              0.0000  Tot=              0.0000
+ Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=             -9.8828   YY=             -9.8828   ZZ=            -10.1428
+   XY=              0.0000   XZ=              0.0000   YZ=              0.0000
+ Traceless Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=              0.0867   YY=              0.0867   ZZ=             -0.1733
+   XY=              0.0000   XZ=              0.0000   YZ=              0.0000
+ Octapole moment (field-independent basis, Debye-Ang**2):
+  XXX=             -0.0000  YYY=              0.0000  ZZZ=             -0.0000  XYY=             -0.0000
+  XXY=              0.0000  XXZ=             -0.0000  XZZ=             -0.0000  YZZ=             -0.0000
+  YYZ=             -0.0000  XYZ=              0.0000
+ Hexadecapole moment (field-independent basis, Debye-Ang**3):
+ XXXX=             -6.4888 YYYY=             -6.4888 ZZZZ=            -29.9245 XXXY=              0.0000
+ XXXZ=              0.0000 YYYX=              0.0000 YYYZ=              0.0000 ZZZX=              0.0000
+ ZZZY=              0.0000 XXYY=             -2.1629 XXZZ=             -6.3154 YYZZ=             -6.3154
+ XXYZ=              0.0000 YYXZ=              0.0000 ZZXY=             -0.0000
+ N-N= 2.641758307245D+01 E-N=-4.070944464775D+02  KE= 1.484333121446D+02
+ Symmetry AG   KE= 6.881868516181D+01
+ Symmetry B1G  KE= 1.347907125162D-34
+ Symmetry B2G  KE= 3.022903193025D+00
+ Symmetry B3G  KE= 3.022903193025D+00
+ Symmetry AU   KE= 3.055254448075D-34
+ Symmetry B1U  KE= 6.447212011121D+01
+ Symmetry B2U  KE= 4.548350242765D+00
+ Symmetry B3U  KE= 4.548350242765D+00
+ Symmetry AG   SP=-1.574685504444D-16
+ Symmetry B1G  SP= 2.244719852134D-35
+ Symmetry B2G  SP= 1.000000000000D+00
+ Symmetry B3G  SP= 1.000000000000D+00
+ Symmetry AU   SP= 1.791501245992D-35
+ Symmetry B1U  SP= 3.848482410673D-15
+ Symmetry B2U  SP=-2.690996254878D-16
+ Symmetry B3U  SP= 8.723484217050D-16
+                          Isotropic Fermi Contact Couplings
+        Atom                 a.u.       MegaHertz       Gauss      10(-4) cm-1
+     1  O(17)             -0.06896      20.90181       7.45829       6.97209
+     2  O(17)             -0.06896      20.90181       7.45829       6.97209
+ --------------------------------------------------------
+       Center         ----  Spin Dipole Couplings  ----
+                      3XX-RR        3YY-RR        3ZZ-RR
+ --------------------------------------------------------
+     1   Atom        1.134391      1.134391     -2.268782
+     2   Atom        1.134391      1.134391     -2.268782
+ --------------------------------------------------------
+                        XY            XZ            YZ
+ --------------------------------------------------------
+     1   Atom        0.000000     -0.000000      0.000000
+     2   Atom        0.000000     -0.000000      0.000000
+ --------------------------------------------------------
+
+
+ ---------------------------------------------------------------------------------
+              Anisotropic Spin Dipole Couplings in Principal Axis System
+ ---------------------------------------------------------------------------------
+
+       Atom             a.u.   MegaHertz   Gauss  10(-4) cm-1        Axes
+
+              Baa    -2.2688   164.168    58.579    54.760  0.0000  0.0000  1.0000
+     1 O(17)  Bbb     1.1344   -82.084   -29.290   -27.380 -0.0112  0.9999 -0.0000
+              Bcc     1.1344   -82.084   -29.290   -27.380  0.9999  0.0112  0.0000
+ 
+              Baa    -2.2688   164.168    58.579    54.760  0.0000  0.0000  1.0000
+     2 O(17)  Bbb     1.1344   -82.084   -29.290   -27.380 -0.0110  0.9999 -0.0000
+              Bcc     1.1344   -82.084   -29.290   -27.380  0.9999  0.0110  0.0000
+ 
+
+ ---------------------------------------------------------------------------------
+
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8           0.102142083   -0.000000000    0.000000000
+      2        8          -0.102142083    0.000000000   -0.000000000
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.102142083 RMS     0.058971759
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+ Internal  Forces:  Max     0.102142083 RMS     0.102142083
+ Search for a local minimum.
+ Step number   1 out of a maximum of   20
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Mixed Optimization -- RFO/linear search
+ Second derivative matrix not updated -- first step.
+ The second derivative matrix:
+                          R1
+           R1           0.72451
+ ITU=  0
+     Eigenvalues ---    0.72451
+ RFO step:  Lambda=-1.41247847D-02 EMin= 7.24506308D-01
+ Linear search not attempted -- first point.
+ Iteration  1 RMS(Cart)=  0.09778272 RMS(Int)=  0.00000000
+ Iteration  2 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ ClnCor:  largest displacement from symmetrization is 6.94D-18 for atom     1.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        2.42263  -0.10214   0.00000  -0.13829  -0.13829   2.28434
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.102142     0.000450     NO 
+ RMS     Force            0.102142     0.000300     NO 
+ Maximum Displacement     0.069143     0.001800     NO 
+ RMS     Displacement     0.097783     0.001200     NO 
+ Predicted change in Energy=-7.197446D-03
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        1.065979   -0.094600   -0.030700
+      2          8           0        2.274801   -0.094600   -0.030700
+ ---------------------------------------------------------------------
+ Stoichiometry    O2(3)
+ Framework group  D*H[C*(O.O)]
+ Deg. of freedom     1
+ Full point group                 D*H     NOp   8
+ Largest Abelian subgroup         D2H     NOp   8
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.000000    0.000000    0.604411
+      2          8           0        0.000000    0.000000   -0.604411
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):           0.0000000          43.2454362          43.2454362
+ Standard basis: 6-31G(d,p) (6D, 7F)
+ There are     8 symmetry adapted cartesian basis functions of AG  symmetry.
+ There are     1 symmetry adapted cartesian basis functions of B1G symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B2G symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B3G symmetry.
+ There are     1 symmetry adapted cartesian basis functions of AU  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1U symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B2U symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B3U symmetry.
+ There are     8 symmetry adapted basis functions of AG  symmetry.
+ There are     1 symmetry adapted basis functions of B1G symmetry.
+ There are     3 symmetry adapted basis functions of B2G symmetry.
+ There are     3 symmetry adapted basis functions of B3G symmetry.
+ There are     1 symmetry adapted basis functions of AU  symmetry.
+ There are     8 symmetry adapted basis functions of B1U symmetry.
+ There are     3 symmetry adapted basis functions of B2U symmetry.
+ There are     3 symmetry adapted basis functions of B3U symmetry.
+    30 basis functions,    56 primitive gaussians,    30 cartesian basis functions
+     9 alpha electrons        7 beta electrons
+       nuclear repulsion energy        28.0168054106 Hartrees.
+ NAtoms=    2 NActive=    2 NUniq=    1 SFac= 4.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    30 RedAO= T EigKep=  7.05D-03  NBF=     8     1     3     3     1     8     3     3
+ NBsUse=    30 1.00D-06 EigRej= -1.00D+00 NBFU=     8     1     3     3     1     8     3     3
+ Initial guess from the checkpoint file:  "/home/jzzeng/test/Gau-6215.chk"
+ B after Tr=    -0.000000    0.000000   -0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+ Alpha Orbitals:
+       Occupied  (SGG) (SGU) (SGG) (SGU) (PIU) (PIU) (SGG) (PIG)
+                 (PIG)
+       Virtual   (SGU) (SGG) (SGU) (PIU) (PIU) (SGG) (PIG) (PIG)
+                 (SGU) (PIU) (PIU) (DLTG) (DLTG) (DLTU) (DLTU)
+                 (SGG) (PIG) (PIG) (SGU) (SGG) (SGU)
+ Beta  Orbitals:
+       Occupied  (SGG) (SGU) (SGG) (SGU) (SGG) (PIU) (PIU)
+       Virtual   (PIG) (PIG) (SGU) (SGG) (SGU) (PIU) (PIU) (SGG)
+                 (PIG) (PIG) (SGU) (PIU) (PIU) (DLTG) (DLTG) (DLTU)
+                 (DLTU) (SGG) (PIG) (PIG) (SGU) (SGG) (SGU)
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 1.0000 <S**2>= 2.0040 S= 1.0013
+ ExpMin= 2.70D-01 ExpMax= 5.48D+03 ExpMxC= 8.25D+02 IAcc=2 IRadAn=         4 AccDes= 0.00D+00
+ Harris functional with IExCor= 1009 and IRadAn=       4 diagonalized for initial guess.
+ HarFok:  IExCor= 1009 AccDes= 0.00D+00 IRadAn=         4 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Petite list used in FoFCou.
+ Keep R1 and R2 ints in memory in symmetry-blocked form, NReq=3563861.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(UMN15) =  -150.165150112     A.U. after   10 cycles
+            NFock= 10  Conv=0.27D-08     -V/T= 2.0101
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 1.0000 <S**2>= 2.0036 S= 1.0012
+ <L.S>=  0.00000000000    
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation     2.0036,   after     2.0000
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8           0.005070257   -0.000000000    0.000000000
+      2        8          -0.005070257    0.000000000   -0.000000000
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.005070257 RMS     0.002927314
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ Internal  Forces:  Max     0.005070257 RMS     0.005070257
+ Search for a local minimum.
+ Step number   2 out of a maximum of   20
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Mixed Optimization -- RFO/linear search
+ Update second derivatives using D2CorX and points    1    2
+ DE= -8.01D-03 DEPred=-7.20D-03 R= 1.11D+00
+ TightC=F SS=  1.41D+00  RLast= 1.38D-01 DXNew= 5.0454D-01 4.1486D-01
+ Trust test= 1.11D+00 RLast= 1.38D-01 DXMaxT set to 4.15D-01
+ The second derivative matrix:
+                          R1
+           R1           0.70197
+ ITU=  1  0
+ Use linear search instead of GDIIS.
+     Eigenvalues ---    0.70197
+ RFO step:  Lambda= 0.00000000D+00 EMin= 7.01965995D-01
+ Quartic linear search produced a step of  0.04052.
+ Iteration  1 RMS(Cart)=  0.00396177 RMS(Int)=  0.00000000
+ Iteration  2 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ ClnCor:  largest displacement from symmetrization is 0.00D+00 for atom     0.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        2.28434  -0.00507  -0.00560   0.00000  -0.00560   2.27874
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.005070     0.000450     NO 
+ RMS     Force            0.005070     0.000300     NO 
+ Maximum Displacement     0.002801     0.001800     NO 
+ RMS     Displacement     0.003962     0.001200     NO 
+ Predicted change in Energy=-1.738979D-05
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        1.067461   -0.094600   -0.030700
+      2          8           0        2.273319   -0.094600   -0.030700
+ ---------------------------------------------------------------------
+ Stoichiometry    O2(3)
+ Framework group  D*H[C*(O.O)]
+ Deg. of freedom     1
+ Full point group                 D*H     NOp   8
+ Largest Abelian subgroup         D2H     NOp   8
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.000000    0.000000    0.602929
+      2          8           0        0.000000    0.000000   -0.602929
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):           0.0000000          43.4583546          43.4583546
+ Standard basis: 6-31G(d,p) (6D, 7F)
+ There are     8 symmetry adapted cartesian basis functions of AG  symmetry.
+ There are     1 symmetry adapted cartesian basis functions of B1G symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B2G symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B3G symmetry.
+ There are     1 symmetry adapted cartesian basis functions of AU  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1U symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B2U symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B3U symmetry.
+ There are     8 symmetry adapted basis functions of AG  symmetry.
+ There are     1 symmetry adapted basis functions of B1G symmetry.
+ There are     3 symmetry adapted basis functions of B2G symmetry.
+ There are     3 symmetry adapted basis functions of B3G symmetry.
+ There are     1 symmetry adapted basis functions of AU  symmetry.
+ There are     8 symmetry adapted basis functions of B1U symmetry.
+ There are     3 symmetry adapted basis functions of B2U symmetry.
+ There are     3 symmetry adapted basis functions of B3U symmetry.
+    30 basis functions,    56 primitive gaussians,    30 cartesian basis functions
+     9 alpha electrons        7 beta electrons
+       nuclear repulsion energy        28.0856909319 Hartrees.
+ NAtoms=    2 NActive=    2 NUniq=    1 SFac= 4.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    30 RedAO= T EigKep=  6.99D-03  NBF=     8     1     3     3     1     8     3     3
+ NBsUse=    30 1.00D-06 EigRej= -1.00D+00 NBFU=     8     1     3     3     1     8     3     3
+ Initial guess from the checkpoint file:  "/home/jzzeng/test/Gau-6215.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+ Alpha Orbitals:
+       Occupied  (SGG) (SGU) (SGG) (SGU) (PIU) (PIU) (SGG) (PIG)
+                 (PIG)
+       Virtual   (SGU) (SGG) (SGU) (PIU) (PIU) (SGG) (PIG) (PIG)
+                 (SGU) (PIU) (PIU) (DLTG) (DLTG) (DLTU) (DLTU)
+                 (SGG) (PIG) (PIG) (SGU) (SGG) (SGU)
+ Beta  Orbitals:
+       Occupied  (SGG) (SGU) (SGG) (SGU) (SGG) (PIU) (PIU)
+       Virtual   (PIG) (PIG) (SGU) (SGG) (SGU) (PIU) (PIU) (SGG)
+                 (PIG) (PIG) (SGU) (PIU) (PIU) (DLTG) (DLTG) (DLTU)
+                 (DLTU) (SGG) (PIG) (PIG) (SGU) (SGG) (SGU)
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 1.0000 <S**2>= 2.0036 S= 1.0012
+ Keep R1 and R2 ints in memory in symmetry-blocked form, NReq=3563861.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(UMN15) =  -150.165164262     A.U. after    6 cycles
+            NFock=  6  Conv=0.90D-08     -V/T= 2.0100
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 1.0000 <S**2>= 2.0036 S= 1.0012
+ <L.S>=  0.00000000000    
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation     2.0036,   after     2.0000
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8          -0.000037010   -0.000000000    0.000000000
+      2        8           0.000037010    0.000000000   -0.000000000
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.000037010 RMS     0.000021368
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Using GEDIIS/GDIIS optimizer.
+ Internal  Forces:  Max     0.000037010 RMS     0.000037010
+ Search for a local minimum.
+ Step number   3 out of a maximum of   20
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Mixed Optimization -- En-DIIS/RFO-DIIS
+ Update second derivatives using D2CorX and points    2    3
+ DE= -1.41D-05 DEPred=-1.74D-05 R= 8.14D-01
+ TightC=F SS=  1.41D+00  RLast= 5.60D-03 DXNew= 6.9770D-01 1.6808D-02
+ Trust test= 8.14D-01 RLast= 5.60D-03 DXMaxT set to 4.15D-01
+ The second derivative matrix:
+                          R1
+           R1           0.91156
+ ITU=  1  1
+ Use linear search instead of GDIIS.
+     Eigenvalues ---    0.91156
+ RFO step:  Lambda= 0.00000000D+00 EMin= 9.11558115D-01
+ Quartic linear search produced a step of -0.00717.
+ Iteration  1 RMS(Cart)=  0.00002842 RMS(Int)=  0.00000000
+ Iteration  2 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ ClnCor:  largest displacement from symmetrization is 0.00D+00 for atom     0.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        2.27874   0.00004   0.00004  -0.00000   0.00004   2.27878
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000037     0.000450     YES
+ RMS     Force            0.000037     0.000300     YES
+ Maximum Displacement     0.000020     0.001800     YES
+ RMS     Displacement     0.000028     0.001200     YES
+ Predicted change in Energy=-7.512377D-10
+ Optimization completed.
+    -- Stationary point found.
+                           ----------------------------
+                           !   Optimized Parameters   !
+                           ! (Angstroms and Degrees)  !
+ --------------------------                            --------------------------
+ ! Name  Definition              Value          Derivative Info.                !
+ --------------------------------------------------------------------------------
+ ! R1    R(1,2)                  1.2059         -DE/DX =    0.0                 !
+ --------------------------------------------------------------------------------
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        1.067461   -0.094600   -0.030700
+      2          8           0        2.273319   -0.094600   -0.030700
+ ---------------------------------------------------------------------
+ Stoichiometry    O2(3)
+ Framework group  D*H[C*(O.O)]
+ Deg. of freedom     1
+ Full point group                 D*H     NOp   8
+ Largest Abelian subgroup         D2H     NOp   8
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.000000    0.000000    0.602929
+      2          8           0        0.000000    0.000000   -0.602929
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):           0.0000000          43.4583546          43.4583546
+
+ **********************************************************************
+
+            Population analysis using the SCF density.
+
+ **********************************************************************
+
+ Orbital symmetries:
+ Alpha Orbitals:
+       Occupied  (SGG) (SGU) (SGG) (SGU) (PIU) (PIU) (SGG) (PIG)
+                 (PIG)
+       Virtual   (SGU) (SGG) (SGU) (PIU) (PIU) (SGG) (PIG) (PIG)
+                 (SGU) (PIU) (PIU) (DLTG) (DLTG) (DLTU) (DLTU)
+                 (SGG) (PIG) (PIG) (SGU) (SGG) (SGU)
+ Beta  Orbitals:
+       Occupied  (SGG) (SGU) (SGG) (SGU) (SGG) (PIU) (PIU)
+       Virtual   (PIG) (PIG) (SGU) (SGG) (SGU) (PIU) (PIU) (SGG)
+                 (PIG) (PIG) (SGU) (PIU) (PIU) (DLTG) (DLTG) (DLTU)
+                 (DLTU) (SGG) (PIG) (PIG) (SGU) (SGG) (SGU)
+ The electronic state is 3-SGG.
+ Alpha  occ. eigenvalues --  -19.00506 -19.00473  -1.33976  -0.86059  -0.60821
+ Alpha  occ. eigenvalues --   -0.60821  -0.59462  -0.34539  -0.34539
+ Alpha virt. eigenvalues --    0.26790   0.71351   0.75599   0.81418   0.81418
+ Alpha virt. eigenvalues --    0.88885   0.93571   0.93571   1.32218   1.51959
+ Alpha virt. eigenvalues --    1.51959   1.54391   1.54391   1.92809   1.92809
+ Alpha virt. eigenvalues --    2.43904   2.56053   2.56053   2.81429   3.19154
+ Alpha virt. eigenvalues --    3.50356
+  Beta  occ. eigenvalues --  -18.98301 -18.98238  -1.28462  -0.79214  -0.54738
+  Beta  occ. eigenvalues --   -0.50864  -0.50864
+  Beta virt. eigenvalues --   -0.07208  -0.07208   0.29413   0.72505   0.77144
+  Beta virt. eigenvalues --    0.86297   0.86297   0.89529   0.99664   0.99664
+  Beta virt. eigenvalues --    1.35028   1.55033   1.55033   1.58773   1.58773
+  Beta virt. eigenvalues --    1.99139   1.99139   2.45535   2.59154   2.59154
+  Beta virt. eigenvalues --    2.81856   3.21403   3.55349
+          Condensed to atoms (all electrons):
+               1          2
+     1  O    7.856573   0.143427
+     2  O    0.143427   7.856573
+          Atomic-Atomic Spin Densities.
+               1          2
+     1  O    1.337639  -0.337639
+     2  O   -0.337639   1.337639
+ Mulliken charges and spin densities:
+               1          2
+     1  O   -0.000000   1.000000
+     2  O   -0.000000   1.000000
+ Sum of Mulliken charges =  -0.00000   2.00000
+ Mulliken charges and spin densities with hydrogens summed into heavy atoms:
+               1          2
+     1  O   -0.000000   1.000000
+     2  O   -0.000000   1.000000
+ Electronic spatial extent (au):  <R**2>=             42.9369
+ Charge=             -0.0000 electrons
+ Dipole moment (field-independent basis, Debye):
+    X=             -0.0000    Y=             -0.0000    Z=             -0.0000  Tot=              0.0000
+ Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=             -9.7688   YY=             -9.7688   ZZ=            -10.2768
+   XY=              0.0000   XZ=              0.0000   YZ=              0.0000
+ Traceless Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=              0.1693   YY=              0.1693   ZZ=             -0.3386
+   XY=              0.0000   XZ=              0.0000   YZ=              0.0000
+ Octapole moment (field-independent basis, Debye-Ang**2):
+  XXX=             -0.0000  YYY=              0.0000  ZZZ=             -0.0000  XYY=             -0.0000
+  XXY=             -0.0000  XXZ=             -0.0000  XZZ=             -0.0000  YZZ=             -0.0000
+  YYZ=             -0.0000  XYZ=              0.0000
+ Hexadecapole moment (field-independent basis, Debye-Ang**3):
+ XXXX=             -6.3568 YYYY=             -6.3568 ZZZZ=            -27.4469 XXXY=              0.0000
+ XXXZ=              0.0000 YYYX=              0.0000 YYYZ=              0.0000 ZZZX=              0.0000
+ ZZZY=              0.0000 XXYY=             -2.1189 XXZZ=             -5.8430 YYZZ=             -5.8430
+ XXYZ=              0.0000 YYXZ=              0.0000 ZZXY=             -0.0000
+ N-N= 2.808569093187D+01 E-N=-4.105439970877D+02  KE= 1.486710799631D+02
+ Symmetry AG   KE= 6.901802799890D+01
+ Symmetry B1G  KE= 1.826756589594D-34
+ Symmetry B2G  KE= 3.060267932673D+00
+ Symmetry B3G  KE= 3.060267932673D+00
+ Symmetry AU   KE= 4.321715834100D-34
+ Symmetry B1U  KE= 6.439955296416D+01
+ Symmetry B2U  KE= 4.566481567347D+00
+ Symmetry B3U  KE= 4.566481567347D+00
+ Symmetry AG   SP=-3.609702100494D-15
+ Symmetry B1G  SP= 3.225012232782D-35
+ Symmetry B2G  SP= 1.000000000000D+00
+ Symmetry B3G  SP= 1.000000000000D+00
+ Symmetry AU   SP= 3.044326762769D-35
+ Symmetry B1U  SP= 1.808701913130D-15
+ Symmetry B2U  SP=-3.587035501572D-16
+ Symmetry B3U  SP=-5.911564959381D-16
+                          Isotropic Fermi Contact Couplings
+        Atom                 a.u.       MegaHertz       Gauss      10(-4) cm-1
+     1  O(17)             -0.07033      21.31704       7.60645       7.11060
+     2  O(17)             -0.07033      21.31704       7.60645       7.11060
+ --------------------------------------------------------
+       Center         ----  Spin Dipole Couplings  ----
+                      3XX-RR        3YY-RR        3ZZ-RR
+ --------------------------------------------------------
+     1   Atom        1.136495      1.136495     -2.272990
+     2   Atom        1.136495      1.136495     -2.272990
+ --------------------------------------------------------
+                        XY            XZ            YZ
+ --------------------------------------------------------
+     1   Atom        0.000000     -0.000000      0.000000
+     2   Atom        0.000000     -0.000000      0.000000
+ --------------------------------------------------------
+
+
+ ---------------------------------------------------------------------------------
+              Anisotropic Spin Dipole Couplings in Principal Axis System
+ ---------------------------------------------------------------------------------
+
+       Atom             a.u.   MegaHertz   Gauss  10(-4) cm-1        Axes
+
+              Baa    -2.2730   164.472    58.688    54.862  0.0000  0.0000  1.0000
+     1 O(17)  Bbb     1.1365   -82.236   -29.344   -27.431  0.9997  0.0244  0.0000
+              Bcc     1.1365   -82.236   -29.344   -27.431 -0.0244  0.9997 -0.0000
+ 
+              Baa    -2.2730   164.472    58.688    54.862  0.0000  0.0000  1.0000
+     2 O(17)  Bbb     1.1365   -82.236   -29.344   -27.431  1.0000  0.0000  0.0000
+              Bcc     1.1365   -82.236   -29.344   -27.431  0.0000  1.0000  0.0000
+ 
+
+ ---------------------------------------------------------------------------------
+
+ 1\1\GINC-LOCALHOST\FOpt\UMN15\6-31G(d,p)\O2(3)\JZZENG\07-Oct-2018\0\\#
+  opt freq mn15/6-31g(d,p)\\Run automatically by GaussianRunner\\0,3\O,
+ 1.0674612421,-0.0946,-0.0307\O,2.2733187579,-0.0946,-0.0307\\Version=E
+ S64L-G16RevA.03\State=3-SGG\HF=-150.1651643\S2=2.003622\S2-1=0.\S2A=2.
+ 000006\RMSD=8.991e-09\RMSF=2.137e-05\Dipole=0.,0.,0.\Quadrupole=-0.251
+ 7749,0.1258875,0.1258875,0.,0.,0.\PG=D*H [C*(O1.O1)]\\@
+
+
+      HUMANKIND PERIODICALLY GOES THROUGH A SPEEDUP OF ITS AFFAIRS, 
+      THEREBY EXPERIENCING THE RACE BETWEEN THE RENEWABLE VITALITY
+      OF THE LIVING, AND THE BECKONING VITIATION OF DECADENCE.
+      IN THIS PERIODIC RACE, ANY PAUSE BECOMES A LUXURY.
+      ONLY THEN CAN ONE REFLECT THAT ALL IS PERMITTED;
+      ALL IS POSSIBLE.
+
+                              -- THE APOCRYPHA OF MUAD'DIB
+                                 CHILDREN OF DUNE, BY FRANK HERBERT
+ Job cpu time:       0 days  0 hours  0 minutes 16.4 seconds.
+ Elapsed time:       0 days  0 hours  0 minutes  4.2 seconds.
+ File lengths (MBytes):  RWF=      6 Int=      0 D2E=      0 Chk=      1 Scr=      1
+ Normal termination of Gaussian 16 at Sun Oct  7 14:17:59 2018.
+ Link1:  Proceeding to internal job step number  2.
+ ---------------------------------------------------------------------
+ #N Geom=AllCheck Guess=TCheck SCRF=Check GenChk UMN15/6-31G(d,p) Freq
+ ---------------------------------------------------------------------
+ 1/10=4,29=7,30=1,38=1,40=1/1,3;
+ 2/12=2,40=1/2;
+ 3/5=1,6=6,7=101,11=2,14=-4,25=1,30=1,70=2,71=2,74=-73,116=2,140=1/1,2,3;
+ 4/5=101/1;
+ 5/5=2,38=6,98=1/2;
+ 8/6=4,10=90,11=11/1;
+ 11/6=1,8=1,9=11,15=111,16=1/1,2,10;
+ 10/6=1/2;
+ 6/7=2,8=2,9=2,10=2,28=1/1;
+ 7/8=1,10=1,25=1/1,2,3,16;
+ 1/10=4,30=1/3;
+ 99//99;
+ Structure from the checkpoint file:  "/home/jzzeng/test/Gau-6215.chk"
+ -----------------------------------
+ Run automatically by GaussianRunner
+ -----------------------------------
+ Charge =  0 Multiplicity = 3
+ Redundant internal coordinates found in file.  (old form).
+ O,0,1.0674612421,-0.0946,-0.0307
+ O,0,2.2733187579,-0.0946,-0.0307
+ Recover connectivity data from disk.
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Initialization pass.
+                           ----------------------------
+                           !    Initial Parameters    !
+                           ! (Angstroms and Degrees)  !
+ --------------------------                            --------------------------
+ ! Name  Definition              Value          Derivative Info.                !
+ --------------------------------------------------------------------------------
+ ! R1    R(1,2)                  1.2059         calculate D2E/DX2 analytically  !
+ --------------------------------------------------------------------------------
+ Trust Radius=3.00D-01 FncErr=1.00D-07 GrdErr=1.00D-07 EigMax=2.50D+02 EigMin=1.00D-04
+ Number of steps in this run=      2 maximum allowed number of steps=      2.
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        1.067461   -0.094600   -0.030700
+      2          8           0        2.273319   -0.094600   -0.030700
+ ---------------------------------------------------------------------
+ Stoichiometry    O2(3)
+ Framework group  D*H[C*(O.O)]
+ Deg. of freedom     1
+ Full point group                 D*H     NOp   8
+ Largest Abelian subgroup         D2H     NOp   8
+ Largest concise Abelian subgroup C2      NOp   2
+                         Standard orientation:                         
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          8           0        0.000000    0.000000    0.602929
+      2          8           0        0.000000    0.000000   -0.602929
+ ---------------------------------------------------------------------
+ Rotational constants (GHZ):           0.0000000          43.4583546          43.4583546
+ Standard basis: 6-31G(d,p) (6D, 7F)
+ There are     8 symmetry adapted cartesian basis functions of AG  symmetry.
+ There are     1 symmetry adapted cartesian basis functions of B1G symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B2G symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B3G symmetry.
+ There are     1 symmetry adapted cartesian basis functions of AU  symmetry.
+ There are     8 symmetry adapted cartesian basis functions of B1U symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B2U symmetry.
+ There are     3 symmetry adapted cartesian basis functions of B3U symmetry.
+ There are     8 symmetry adapted basis functions of AG  symmetry.
+ There are     1 symmetry adapted basis functions of B1G symmetry.
+ There are     3 symmetry adapted basis functions of B2G symmetry.
+ There are     3 symmetry adapted basis functions of B3G symmetry.
+ There are     1 symmetry adapted basis functions of AU  symmetry.
+ There are     8 symmetry adapted basis functions of B1U symmetry.
+ There are     3 symmetry adapted basis functions of B2U symmetry.
+ There are     3 symmetry adapted basis functions of B3U symmetry.
+    30 basis functions,    56 primitive gaussians,    30 cartesian basis functions
+     9 alpha electrons        7 beta electrons
+       nuclear repulsion energy        28.0856909319 Hartrees.
+ NAtoms=    2 NActive=    2 NUniq=    1 SFac= 4.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned on.
+ One-electron integrals computed using PRISM.
+ NBasis=    30 RedAO= T EigKep=  6.99D-03  NBF=     8     1     3     3     1     8     3     3
+ NBsUse=    30 1.00D-06 EigRej= -1.00D+00 NBFU=     8     1     3     3     1     8     3     3
+ Initial guess from the checkpoint file:  "/home/jzzeng/test/Gau-6215.chk"
+ B after Tr=     0.000000    0.000000    0.000000
+         Rot=    1.000000    0.000000    0.000000    0.000000 Ang=   0.00 deg.
+ Initial guess orbital symmetries:
+ Alpha Orbitals:
+       Occupied  (SGG) (SGU) (SGG) (SGU) (PIU) (PIU) (SGG) (PIG)
+                 (PIG)
+       Virtual   (SGU) (SGG) (SGU) (PIU) (PIU) (SGG) (PIG) (PIG)
+                 (SGU) (PIU) (PIU) (DLTG) (DLTG) (DLTU) (DLTU)
+                 (SGG) (PIG) (PIG) (SGU) (SGG) (SGU)
+ Beta  Orbitals:
+       Occupied  (SGG) (SGU) (SGG) (SGU) (SGG) (PIU) (PIU)
+       Virtual   (PIG) (PIG) (SGU) (SGG) (SGU) (PIU) (PIU) (SGG)
+                 (PIG) (PIG) (SGU) (PIU) (PIU) (DLTG) (DLTG) (DLTU)
+                 (DLTU) (SGG) (PIG) (PIG) (SGU) (SGG) (SGU)
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 1.0000 <S**2>= 2.0036 S= 1.0012
+ Keep R1 and R2 ints in memory in symmetry-blocked form, NReq=3563861.
+ Requested convergence on RMS density matrix=1.00D-08 within 128 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ SCF Done:  E(UMN15) =  -150.165164262     A.U. after    1 cycles
+            NFock=  1  Conv=0.84D-09     -V/T= 2.0100
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 1.0000 <S**2>= 2.0036 S= 1.0012
+ <L.S>=  0.00000000000    
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation     2.0036,   after     2.0000
+ DoSCS=F DFT=T ScalE2(SS,OS)=  1.000000  1.000000
+ Range of M.O.s used for correlation:     1    30
+ NBasis=    30 NAE=     9 NBE=     7 NFC=     0 NFV=     0
+ NROrb=     30 NOA=     9 NOB=     7 NVA=    21 NVB=    23
+ Symmetrizing basis deriv contribution to polar:
+ IMax=3 JMax=2 DiffMx= 0.00D+00
+ G2DrvN: will do     3 centers at a time, making    1 passes.
+ Calling FoFCou, ICntrl=  3107 FMM=F I1Cent=   0 AccDes= 0.00D+00.
+ End of G2Drv F.D. properties file   721 does not exist.
+ End of G2Drv F.D. properties file   722 does not exist.
+ End of G2Drv F.D. properties file   788 does not exist.
+          IDoAtm=11
+          Differentiating once with respect to electric field.
+                with respect to dipole field.
+          Differentiating once with respect to nuclear coordinates.
+ Keep R1 and R2 ints in memory in symmetry-blocked form, NReq=3551934.
+          There are     6 degrees of freedom in the 1st order CPHF.  IDoFFX=4 NUNeed=     6.
+      6 vectors produced by pass  0 Test12= 5.83D-15 1.67D-08 XBig12= 1.74D+01 2.60D+00.
+ AX will form     6 AO Fock derivatives at one time.
+      6 vectors produced by pass  1 Test12= 5.83D-15 1.67D-08 XBig12= 8.11D+00 1.06D+00.
+      6 vectors produced by pass  2 Test12= 5.83D-15 1.67D-08 XBig12= 5.64D-01 4.14D-01.
+      6 vectors produced by pass  3 Test12= 5.83D-15 1.67D-08 XBig12= 1.88D-02 5.71D-02.
+      6 vectors produced by pass  4 Test12= 5.83D-15 1.67D-08 XBig12= 2.33D-04 8.14D-03.
+      6 vectors produced by pass  5 Test12= 5.83D-15 1.67D-08 XBig12= 3.03D-06 1.16D-03.
+      6 vectors produced by pass  6 Test12= 5.83D-15 1.67D-08 XBig12= 3.77D-08 9.76D-05.
+      3 vectors produced by pass  7 Test12= 5.83D-15 1.67D-08 XBig12= 1.24D-10 3.20D-06.
+      1 vectors produced by pass  8 Test12= 5.83D-15 1.67D-08 XBig12= 4.99D-13 2.33D-07.
+ InvSVY:  IOpt=1 It=  1 EMax= 8.88D-16
+ Solved reduced A of dimension    46 with     6 vectors.
+ Isotropic polarizability for W=    0.000000        6.95 Bohr**3.
+ End of Minotr F.D. properties file   721 does not exist.
+ End of Minotr F.D. properties file   722 does not exist.
+ End of Minotr F.D. properties file   788 does not exist.
+
+ **********************************************************************
+
+            Population analysis using the SCF density.
+
+ **********************************************************************
+
+ Orbital symmetries:
+ Alpha Orbitals:
+       Occupied  (SGG) (SGU) (SGG) (SGU) (PIU) (PIU) (SGG) (PIG)
+                 (PIG)
+       Virtual   (SGU) (SGG) (SGU) (PIU) (PIU) (SGG) (PIG) (PIG)
+                 (SGU) (PIU) (PIU) (DLTG) (DLTG) (DLTU) (DLTU)
+                 (SGG) (PIG) (PIG) (SGU) (SGG) (SGU)
+ Beta  Orbitals:
+       Occupied  (SGG) (SGU) (SGG) (SGU) (SGG) (PIU) (PIU)
+       Virtual   (PIG) (PIG) (SGU) (SGG) (SGU) (PIU) (PIU) (SGG)
+                 (PIG) (PIG) (SGU) (PIU) (PIU) (DLTG) (DLTG) (DLTU)
+                 (DLTU) (SGG) (PIG) (PIG) (SGU) (SGG) (SGU)
+ The electronic state is 3-SGG.
+ Alpha  occ. eigenvalues --  -19.00506 -19.00473  -1.33976  -0.86059  -0.60821
+ Alpha  occ. eigenvalues --   -0.60821  -0.59462  -0.34539  -0.34539
+ Alpha virt. eigenvalues --    0.26790   0.71351   0.75599   0.81418   0.81418
+ Alpha virt. eigenvalues --    0.88885   0.93571   0.93571   1.32218   1.51959
+ Alpha virt. eigenvalues --    1.51959   1.54391   1.54391   1.92809   1.92809
+ Alpha virt. eigenvalues --    2.43904   2.56053   2.56053   2.81429   3.19154
+ Alpha virt. eigenvalues --    3.50356
+  Beta  occ. eigenvalues --  -18.98301 -18.98238  -1.28462  -0.79214  -0.54738
+  Beta  occ. eigenvalues --   -0.50864  -0.50864
+  Beta virt. eigenvalues --   -0.07208  -0.07208   0.29413   0.72505   0.77144
+  Beta virt. eigenvalues --    0.86297   0.86297   0.89529   0.99664   0.99664
+  Beta virt. eigenvalues --    1.35028   1.55033   1.55033   1.58773   1.58773
+  Beta virt. eigenvalues --    1.99139   1.99139   2.45535   2.59154   2.59154
+  Beta virt. eigenvalues --    2.81856   3.21403   3.55349
+          Condensed to atoms (all electrons):
+               1          2
+     1  O    7.856573   0.143427
+     2  O    0.143427   7.856573
+          Atomic-Atomic Spin Densities.
+               1          2
+     1  O    1.337639  -0.337639
+     2  O   -0.337639   1.337639
+ Mulliken charges and spin densities:
+               1          2
+     1  O   -0.000000   1.000000
+     2  O   -0.000000   1.000000
+ Sum of Mulliken charges =  -0.00000   2.00000
+ Mulliken charges and spin densities with hydrogens summed into heavy atoms:
+               1          2
+     1  O   -0.000000   1.000000
+     2  O   -0.000000   1.000000
+ APT charges:
+               1
+     1  O   -0.000000
+     2  O   -0.000000
+ Sum of APT charges =  -0.00000
+ APT charges with hydrogens summed into heavy atoms:
+               1
+     1  O   -0.000000
+     2  O   -0.000000
+ Electronic spatial extent (au):  <R**2>=             42.9369
+ Charge=             -0.0000 electrons
+ Dipole moment (field-independent basis, Debye):
+    X=             -0.0000    Y=             -0.0000    Z=             -0.0000  Tot=              0.0000
+ Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=             -9.7688   YY=             -9.7688   ZZ=            -10.2768
+   XY=              0.0000   XZ=              0.0000   YZ=              0.0000
+ Traceless Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=              0.1693   YY=              0.1693   ZZ=             -0.3386
+   XY=              0.0000   XZ=              0.0000   YZ=              0.0000
+ Octapole moment (field-independent basis, Debye-Ang**2):
+  XXX=             -0.0000  YYY=              0.0000  ZZZ=             -0.0000  XYY=             -0.0000
+  XXY=             -0.0000  XXZ=             -0.0000  XZZ=             -0.0000  YZZ=             -0.0000
+  YYZ=             -0.0000  XYZ=              0.0000
+ Hexadecapole moment (field-independent basis, Debye-Ang**3):
+ XXXX=             -6.3568 YYYY=             -6.3568 ZZZZ=            -27.4469 XXXY=              0.0000
+ XXXZ=              0.0000 YYYX=              0.0000 YYYZ=              0.0000 ZZZX=              0.0000
+ ZZZY=              0.0000 XXYY=             -2.1189 XXZZ=             -5.8430 YYZZ=             -5.8430
+ XXYZ=              0.0000 YYXZ=              0.0000 ZZXY=             -0.0000
+ N-N= 2.808569093187D+01 E-N=-4.105439972284D+02  KE= 1.486710800525D+02
+ Symmetry AG   KE= 6.901802803963D+01
+ Symmetry B1G  KE= 1.826756601606D-34
+ Symmetry B2G  KE= 3.060267915066D+00
+ Symmetry B3G  KE= 3.060267915066D+00
+ Symmetry AU   KE= 4.321715775384D-34
+ Symmetry B1U  KE= 6.439955300660D+01
+ Symmetry B2U  KE= 4.566481588044D+00
+ Symmetry B3U  KE= 4.566481588044D+00
+ Symmetry AG   SP=-1.793663459641D-15
+ Symmetry B1G  SP= 3.225012289366D-35
+ Symmetry B2G  SP= 1.000000000000D+00
+ Symmetry B3G  SP= 1.000000000000D+00
+ Symmetry AU   SP= 3.044326967508D-35
+ Symmetry B1U  SP= 4.932665217293D-16
+ Symmetry B2U  SP= 3.334395952963D-17
+ Symmetry B3U  SP=-6.327898552455D-16
+  Exact polarizability:   4.240  -0.000   4.240  -0.000  -0.000  12.369
+ Approx polarizability:   4.945  -0.000   4.945  -0.000  -0.000  19.468
+                          Isotropic Fermi Contact Couplings
+        Atom                 a.u.       MegaHertz       Gauss      10(-4) cm-1
+     1  O(17)             -0.07033      21.31705       7.60645       7.11060
+     2  O(17)             -0.07033      21.31705       7.60645       7.11060
+ --------------------------------------------------------
+       Center         ----  Spin Dipole Couplings  ----
+                      3XX-RR        3YY-RR        3ZZ-RR
+ --------------------------------------------------------
+     1   Atom        1.136495      1.136495     -2.272990
+     2   Atom        1.136495      1.136495     -2.272990
+ --------------------------------------------------------
+                        XY            XZ            YZ
+ --------------------------------------------------------
+     1   Atom        0.000000     -0.000000      0.000000
+     2   Atom        0.000000     -0.000000      0.000000
+ --------------------------------------------------------
+
+
+ ---------------------------------------------------------------------------------
+              Anisotropic Spin Dipole Couplings in Principal Axis System
+ ---------------------------------------------------------------------------------
+
+       Atom             a.u.   MegaHertz   Gauss  10(-4) cm-1        Axes
+
+              Baa    -2.2730   164.472    58.688    54.862  0.0000  0.0000  1.0000
+     1 O(17)  Bbb     1.1365   -82.236   -29.344   -27.431  1.0000  0.0000  0.0000
+              Bcc     1.1365   -82.236   -29.344   -27.431  0.0000  1.0000  0.0000
+ 
+              Baa    -2.2730   164.472    58.688    54.862  0.0000  0.0000  1.0000
+     2 O(17)  Bbb     1.1365   -82.236   -29.344   -27.431  1.0000  0.0000  0.0000
+              Bcc     1.1365   -82.236   -29.344   -27.431  0.0000  1.0000  0.0000
+ 
+
+ ---------------------------------------------------------------------------------
+
+ Calling FoFJK, ICntrl=    100127 FMM=F ISym2X=1 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ Full mass-weighted force constant matrix:
+ Low frequencies ---  -13.8785  -13.8785   -0.0021   -0.0010   -0.0010 1744.4936
+ Diagonal vibrational polarizability:
+        0.0000000       0.0000000       0.0000000
+ Harmonic frequencies (cm**-1), IR intensities (KM/Mole), Raman scattering
+ activities (A**4/AMU), depolarization ratios for plane and unpolarized
+ incident light, reduced masses (AMU), force constants (mDyne/A),
+ and normal coordinates:
+                      1
+                     SGG
+ Frequencies --   1744.4936
+ Red. masses --     15.9949
+ Frc consts  --     28.6795
+ IR Inten    --      0.0000
+  Atom  AN      X      Y      Z
+     1   8    -0.00   0.00   0.71
+     2   8     0.00   0.00  -0.71
+
+ -------------------
+ - Thermochemistry -
+ -------------------
+ Temperature   298.150 Kelvin.  Pressure   1.00000 Atm.
+ Atom     1 has atomic number  8 and mass  15.99491
+ Atom     2 has atomic number  8 and mass  15.99491
+ Molecular mass:    31.98983 amu.
+ Principal axes and moments of inertia in atomic units:
+                           1         2         3
+     Eigenvalues --     0.00000  41.52806  41.52806
+           X           -0.00000   1.00000  -0.00000
+           Y            0.00000   0.00000   1.00000
+           Z            1.00000   0.00000  -0.00000
+ This molecule is a prolate symmetric top.
+ Rotational symmetry number  2.
+ Rotational temperature (Kelvin)      2.08567
+ Rotational constant (GHZ):          43.458355
+ Zero-point vibrational energy      10434.4 (Joules/Mol)
+                                    2.49388 (Kcal/Mol)
+ Vibrational temperatures:   2509.94
+          (Kelvin)
+ 
+ Zero-point correction=                           0.003974 (Hartree/Particle)
+ Thermal correction to Energy=                    0.006336
+ Thermal correction to Enthalpy=                  0.007281
+ Thermal correction to Gibbs Free Energy=        -0.015991
+ Sum of electronic and zero-point Energies=           -150.161190
+ Sum of electronic and thermal Energies=              -150.158828
+ Sum of electronic and thermal Enthalpies=            -150.157884
+ Sum of electronic and thermal Free Energies=         -150.181155
+ 
+                     E (Thermal)             CV                S
+                      KCal/Mol        Cal/Mol-Kelvin    Cal/Mol-Kelvin
+ Total                    3.976              4.999             48.979
+ Electronic               0.000              0.000              2.183
+ Translational            0.889              2.981             36.321
+ Rotational               0.592              1.987             10.471
+ Vibrational              2.495              0.031              0.004
+                       Q            Log10(Q)             Ln(Q)
+ Total Bot       0.226632D+08          7.355322         16.936254
+ Total V=0       0.152527D+10          9.183348         21.145439
+ Vib (Bot)       0.148617D-01         -1.827930         -4.208965
+ Vib (V=0)       0.100022D+01          0.000096          0.000221
+ Electronic      0.300000D+01          0.477121          1.098612
+ Translational   0.711167D+07          6.851972         15.777248
+ Rotational      0.714758D+02          1.854159          4.269358
+ ***** Axes restored to original set *****
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        8          -0.000037007    0.000000000    0.000000000
+      2        8           0.000037007   -0.000000000   -0.000000000
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.000037007 RMS     0.000021366
+ FormGI is forming the generalized inverse of G from B-inverse, IUseBI=4.
+
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+ Berny optimization.
+ Internal  Forces:  Max     0.000037007 RMS     0.000037007
+ Search for a local minimum.
+ Step number   1 out of a maximum of    2
+ All quantities printed in internal units (Hartrees-Bohrs-Radians)
+ Second derivative matrix not updated -- analytic derivatives used.
+ The second derivative matrix:
+                          R1
+           R1           0.92105
+ ITU=  0
+     Eigenvalues ---    0.92105
+ Angle between quadratic step and forces=   0.00 degrees.
+ Linear search not attempted -- first point.
+ Iteration  1 RMS(Cart)=  0.00002841 RMS(Int)=  0.00000000
+ Iteration  2 RMS(Cart)=  0.00000000 RMS(Int)=  0.00000000
+ ClnCor:  largest displacement from symmetrization is 0.00D+00 for atom     0.
+ Variable       Old X    -DE/DX   Delta X   Delta X   Delta X     New X
+                                 (Linear)    (Quad)   (Total)
+    R1        2.27874   0.00004   0.00000   0.00004   0.00004   2.27878
+         Item               Value     Threshold  Converged?
+ Maximum Force            0.000037     0.000450     YES
+ RMS     Force            0.000037     0.000300     YES
+ Maximum Displacement     0.000020     0.001800     YES
+ RMS     Displacement     0.000028     0.001200     YES
+ Predicted change in Energy=-7.434590D-10
+ Optimization completed.
+    -- Stationary point found.
+                           ----------------------------
+                           !   Optimized Parameters   !
+                           ! (Angstroms and Degrees)  !
+ --------------------------                            --------------------------
+ ! Name  Definition              Value          Derivative Info.                !
+ --------------------------------------------------------------------------------
+ ! R1    R(1,2)                  1.2059         -DE/DX =    0.0                 !
+ --------------------------------------------------------------------------------
+ GradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGradGrad
+
+ Dipole is zero, so no output in dipole orientation.
+
+ ----------------------------------------------------------------------
+
+ Electric dipole moment (input orientation):
+ (Debye = 10**-18 statcoulomb cm , SI units = C m)
+                  (au)            (Debye)         (10**-30 SI)
+   Tot        0.000000D+00      0.000000D+00      0.000000D+00
+   x          0.000000D+00      0.000000D+00      0.000000D+00
+   y          0.000000D+00      0.000000D+00      0.000000D+00
+   z          0.000000D+00      0.000000D+00      0.000000D+00
+
+ Dipole polarizability, Alpha (input orientation).
+ (esu units = cm**3 , SI units = C**2 m**2 J**-1)
+ Alpha(0;0):
+               (au)            (10**-24 esu)      (10**-40 SI)
+   iso        0.694920D+01      0.102977D+01      0.114577D+01
+   aniso      0.812910D+01      0.120461D+01      0.134031D+01
+   xx         0.123686D+02      0.183284D+01      0.203931D+01
+   yx         0.000000D+00      0.000000D+00      0.000000D+00
+   yy         0.423950D+01      0.628230D+00      0.699000D+00
+   zx         0.000000D+00      0.000000D+00      0.000000D+00
+   zy         0.000000D+00      0.000000D+00      0.000000D+00
+   zz         0.423950D+01      0.628230D+00      0.699000D+00
+
+ ----------------------------------------------------------------------
+ 1\1\GINC-LOCALHOST\Freq\UMN15\6-31G(d,p)\O2(3)\JZZENG\07-Oct-2018\0\\#
+ N Geom=AllCheck Guess=TCheck SCRF=Check GenChk UMN15/6-31G(d,p) Freq\\
+ Run automatically by GaussianRunner\\0,3\O,1.0674612421,-0.0946,-0.030
+ 7\O,2.2733187579,-0.0946,-0.0307\\Version=ES64L-G16RevA.03\State=3-SGG
+ \HF=-150.1651643\S2=2.003622\S2-1=0.\S2A=2.000006\RMSD=8.388e-10\RMSF=
+ 2.137e-05\ZeroPoint=0.0039742\Thermal=0.0063365\Dipole=0.,0.,0.\Dipole
+ Deriv=0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.\Polar=12.3
+ 68608,0.,4.2395033,0.,0.,4.2395033\Quadrupole=-0.251775,0.1258875,0.12
+ 58875,0.,0.,0.\PG=D*H [C*(O1.O1)]\NImag=0\\0.92104775,0.,-0.00005830,0
+ .,0.,-0.00005830,-0.92104775,0.,0.,0.92104775,0.,0.00005830,0.,0.,-0.0
+ 0005830,0.,0.,0.00005830,0.,0.,-0.00005830\\0.00003701,0.,0.,-0.000037
+ 01,0.,0.\\\@
+
+
+ YOU KNOW YOU'VE SPOKEN TOO LONG WHEN THE AUDIENCE STOPS LOOKING AT
+ THEIR WATCHES AND STARTS SHAKING THEM.
+ Job cpu time:       0 days  0 hours  0 minutes 13.8 seconds.
+ Elapsed time:       0 days  0 hours  0 minutes  3.7 seconds.
+ File lengths (MBytes):  RWF=      6 Int=      0 D2E=      0 Chk=      1 Scr=      1
+ Normal termination of Gaussian 16 at Sun Oct  7 14:18:03 2018.
+

--- a/tests/test_multisystems.py
+++ b/tests/test_multisystems.py
@@ -5,7 +5,18 @@ from context import dpdata
 from comp_sys import CompSys
 from comp_sys import CompLabeledSys
 
-class TestMultiSystems(unittest.TestCase, CompLabeledSys):
+class MultiSystems:
+    def test_systems_name(self):
+        self.assertEqual(set(self.systems.systems), set(self.system_names))
+    
+    def test_systems_size(self):
+        for name, size in self.system_sizes.items():
+            self.assertEqual(self.systems[name].get_nframes(), size)
+    
+    def test_atom_names(self):
+        self.assertEqual(self.atom_names, self.systems.atom_names)
+
+class TestMultiSystems(unittest.TestCase, CompLabeledSys, MultiSystems):
     def setUp(self):
         self.places = 6
         self.e_places = 6
@@ -22,15 +33,22 @@ class TestMultiSystems(unittest.TestCase, CompLabeledSys):
         self.system_1 = self.systems['C1H3']
         self.system_2 = system_3
     
-    def test_systems_name(self):
-        system_names = ['C1H4', 'C1H3']
-        self.assertEqual(set(self.systems.systems), set(system_names))
-    
-    def test_systems_size(self):
-        system_sizes = {'C1H4':2, 'C1H3':1}
-        for name, size in system_sizes.items():
-            self.assertEqual(self.systems[name].get_nframes(), size)
+        self.system_names = ['C1H4', 'C1H3']
+        self.system_sizes = {'C1H4':2, 'C1H3':1}
+        self.atom_names = ['C', 'H']
 
+
+class TestMultiSystems(unittest.TestCase, MultiSystems):
+    def setUp(self):
+        # CH4 and O2
+        system_1 = dpdata.LabeledSystem('gaussian/methane.gaussianlog', fmt='gaussian/log')
+        system_2 = dpdata.LabeledSystem('gaussian/oxygen.gaussianlog', fmt='gaussian/log')
+        self.systems = dpdata.MultiSystems(system_1, system_2)
+
+        self.system_names = ['C1H4O0', 'C0H0O2']
+        self.system_sizes = {'C1H4O0':1, 'C0H0O2':1}
+        self.atom_names = ['C', 'H', 'O']
+        
 class TestMultiDeepmdDumpRaw(unittest.TestCase, CompLabeledSys):
     def setUp (self) :
         self.places = 6


### PR DESCRIPTION
Previous: `atom_types` of H2 and O2 are all `[0, 0]`
Now: `atom_types` of H2 and O2 are `[0, 0]` and `[1, 1]` respectively, so `dump_deepmd_npy` will dump correct `types.raw`.