### PR TITLE
Fix bug in log.py

### DIFF
--- a/dpdata/gaussian/log.py
+++ b/dpdata/gaussian/log.py
@@ -27,7 +27,7 @@ def to_system_data(file_name, md=False):
             elif line.startswith(" Center     Atomic                   Forces (Hartrees/Bohr)"):
                 flag = 1
                 forces = []
-            elif line.startswith("                          Input orientation:") or line.startswith("                         Z-Matrix orientation:"):
+            elif line.startswith("                          Input orientation:") or line.startswith("                         Z-Matrix orientation:") or line.startswith("                         Standard orientation:"):
                 flag = 5
                 coords = []
                 atom_symbols = []


### PR DESCRIPTION
For system with more than 50 atoms, gaussian will not output the " Input orientation" or "Z-Matrix orientation", so we need to add keywords "Standard orientation". Instead, you can add "geom=printinputorient" keywords in the gaussian input to get the " Input orientation".