### PR TITLE
No way to pass parameter "md" in gaussian/log

### DIFF
--- a/dpdata/system.py
+++ b/dpdata/system.py
@@ -69,7 +69,8 @@ class System (MSONable) :
                   type_map = None,
                   begin = 0,
                   step = 1,
-                  data = None) :
+                  data = None,
+                  **kwargs) :
         """
         Constructor
 
@@ -113,7 +114,7 @@ class System (MSONable) :
             return
         if file_name is None :
             return
-        self.from_fmt(file_name, fmt, type_map=type_map, begin= begin, step=step)
+        self.from_fmt(file_name, fmt, type_map=type_map, begin= begin, step=step, **kwargs)
 
         if type_map is not None:
             self.apply_type_map(type_map)
@@ -898,7 +899,8 @@ class LabeledSystem (System):
                   type_map = None,
                   begin = 0,
                   step = 1,
-                  data=None) :
+                  data=None,
+                  **kwargs) :
         """
         Constructor
 
@@ -941,7 +943,7 @@ class LabeledSystem (System):
            return
         if file_name is None :
             return
-        self.from_fmt(file_name, fmt, type_map=type_map, begin= begin, step=step)
+        self.from_fmt(file_name, fmt, type_map=type_map, begin= begin, step=step, **kwargs)
         if type_map is not None:
             self.apply_type_map(type_map)
 


### PR DESCRIPTION
the gaussian/log function has a parameter `md`, but there is no way to pass it.

https://github.com/deepmodeling/dpdata/blob/2dac5ffe9432d26d4bef3d85429c1e8c884d8fae/dpdata/gaussian/log.py#L13

fix this bug, add `**kwargs` in `__init__` of `class System`