### PR TITLE
enhance MultiSystems methods and bugfix

### DIFF
--- a/tests/test_multisystems.py
+++ b/tests/test_multisystems.py
@@ -38,7 +38,33 @@ class TestMultiSystems(unittest.TestCase, CompLabeledSys, MultiSystems):
         self.atom_names = ['C', 'H']
 
 
-class TestMultiSystems(unittest.TestCase, MultiSystems):
+class TestMultiSystemsAdd(unittest.TestCase, CompLabeledSys, MultiSystems):
+    def setUp(self):
+        self.places = 6
+        self.e_places = 6
+        self.f_places = 6
+        self.v_places = 6
+
+        system_1 = dpdata.LabeledSystem('gaussian/methane.gaussianlog', fmt='gaussian/log')
+        system_2 = dpdata.LabeledSystem('gaussian/methane_reordered.gaussianlog', fmt='gaussian/log')
+        system_3 = dpdata.LabeledSystem('gaussian/methane_sub.gaussianlog', fmt='gaussian/log')
+        system_4 = dpdata.LabeledSystem('gaussian/noncoveraged.gaussianlog', fmt='gaussian/log')
+
+        self.systems = dpdata.MultiSystems(system_1)
+        self.systems += system_2
+        self.systems += system_3
+        self.systems += system_4
+        for s in self.systems:
+            if s.formula == 'C1H3':
+                self.system_1 = s
+        self.system_2 = system_3
+    
+        self.system_names = ['C1H4', 'C1H3']
+        self.system_sizes = {'C1H4':2, 'C1H3':1}
+        self.atom_names = ['C', 'H']
+
+
+class TestMultiSystemsSorted(unittest.TestCase, MultiSystems):
     def setUp(self):
         # CH4 and O2
         system_1 = dpdata.LabeledSystem('gaussian/methane.gaussianlog', fmt='gaussian/log')


### PR DESCRIPTION
including `__len__`, `__repr__`, `__str__`, `__add__`, and so on
```python
>>> import dpdata
>>> s1=dpdata.LabeledSystem("ch4_10s_0.6_H_00054.log", fmt="gaussian/log")
>>> s2=dpdata.LabeledSystem("ch4_10s_0.6_H_03070.log", fmt="gaussian/log")
>>> s3=dpdata.LabeledSystem("ch4_10s_0.6_H_08081.log", fmt="gaussian/log")
>>> m=dpdata.MultiSystems(s1)
>>> m
MultiSystems (1 systems containing 1 frames)
>>> m+=s2
>>> m
MultiSystems (2 systems containing 2 frames)
>>> m+s3
MultiSystems (3 systems containing 3 frames)
>>> len(m)
2
>>> for s in m:
...     print(s.formula)
...
C1H3O4
C0H5O3
```
also fix several bugs.