### PR TITLE
fix double cell bug and no virial information case

### DIFF
--- a/dpdata/system.py
+++ b/dpdata/system.py
@@ -1248,8 +1248,10 @@ class LabeledSystem (System):
             self.data['coords'], \
             self.data['energies'], \
             self.data['forces'], \
-            self.data['virials'] \
+            tmp_virial \
             = dpdata.cp2k.output.get_frames(file_name)
+        if tmp_virial is not None:
+            self.data['virials'] = tmp_virial
     @register_from_funcs.register_funcs('movement')
     @register_from_funcs.register_funcs('MOVEMENT')
     @register_from_funcs.register_funcs('mlmd')

--- a/tests/cp2k/cp2k_output_2
+++ b/tests/cp2k/cp2k_output_2
@@ -1,0 +1,2288 @@
+ DBCSR| Multiplication driver                                               BLAS
+ DBCSR| Multrec recursion limit                                              512
+ DBCSR| Multiplication stack size                                           1000
+ DBCSR| Maximum elements for images                                    UNLIMITED
+ DBCSR| Multiplicative factor virtual images                                   1
+ DBCSR| Randmat seed                                                    12341313
+ DBCSR| Multiplication size stacks                                             3
+ DBCSR| Number of 3D layers                                               SINGLE
+ DBCSR| Use MPI memory allocation                                              T
+ DBCSR| Use RMA algorithm                                                      F
+ DBCSR| Use Communication thread                                               T
+ DBCSR| Communication thread load                                             87
+
+
+  **** **** ******  **  PROGRAM STARTED AT               2019-08-10 12:43:41.832
+ ***** ** ***  *** **   PROGRAM STARTED ON                                  c038
+ **    ****   ******    PROGRAM STARTED BY                                 fengw
+ ***** **    ** ** **   PROGRAM PROCESS ID                                 21094
+  **** **  *******  **  PROGRAM STARTED IN /data/fengw/PC-LiTFSI/energy/BLYP/0.3
+                                           7_CBM_VBM/KS/29000/test
+
+ CP2K| version string:                                          CP2K version 4.1
+ CP2K| source code revision number:                                    svn:17462
+ CP2K| cp2kflags: omp libint fftw3 libxc parallel mpi3 scalapack libderiv_max_am
+ CP2K|            1=5 libint_max_am=6
+ CP2K| is freely available from                            https://www.cp2k.org/
+ CP2K| Program compiled at                          Tue May  2 22:33:05 CST 2017
+ CP2K| Program compiled on                                                   mgt
+ CP2K| Program compiled for                                Linux-x86-64-gfortran
+ CP2K| Data directory path                             /share/soft/cp2k-4.1/data
+ CP2K| Input file name                                                 input.inp
+ 
+ GLOBAL| Force Environment number                                              1
+ GLOBAL| Basis set file name                     /data/fengw/data/GTH_BASIS_SETS
+ GLOBAL| Potential file name                     /data/fengw/data/GTH_POTENTIALS
+ GLOBAL| MM Potential file name                                     MM_POTENTIAL
+ GLOBAL| Coordinate file name                                      __STD_INPUT__
+ GLOBAL| Method name                                                        CP2K
+ GLOBAL| Project name                                              Solv_0.37-0.0
+ GLOBAL| Preferred FFT library                                             FFTW3
+ GLOBAL| Preferred diagonalization lib.                                       SL
+ GLOBAL| Run type                                                   ENERGY_FORCE
+ GLOBAL| All-to-all communication in single precision                          F
+ GLOBAL| FFTs using library dependent lengths                                  F
+ GLOBAL| Global print level                                               MEDIUM
+ GLOBAL| Total number of message passing processes                            28
+ GLOBAL| Number of threads for this process                                    1
+ GLOBAL| This output is from process                                           0
+ GLOBAL| CPU model name :  Intel(R) Xeon(R) CPU E5-2680 v4 @ 2.40GHz
+
+ MEMORY| system memory details [Kb]
+ MEMORY|                        rank 0           min           max       average
+ MEMORY| MemTotal             65125420      65125420      65125420      65125420
+ MEMORY| MemFree              44849788      44849788      44849788      44849788
+ MEMORY| Buffers                144020        144020        144020        144020
+ MEMORY| Cached               18013976      18013976      18013976      18013976
+ MEMORY| Slab                   402832        402832        402832        402832
+ MEMORY| SReclaimable           174504        174504        174504        174504
+ MEMORY| MemLikelyFree        63182288      63182288      63182288      63182288
+
+
+ *** Fundamental physical constants (SI units) ***
+
+ *** Literature: B. J. Mohr and B. N. Taylor,
+ ***             CODATA recommended values of the fundamental physical
+ ***             constants: 2006, Web Version 5.1
+ ***             http://physics.nist.gov/constants
+
+ Speed of light in vacuum [m/s]                             2.99792458000000E+08
+ Magnetic constant or permeability of vacuum [N/A**2]       1.25663706143592E-06
+ Electric constant or permittivity of vacuum [F/m]          8.85418781762039E-12
+ Planck constant (h) [J*s]                                  6.62606896000000E-34
+ Planck constant (h-bar) [J*s]                              1.05457162825177E-34
+ Elementary charge [C]                                      1.60217648700000E-19
+ Electron mass [kg]                                         9.10938215000000E-31
+ Electron g factor [ ]                                     -2.00231930436220E+00
+ Proton mass [kg]                                           1.67262163700000E-27
+ Fine-structure constant                                    7.29735253760000E-03
+ Rydberg constant [1/m]                                     1.09737315685270E+07
+ Avogadro constant [1/mol]                                  6.02214179000000E+23
+ Boltzmann constant [J/K]                                   1.38065040000000E-23
+ Atomic mass unit [kg]                                      1.66053878200000E-27
+ Bohr radius [m]                                            5.29177208590000E-11
+
+ *** Conversion factors ***
+
+ [u] -> [a.u.]                                              1.82288848426455E+03
+ [Angstrom] -> [Bohr] = [a.u.]                              1.88972613288564E+00
+ [a.u.] = [Bohr] -> [Angstrom]                              5.29177208590000E-01
+ [a.u.] -> [s]                                              2.41888432650478E-17
+ [a.u.] -> [fs]                                             2.41888432650478E-02
+ [a.u.] -> [J]                                              4.35974393937059E-18
+ [a.u.] -> [N]                                              8.23872205491840E-08
+ [a.u.] -> [K]                                              3.15774647902944E+05
+ [a.u.] -> [kJ/mol]                                         2.62549961709828E+03
+ [a.u.] -> [kcal/mol]                                       6.27509468713739E+02
+ [a.u.] -> [Pa]                                             2.94210107994716E+13
+ [a.u.] -> [bar]                                            2.94210107994716E+08
+ [a.u.] -> [atm]                                            2.90362800883016E+08
+ [a.u.] -> [eV]                                             2.72113838565563E+01
+ [a.u.] -> [Hz]                                             6.57968392072181E+15
+ [a.u.] -> [1/cm] (wave numbers)                            2.19474631370540E+05
+ [a.u./Bohr**2] -> [1/cm]                                   5.14048714338585E+03
+ 
+
+ CELL_TOP| Volume [angstrom^3]:                                         4499.480
+ CELL_TOP| Vector a [angstrom    16.509     0.000     0.000    |a| =      16.509
+ CELL_TOP| Vector b [angstrom     0.000    16.509     0.000    |b| =      16.509
+ CELL_TOP| Vector c [angstrom     0.000     0.000    16.509    |c| =      16.509
+ CELL_TOP| Angle (b,c), alpha [degree]:                                   90.000
+ CELL_TOP| Angle (a,c), beta  [degree]:                                   90.000
+ CELL_TOP| Angle (a,b), gamma [degree]:                                   90.000
+ CELL_TOP| Numerically orthorhombic:                                         YES
+ 
+ GENERATE|  Preliminary Number of Bonds generated:                             0
+ GENERATE|  Achieved consistency in connectivity generation.
+
+ CELL| Volume [angstrom^3]:                                             4499.480
+ CELL| Vector a [angstrom]:      16.509     0.000     0.000    |a| =      16.509
+ CELL| Vector b [angstrom]:       0.000    16.509     0.000    |b| =      16.509
+ CELL| Vector c [angstrom]:       0.000     0.000    16.509    |c| =      16.509
+ CELL| Angle (b,c), alpha [degree]:                                       90.000
+ CELL| Angle (a,c), beta  [degree]:                                       90.000
+ CELL| Angle (a,b), gamma [degree]:                                       90.000
+ CELL| Numerically orthorhombic:                                             YES
+
+ CELL_REF| Volume [angstrom^3]:                                         4499.480
+ CELL_REF| Vector a [angstrom    16.509     0.000     0.000    |a| =      16.509
+ CELL_REF| Vector b [angstrom     0.000    16.509     0.000    |b| =      16.509
+ CELL_REF| Vector c [angstrom     0.000     0.000    16.509    |c| =      16.509
+ CELL_REF| Angle (b,c), alpha [degree]:                                   90.000
+ CELL_REF| Angle (a,c), beta  [degree]:                                   90.000
+ CELL_REF| Angle (a,b), gamma [degree]:                                   90.000
+ CELL_REF| Numerically orthorhombic:                                         YES
+
+ *******************************************************************************
+ *******************************************************************************
+ **                                                                           **
+ **     #####                         ##              ##                      **
+ **    ##   ##            ##          ##              ##                      **
+ **   ##     ##                       ##            ######                    **
+ **   ##     ##  ##   ##  ##   #####  ##  ##   ####   ##    #####    #####    **
+ **   ##     ##  ##   ##  ##  ##      ## ##   ##      ##   ##   ##  ##   ##   **
+ **   ##  ## ##  ##   ##  ##  ##      ####     ###    ##   ######   ######    **
+ **    ##  ###   ##   ##  ##  ##      ## ##      ##   ##   ##       ##        **
+ **     #######   #####   ##   #####  ##  ##  ####    ##    #####   ##        **
+ **           ##                                                    ##        **
+ **                                                                           **
+ **                                                ... make the atoms dance   **
+ **                                                                           **
+ **            Copyright (C) by CP2K developers group (2000 - 2016)           **
+ **                                                                           **
+ *******************************************************************************
+
+ DFT| Spin restricted Kohn-Sham (RKS) calculation                            RKS
+ DFT| Multiplicity                                                             1
+ DFT| Number of spin states                                                    1
+ DFT| Charge                                                                   0
+ DFT| Self-interaction correction (SIC)                                       NO
+ DFT| Cutoffs: density                                              1.000000E-10
+ DFT|          gradient                                             1.000000E-10
+ DFT|          tau                                                  1.000000E-10
+ DFT|          cutoff_smoothing_range                               0.000000E+00
+ DFT| XC density smoothing                                                  NN50
+ DFT| XC derivatives                                                 NN50_SMOOTH
+ FUNCTIONAL| ROUTINE=NEW
+ FUNCTIONAL| BECKE88:
+ FUNCTIONAL| A. Becke, Phys. Rev. A 38, 3098 (1988) {LDA version}               
+ FUNCTIONAL| LYP:
+ FUNCTIONAL| C. Lee, W. Yang, R.G. Parr, Phys. Rev. B, 37, 785 (1988) {LDA versi
+ FUNCTIONAL| on}                                                                
+ vdW POTENTIAL|                                                   Pair Potential
+ vdW POTENTIAL|          DFT-D3 (Version 3.1)
+ vdW POTENTIAL|          Potential Form: S. Grimme et al, JCP 132: 154104 (2010)
+ vdW POTENTIAL|          Zero Damping
+ vdW POTENTIAL|          Cutoff Radius [Bohr]:                             20.00
+ vdW POTENTIAL|          s6 Scaling Factor:                               1.0000
+ vdW POTENTIAL|          sr6 Scaling Factor:                              1.0940
+ vdW POTENTIAL|          s8 Scaling Factor:                               1.6820
+ vdW POTENTIAL|          Cutoff for CN calculation:                   0.1000E-05
+
+ QS| Method:                                                                 GPW
+ QS| Density plane wave grid type                        NON-SPHERICAL FULLSPACE
+ QS| Number of grid levels:                                                    4
+ QS| Density cutoff [a.u.]:                                                250.0
+ QS| Multi grid cutoff [a.u.]: 1) grid level                               250.0
+ QS|                           2) grid level                                83.3
+ QS|                           3) grid level                                27.8
+ QS|                           4) grid level                                 9.3
+ QS| Grid level progression factor:                                          3.0
+ QS| Relative density cutoff [a.u.]:                                        30.0
+ QS| Consistent realspace mapping and integration 
+ QS| Interaction thresholds: eps_pgf_orb:                                1.0E-15
+ QS|                         eps_filter_matrix:                          0.0E+00
+ QS|                         eps_core_charge:                            1.0E-14
+ QS|                         eps_rho_gspace:                             1.0E-12
+ QS|                         eps_rho_rspace:                             1.0E-12
+ QS|                         eps_gvg_rspace:                             1.0E-06
+ QS|                         eps_ppl:                                    1.0E-02
+ QS|                         eps_ppnl:                                   1.0E-08
+
+
+ ATOMIC KIND INFORMATION
+
+  1. Atomic kind: C                                     Number of atoms:       4
+
+     Orbital Basis Set                                                  DZVP-GTH
+
+       Number of orbital shell sets:                                           2
+       Number of orbital shells:                                               5
+       Number of primitive Cartesian functions:                                5
+       Number of Cartesian basis functions:                                   14
+       Number of spherical basis functions:                                   13
+       Norm type:                                                              2
+
+       Normalised Cartesian orbitals:
+
+                        Set   Shell   Orbital            Exponent    Coefficient
+
+                          1       1    2s                4.336238       0.319274
+                                                         1.288184      -0.025219
+                                                         0.403777      -0.248447
+                                                         0.118788      -0.057170
+
+                          1       2    3s                4.336238       0.000000
+                                                         1.288184       0.000000
+                                                         0.403777       0.000000
+                                                         0.118788       0.144208
+
+                          1       3    3px               4.336238      -0.783226
+                                                         1.288184      -0.542954
+                                                         0.403777      -0.216197
+                                                         0.118788      -0.040339
+                          1       3    3py               4.336238      -0.783226
+                                                         1.288184      -0.542954
+                                                         0.403777      -0.216197
+                                                         0.118788      -0.040339
+                          1       3    3pz               4.336238      -0.783226
+                                                         1.288184      -0.542954
+                                                         0.403777      -0.216197
+                                                         0.118788      -0.040339
+
+                          1       4    4px               4.336238       0.000000
+                                                         1.288184       0.000000
+                                                         0.403777       0.000000
+                                                         0.118788       0.099404
+                          1       4    4py               4.336238       0.000000
+                                                         1.288184       0.000000
+                                                         0.403777       0.000000
+                                                         0.118788       0.099404
+                          1       4    4pz               4.336238       0.000000
+                                                         1.288184       0.000000
+                                                         0.403777       0.000000
+                                                         0.118788       0.099404
+
+                          2       1    3dx2              0.550000       0.578155
+                          2       1    3dxy              0.550000       1.001394
+                          2       1    3dxz              0.550000       1.001394
+                          2       1    3dy2              0.550000       0.578155
+                          2       1    3dyz              0.550000       1.001394
+                          2       1    3dz2              0.550000       0.578155
+
+     Potential information for                                       GTH-BLYP-q4
+
+       Description:                       Goedecker-Teter-Hutter pseudopotential
+                                           Goedecker et al., PRB 54, 1703 (1996)
+                                          Hartwigsen et al., PRB 58, 3641 (1998)
+                                                      Krack, TCA 114, 145 (2005)
+
+       Gaussian exponent of the core charge distribution:               4.374886
+       Electronic configuration (s p d ...):                               2   2
+
+       Parameters of the local part of the GTH pseudopotential:
+
+                          rloc        C1          C2          C3          C4
+                        0.338066   -9.136269    1.429260
+
+       Parameters of the non-local part of the GTH pseudopotential:
+
+                   l      r(l)      h(i,j,l)
+
+                   0    0.302322    9.665512
+                   1    0.286379
+
+  2. Atomic kind: H                                     Number of atoms:       6
+
+     Orbital Basis Set                                                  DZVP-GTH
+
+       Number of orbital shell sets:                                           2
+       Number of orbital shells:                                               3
+       Number of primitive Cartesian functions:                                5
+       Number of Cartesian basis functions:                                    5
+       Number of spherical basis functions:                                    5
+       Norm type:                                                              2
+
+       Normalised Cartesian orbitals:
+
+                        Set   Shell   Orbital            Exponent    Coefficient
+
+                          1       1    1s                8.374435      -0.099425
+                                                         1.805868      -0.148088
+                                                         0.485253      -0.165568
+                                                         0.165824      -0.102436
+
+                          1       2    2s                8.374435       0.000000
+                                                         1.805868       0.000000
+                                                         0.485253       0.000000
+                                                         0.165824       0.185202
+
+                          2       1    2px               0.727000       0.956881
+                          2       1    2py               0.727000       0.956881
+                          2       1    2pz               0.727000       0.956881
+
+     Potential information for                                       GTH-BLYP-q1
+
+       Description:                       Goedecker-Teter-Hutter pseudopotential
+                                           Goedecker et al., PRB 54, 1703 (1996)
+                                          Hartwigsen et al., PRB 58, 3641 (1998)
+                                                      Krack, TCA 114, 145 (2005)
+
+       Gaussian exponent of the core charge distribution:              12.500000
+       Electronic configuration (s p d ...):                                   1
+
+       Parameters of the local part of the GTH pseudopotential:
+
+                          rloc        C1          C2          C3          C4
+                        0.200000   -4.195961    0.730498
+
+  3. Atomic kind: O                                     Number of atoms:       3
+
+     Orbital Basis Set                                                  DZVP-GTH
+
+       Number of orbital shell sets:                                           2
+       Number of orbital shells:                                               5
+       Number of primitive Cartesian functions:                                5
+       Number of Cartesian basis functions:                                   14
+       Number of spherical basis functions:                                   13
+       Norm type:                                                              2
+
+       Normalised Cartesian orbitals:
+
+                        Set   Shell   Orbital            Exponent    Coefficient
+
+                          1       1    2s                8.304386       0.526521
+                                                         2.457948      -0.055011
+                                                         0.759737      -0.404341
+                                                         0.213639      -0.086026
+
+                          1       2    3s                8.304386       0.000000
+                                                         2.457948       0.000000
+                                                         0.759737       0.000000
+                                                         0.213639       0.223960
+
+                          1       3    3px               8.304386      -2.000755
+                                                         2.457948      -1.321076
+                                                         0.759737      -0.480332
+                                                         0.213639      -0.078647
+                          1       3    3py               8.304386      -2.000755
+                                                         2.457948      -1.321076
+                                                         0.759737      -0.480332
+                                                         0.213639      -0.078647
+                          1       3    3pz               8.304386      -2.000755
+                                                         2.457948      -1.321076
+                                                         0.759737      -0.480332
+                                                         0.213639      -0.078647
+
+                          1       4    4px               8.304386       0.000000
+                                                         2.457948       0.000000
+                                                         0.759737       0.000000
+                                                         0.213639       0.207033
+                          1       4    4py               8.304386       0.000000
+                                                         2.457948       0.000000
+                                                         0.759737       0.000000
+                                                         0.213639       0.207033
+                          1       4    4pz               8.304386       0.000000
+                                                         2.457948       0.000000
+                                                         0.759737       0.000000
+                                                         0.213639       0.207033
+
+                          2       1    3dx2              1.185000       2.215218
+                          2       1    3dxy              1.185000       3.836871
+                          2       1    3dxz              1.185000       3.836871
+                          2       1    3dy2              1.185000       2.215218
+                          2       1    3dyz              1.185000       3.836871
+                          2       1    3dz2              1.185000       2.215218
+
+     Potential information for                                       GTH-BLYP-q6
+
+       Description:                       Goedecker-Teter-Hutter pseudopotential
+                                           Goedecker et al., PRB 54, 1703 (1996)
+                                          Hartwigsen et al., PRB 58, 3641 (1998)
+                                                      Krack, TCA 114, 145 (2005)
+
+       Gaussian exponent of the core charge distribution:               8.438331
+       Electronic configuration (s p d ...):                               2   4
+
+       Parameters of the local part of the GTH pseudopotential:
+
+                          rloc        C1          C2          C3          C4
+                        0.243420  -16.991892    2.566142
+
+       Parameters of the non-local part of the GTH pseudopotential:
+
+                   l      r(l)      h(i,j,l)
+
+                   0    0.220831   18.388851
+                   1    0.217201
+
+
+ MOLECULE KIND INFORMATION
+
+
+ All atoms are their own molecule, skipping detailed information
+
+
+ TOTAL NUMBERS AND MAXIMUM NUMBERS
+
+  Total number of            - Atomic kinds:                                   3
+                             - Atoms:                                         13
+                             - Shell sets:                                    26
+                             - Shells:                                        53
+                             - Primitive Cartesian functions:                 65
+                             - Cartesian basis functions:                    128
+                             - Spherical basis functions:                    121
+
+  Maximum angular momentum of- Orbital basis functions:                        2
+                             - Local part of the GTH pseudopotential:          2
+                             - Non-local part of the GTH pseudopotential:      0
+
+
+ MODULE QUICKSTEP:  ATOMIC COORDINATES IN angstrom
+
+  Atom  Kind  Element       X           Y           Z          Z(eff)       Mass
+
+       1     1 C    6    8.502557   13.615841   13.959087      4.00      12.0107
+       2     1 C    6    7.337961   15.436979   13.231602      4.00      12.0107
+       3     1 C    6    7.898228   15.711577   14.610790      4.00      12.0107
+       4     2 H    1    6.191067   15.347699   13.085878      1.00       1.0079
+       5     3 O    8    7.966143   14.222136   12.790193      6.00      15.9994
+       6     1 C    6    7.734765   16.557145   12.069222      4.00      12.0107
+       7     2 H    1    7.130790   15.862453   15.339187      1.00       1.0079
+       8     2 H    1    8.737614   16.468567   14.497932      1.00       1.0079
+       9     3 O    8    8.496264   14.451055   14.990319      6.00      15.9994
+      10     3 O    8    8.899322   12.523607   13.901094      6.00      15.9994
+      11     2 H    1    7.514778   17.615787   12.389690      1.00       1.0079
+      12     2 H    1    8.850553   16.479587   11.921136      1.00       1.0079
+      13     2 H    1    7.059051   16.153899   11.247693      1.00       1.0079
+
+
+
+
+ SCF PARAMETERS         Density guess:                                   RESTART
+                        --------------------------------------------------------
+                        max_scf:                                              50
+                        max_scf_history:                                       0
+                        max_diis:                                              4
+                        --------------------------------------------------------
+                        eps_scf:                                        1.00E-06
+                        eps_scf_history:                                0.00E+00
+                        eps_diis:                                       1.00E-01
+                        eps_eigval:                                     1.00E-05
+                        --------------------------------------------------------
+                        level_shift [a.u.]:                                 0.00
+                        --------------------------------------------------------
+                        Outer loop SCF in use 
+                        No variables optimised in outer loop
+                        eps_scf                                         1.00E-06
+                        max_scf                                               10
+                        No outer loop optimization
+                        step_size                                       3.00E-02
+
+ PW_GRID| Information for grid number                                          1
+ PW_GRID| Grid distributed over                                    28 processors
+ PW_GRID| Real space group dimensions                                    28    1
+ PW_GRID| the grid is blocked:                                                NO
+ PW_GRID| Cutoff [a.u.]                                                    250.0
+ PW_GRID| spherical cutoff:                                                   NO
+ PW_GRID|   Bounds   1           -112     112                Points:         225
+ PW_GRID|   Bounds   2           -112     112                Points:         225
+ PW_GRID|   Bounds   3           -112     112                Points:         225
+ PW_GRID| Volume element (a.u.^3)  0.2666E-02     Volume (a.u.^3)     30363.9949
+ PW_GRID| Grid span                                                    FULLSPACE
+ PW_GRID|   Distribution                         Average         Max         Min
+ PW_GRID|   G-Vectors                           406808.0      407025      406800
+ PW_GRID|   G-Rays                                1808.0        1809        1808
+ PW_GRID|   Real Space Points                   406808.0      455625      405000
+
+ PW_GRID| Information for grid number                                          2
+ PW_GRID| Grid distributed over                                    28 processors
+ PW_GRID| Real space group dimensions                                    28    1
+ PW_GRID| the grid is blocked:                                                NO
+ PW_GRID| Cutoff [a.u.]                                                     83.3
+ PW_GRID| spherical cutoff:                                                   NO
+ PW_GRID|   Bounds   1            -67      67                Points:         135
+ PW_GRID|   Bounds   2            -67      67                Points:         135
+ PW_GRID|   Bounds   3            -67      67                Points:         135
+ PW_GRID| Volume element (a.u.^3)  0.1234E-01     Volume (a.u.^3)     30363.9949
+ PW_GRID| Grid span                                                    FULLSPACE
+ PW_GRID|   Distribution                         Average         Max         Min
+ PW_GRID|   G-Vectors                            87870.5       88020       87750
+ PW_GRID|   G-Rays                                 650.9         652         650
+ PW_GRID|   Real Space Points                    87870.5       91125       72900
+
+ PW_GRID| Information for grid number                                          3
+ PW_GRID| Grid distributed over                                    28 processors
+ PW_GRID| Real space group dimensions                                    28    1
+ PW_GRID| the grid is blocked:                                                NO
+ PW_GRID| Cutoff [a.u.]                                                     27.8
+ PW_GRID| spherical cutoff:                                                   NO
+ PW_GRID|   Bounds   1            -37      37                Points:          75
+ PW_GRID|   Bounds   2            -37      37                Points:          75
+ PW_GRID|   Bounds   3            -37      37                Points:          75
+ PW_GRID| Volume element (a.u.^3)  0.7197E-01     Volume (a.u.^3)     30363.9949
+ PW_GRID| Grid span                                                    FULLSPACE
+ PW_GRID|   Distribution                         Average         Max         Min
+ PW_GRID|   G-Vectors                            15067.0       15150       14850
+ PW_GRID|   G-Rays                                 200.9         202         198
+ PW_GRID|   Real Space Points                    15067.0       16875       11250
+
+ PW_GRID| Information for grid number                                          4
+ PW_GRID| Grid distributed over                                    28 processors
+ PW_GRID| Real space group dimensions                                    28    1
+ PW_GRID| the grid is blocked:                                                NO
+ PW_GRID| Cutoff [a.u.]                                                      9.3
+ PW_GRID| spherical cutoff:                                                   NO
+ PW_GRID|   Bounds   1            -22      22                Points:          45
+ PW_GRID|   Bounds   2            -22      22                Points:          45
+ PW_GRID|   Bounds   3            -22      22                Points:          45
+ PW_GRID| Volume element (a.u.^3)  0.3332         Volume (a.u.^3)     30363.9949
+ PW_GRID| Grid span                                                    FULLSPACE
+ PW_GRID|   Distribution                         Average         Max         Min
+ PW_GRID|   G-Vectors                             3254.5        3285        3195
+ PW_GRID|   G-Rays                                  72.3          73          71
+ PW_GRID|   Real Space Points                     3254.5        4050        2025
+
+ POISSON| Solver                                                        PERIODIC
+ POISSON| Periodicity                                                        XYZ
+
+ RS_GRID| Information for grid number                                          1
+ RS_GRID|   Bounds   1           -112     112                Points:         225
+ RS_GRID|   Bounds   2           -112     112                Points:         225
+ RS_GRID|   Bounds   3           -112     112                Points:         225
+ RS_GRID| Real space distribution over                                  4 groups
+ RS_GRID| Real space distribution along direction                              2
+ RS_GRID| Border size                                                         25
+ RS_GRID| Real space distribution over                                  7 groups
+ RS_GRID| Real space distribution along direction                              3
+ RS_GRID| Border size                                                         25
+ RS_GRID|   Distribution                         Average         Max         Min
+ RS_GRID|   Planes                                 106.2         107         106
+ RS_GRID|   Distribution                         Average         Max         Min
+ RS_GRID|   Planes                                  82.1          83          82
+
+ RS_GRID| Information for grid number                                          2
+ RS_GRID|   Bounds   1            -67      67                Points:         135
+ RS_GRID|   Bounds   2            -67      67                Points:         135
+ RS_GRID|   Bounds   3            -67      67                Points:         135
+ RS_GRID| Real space distribution over                                  4 groups
+ RS_GRID| Real space distribution along direction                              2
+ RS_GRID| Border size                                                         28
+ RS_GRID| Real space distribution over                                  7 groups
+ RS_GRID| Real space distribution along direction                              3
+ RS_GRID| Border size                                                         28
+ RS_GRID|   Distribution                         Average         Max         Min
+ RS_GRID|   Planes                                  89.8          90          89
+ RS_GRID|   Distribution                         Average         Max         Min
+ RS_GRID|   Planes                                  75.3          76          75
+
+ RS_GRID| Information for grid number                                          3
+ RS_GRID|   Bounds   1            -37      37                Points:          75
+ RS_GRID|   Bounds   2            -37      37                Points:          75
+ RS_GRID|   Bounds   3            -37      37                Points:          75
+ RS_GRID| Real space fully replicated
+ RS_GRID| Group size                                                           1
+
+ RS_GRID| Information for grid number                                          4
+ RS_GRID|   Bounds   1            -22      22                Points:          45
+ RS_GRID|   Bounds   2            -22      22                Points:          45
+ RS_GRID|   Bounds   3            -22      22                Points:          45
+ RS_GRID| Real space fully replicated
+ RS_GRID| Group size                                                           1
+
+ DISTRIBUTION OF THE PARTICLES (ROWS)
+              Process row      Number of particles         Number of matrix rows
+                        0                        7                            -1
+                        1                        6                            -1
+                      Sum                       13                            -1
+
+ DISTRIBUTION OF THE PARTICLES (COLUMNS)
+              Process col      Number of particles      Number of matrix columns
+                        0                        1                            -1
+                        1                        1                            -1
+                        2                        1                            -1
+                        3                        1                            -1
+                        4                        1                            -1
+                        5                        1                            -1
+                        6                        1                            -1
+                        7                        1                            -1
+                        8                        1                            -1
+                        9                        1                            -1
+                       10                        1                            -1
+                       11                        1                            -1
+                       12                        1                            -1
+                       13                        0                            -1
+                      Sum                       13                            -1
+
+ DISTRIBUTION OF THE NEIGHBOR LISTS
+              Total number of particle pairs:                                261
+              Total number of matrix elements:                             26357
+              Average number of particle pairs:                               10
+              Maximum number of particle pairs:                               25
+              Average number of matrix element:                              942
+              Maximum number of matrix elements:                            3393
+
+
+ DISTRIBUTION OF THE OVERLAP MATRIX
+              Number  of non-zero blocks:                                     91
+              Percentage non-zero blocks:                                 100.00
+              Average number of blocks per CPU:                                4
+              Maximum number of blocks per CPU:                                5
+              Average number of matrix elements per CPU:                     295
+              Maximum number of matrix elements per CPU:                     647
+
+ Number of electrons:                                                         40
+ Number of occupied orbitals:                                                 20
+ Number of molecular orbitals:                                                20
+
+ Number of orbital functions:                                                121
+ Number of independent orbital functions:                                    121
+
+ Extrapolation method: initial_guess
+
+ *** WARNING in qs_initial_guess.F:262 :: User requested to restart the    ***
+ *** wavefunction from the file named: ./Solv_0.37-0.0-RESTART.wfn. This   ***
+ *** file does not exist. Please check the existence of the file or change ***
+ *** properly the value of the keyword WFN_RESTART_FILE_NAME. Calculation  ***
+ *** continues using ATOMIC GUESS.                                         ***
+
+
+ Atomic guess: The first density matrix is obtained in terms of atomic orbitals
+               and electronic configurations assigned to each atomic kind
+
+ Guess for atomic kind: C
+
+ Electronic structure
+    Total number of core electrons                                          2.00
+    Total number of valence electrons                                       4.00
+    Total number of electrons                                               6.00
+    Multiplicity                                                   not specified
+    S   [  2.00] 2.00
+    P      2.00
+ 
+
+ *******************************************************************************
+                  Iteration          Convergence                     Energy [au]
+ *******************************************************************************
+                          1        0.327231                      -5.171846354414
+                          2        0.243406                      -5.237407211855
+                          3        0.585645E-03                  -5.283736081319
+                          4        0.113344E-04                  -5.283736390449
+                          5        0.562146E-05                  -5.283736390525
+                          6        0.373780E-05                  -5.283736390538
+                          7        0.387614E-07                  -5.283736390549
+
+ Energy components [Hartree]           Total Energy ::           -5.283736390549
+                                        Band Energy ::           -1.318690543615
+                                     Kinetic Energy ::            3.419941553466
+                                   Potential Energy ::           -8.703677944015
+                                      Virial (-V/T) ::            2.544978564091
+                                        Core Energy ::           -8.294092137394
+                                          XC Energy ::           -1.376676470246
+                                     Coulomb Energy ::            4.387032217090
+                       Total Pseudopotential Energy ::          -11.748318778537
+                       Local Pseudopotential Energy ::          -12.388386202901
+                    Nonlocal Pseudopotential Energy ::            0.640067424364
+                                        Confinement ::            0.342850876775
+
+ Orbital energies  State     L     Occupation   Energy[a.u.]          Energy[eV]
+
+                       1     0          2.000      -0.483269          -13.150417
+ 
+                       1     1          2.000      -0.176076           -4.791281
+ 
+
+ Total Electron Density at R=0:                                         0.000246
+
+ Guess for atomic kind: H
+
+ Electronic structure
+    Total number of core electrons                                          0.00
+    Total number of valence electrons                                       1.00
+    Total number of electrons                                               1.00
+    Multiplicity                                                   not specified
+    S      1.00
+ 
+
+ *******************************************************************************
+                  Iteration          Convergence                     Energy [au]
+ *******************************************************************************
+                          1        0.146049E-02                  -0.421767924009
+                          2        0.155986E-03                  -0.421770124406
+                          3        0.193312E-07                  -0.421770149791
+
+ Energy components [Hartree]           Total Energy ::           -0.421770149791
+                                        Band Energy ::           -0.187795475903
+                                     Kinetic Energy ::            0.476713143506
+                                   Potential Energy ::           -0.898483293297
+                                      Virial (-V/T) ::            1.884746215910
+                                        Core Energy ::           -0.480212605621
+                                          XC Energy ::           -0.252068122890
+                                     Coulomb Energy ::            0.310510578720
+                       Total Pseudopotential Energy ::           -0.973576798689
+                       Local Pseudopotential Energy ::           -0.973576798689
+                    Nonlocal Pseudopotential Energy ::            0.000000000000
+                                        Confinement ::            0.166510495623
+
+ Orbital energies  State     L     Occupation   Energy[a.u.]          Energy[eV]
+
+                       1     0          1.000      -0.187795           -5.110175
+ 
+
+ Total Electron Density at R=0:                                         0.223082
+
+ Guess for atomic kind: O
+
+ Electronic structure
+    Total number of core electrons                                          2.00
+    Total number of valence electrons                                       6.00
+    Total number of electrons                                               8.00
+    Multiplicity                                                   not specified
+    S   [  2.00] 2.00
+    P      4.00
+ 
+
+ *******************************************************************************
+                  Iteration          Convergence                     Energy [au]
+ *******************************************************************************
+                          1         1.69938                     -14.798518114414
+                          2         2.16886                     -14.874253792865
+                          3        0.907499E-01                 -15.651960249323
+                          4        0.348940E-02                 -15.653277219447
+                          5        0.142526E-02                 -15.653278829294
+                          6        0.884102E-03                 -15.653279027439
+                          7        0.268715E-04                 -15.653279151165
+                          8        0.171415E-06                 -15.653279151285
+
+ Energy components [Hartree]           Total Energy ::          -15.653279151285
+                                        Band Energy ::           -2.985013233435
+                                     Kinetic Energy ::           11.847839736451
+                                   Potential Energy ::          -27.501118887736
+                                      Virial (-V/T) ::            2.321192681492
+                                        Core Energy ::          -26.146913442065
+                                          XC Energy ::           -3.156740274181
+                                     Coulomb Energy ::           13.650374564961
+                       Total Pseudopotential Energy ::          -38.029576734215
+                       Local Pseudopotential Energy ::          -39.318981387664
+                    Nonlocal Pseudopotential Energy ::            1.289404653450
+                                        Confinement ::            0.348235556985
+
+ Orbital energies  State     L     Occupation   Energy[a.u.]          Energy[eV]
+
+                       1     0          2.000      -0.860035          -23.402743
+ 
+                       1     1          4.000      -0.316236           -8.605214
+ 
+
+ Total Electron Density at R=0:                                         0.000665
+ Re-scaling the density matrix to get the right number of electrons
+                  # Electrons              Trace(P)               Scaling factor
+                           40                40.000                        1.000
+
+
+ SCF WAVEFUNCTION OPTIMIZATION
+
+ DBCSR| Multiplication driver                                               BLAS
+ DBCSR| Multrec recursion limit                                              512
+ DBCSR| Multiplication stack size                                           1000
+ DBCSR| Maximum elements for images                                    UNLIMITED
+ DBCSR| Multiplicative factor virtual images                                   1
+ DBCSR| Randmat seed                                                    12341313
+ DBCSR| Multiplication size stacks                                             3
+ DBCSR| Number of 3D layers                                               SINGLE
+ DBCSR| Use MPI memory allocation                                              T
+ DBCSR| Use RMA algorithm                                                      F
+ DBCSR| Use Communication thread                                               T
+ DBCSR| Communication thread load                                             87
+
+
+  **** **** ******  **  PROGRAM STARTED AT               2019-08-10 12:43:41.832
+ ***** ** ***  *** **   PROGRAM STARTED ON                                  c038
+ **    ****   ******    PROGRAM STARTED BY                                 fengw
+ ***** **    ** ** **   PROGRAM PROCESS ID                                 21094
+  **** **  *******  **  PROGRAM STARTED IN /data/fengw/PC-LiTFSI/energy/BLYP/0.3
+                                           7_CBM_VBM/KS/29000/test
+
+ CP2K| version string:                                          CP2K version 4.1
+ CP2K| source code revision number:                                    svn:17462
+ CP2K| cp2kflags: omp libint fftw3 libxc parallel mpi3 scalapack libderiv_max_am
+ CP2K|            1=5 libint_max_am=6
+ CP2K| is freely available from                            https://www.cp2k.org/
+ CP2K| Program compiled at                          Tue May  2 22:33:05 CST 2017
+ CP2K| Program compiled on                                                   mgt
+ CP2K| Program compiled for                                Linux-x86-64-gfortran
+ CP2K| Data directory path                             /share/soft/cp2k-4.1/data
+ CP2K| Input file name                                                 input.inp
+ 
+ GLOBAL| Force Environment number                                              1
+ GLOBAL| Basis set file name                     /data/fengw/data/GTH_BASIS_SETS
+ GLOBAL| Potential file name                     /data/fengw/data/GTH_POTENTIALS
+ GLOBAL| MM Potential file name                                     MM_POTENTIAL
+ GLOBAL| Coordinate file name                                      __STD_INPUT__
+ GLOBAL| Method name                                                        CP2K
+ GLOBAL| Project name                                              Solv_0.37-0.0
+ GLOBAL| Preferred FFT library                                             FFTW3
+ GLOBAL| Preferred diagonalization lib.                                       SL
+ GLOBAL| Run type                                                   ENERGY_FORCE
+ GLOBAL| All-to-all communication in single precision                          F
+ GLOBAL| FFTs using library dependent lengths                                  F
+ GLOBAL| Global print level                                               MEDIUM
+ GLOBAL| Total number of message passing processes                            28
+ GLOBAL| Number of threads for this process                                    1
+ GLOBAL| This output is from process                                           0
+ GLOBAL| CPU model name :  Intel(R) Xeon(R) CPU E5-2680 v4 @ 2.40GHz
+
+ MEMORY| system memory details [Kb]
+ MEMORY|                        rank 0           min           max       average
+ MEMORY| MemTotal             65125420      65125420      65125420      65125420
+ MEMORY| MemFree              44849788      44849788      44849788      44849788
+ MEMORY| Buffers                144020        144020        144020        144020
+ MEMORY| Cached               18013976      18013976      18013976      18013976
+ MEMORY| Slab                   402832        402832        402832        402832
+ MEMORY| SReclaimable           174504        174504        174504        174504
+ MEMORY| MemLikelyFree        63182288      63182288      63182288      63182288
+
+
+ *** Fundamental physical constants (SI units) ***
+
+ *** Literature: B. J. Mohr and B. N. Taylor,
+ ***             CODATA recommended values of the fundamental physical
+ ***             constants: 2006, Web Version 5.1
+ ***             http://physics.nist.gov/constants
+
+ Speed of light in vacuum [m/s]                             2.99792458000000E+08
+ Magnetic constant or permeability of vacuum [N/A**2]       1.25663706143592E-06
+ Electric constant or permittivity of vacuum [F/m]          8.85418781762039E-12
+ Planck constant (h) [J*s]                                  6.62606896000000E-34
+ Planck constant (h-bar) [J*s]                              1.05457162825177E-34
+ Elementary charge [C]                                      1.60217648700000E-19
+ Electron mass [kg]                                         9.10938215000000E-31
+ Electron g factor [ ]                                     -2.00231930436220E+00
+ Proton mass [kg]                                           1.67262163700000E-27
+ Fine-structure constant                                    7.29735253760000E-03
+ Rydberg constant [1/m]                                     1.09737315685270E+07
+ Avogadro constant [1/mol]                                  6.02214179000000E+23
+ Boltzmann constant [J/K]                                   1.38065040000000E-23
+ Atomic mass unit [kg]                                      1.66053878200000E-27
+ Bohr radius [m]                                            5.29177208590000E-11
+
+ *** Conversion factors ***
+
+ [u] -> [a.u.]                                              1.82288848426455E+03
+ [Angstrom] -> [Bohr] = [a.u.]                              1.88972613288564E+00
+ [a.u.] = [Bohr] -> [Angstrom]                              5.29177208590000E-01
+ [a.u.] -> [s]                                              2.41888432650478E-17
+ [a.u.] -> [fs]                                             2.41888432650478E-02
+ [a.u.] -> [J]                                              4.35974393937059E-18
+ [a.u.] -> [N]                                              8.23872205491840E-08
+ [a.u.] -> [K]                                              3.15774647902944E+05
+ [a.u.] -> [kJ/mol]                                         2.62549961709828E+03
+ [a.u.] -> [kcal/mol]                                       6.27509468713739E+02
+ [a.u.] -> [Pa]                                             2.94210107994716E+13
+ [a.u.] -> [bar]                                            2.94210107994716E+08
+ [a.u.] -> [atm]                                            2.90362800883016E+08
+ [a.u.] -> [eV]                                             2.72113838565563E+01
+ [a.u.] -> [Hz]                                             6.57968392072181E+15
+ [a.u.] -> [1/cm] (wave numbers)                            2.19474631370540E+05
+ [a.u./Bohr**2] -> [1/cm]                                   5.14048714338585E+03
+ 
+
+ CELL_TOP| Volume [angstrom^3]:                                         4499.480
+ CELL_TOP| Vector a [angstrom    16.509     0.000     0.000    |a| =      16.509
+ CELL_TOP| Vector b [angstrom     0.000    16.509     0.000    |b| =      16.509
+ CELL_TOP| Vector c [angstrom     0.000     0.000    16.509    |c| =      16.509
+ CELL_TOP| Angle (b,c), alpha [degree]:                                   90.000
+ CELL_TOP| Angle (a,c), beta  [degree]:                                   90.000
+ CELL_TOP| Angle (a,b), gamma [degree]:                                   90.000
+ CELL_TOP| Numerically orthorhombic:                                         YES
+ 
+ GENERATE|  Preliminary Number of Bonds generated:                             0
+ GENERATE|  Achieved consistency in connectivity generation.
+
+ CELL| Volume [angstrom^3]:                                             4499.480
+ CELL| Vector a [angstrom]:      16.509     0.000     0.000    |a| =      16.509
+ CELL| Vector b [angstrom]:       0.000    16.509     0.000    |b| =      16.509
+ CELL| Vector c [angstrom]:       0.000     0.000    16.509    |c| =      16.509
+ CELL| Angle (b,c), alpha [degree]:                                       90.000
+ CELL| Angle (a,c), beta  [degree]:                                       90.000
+ CELL| Angle (a,b), gamma [degree]:                                       90.000
+ CELL| Numerically orthorhombic:                                             YES
+
+ CELL_REF| Volume [angstrom^3]:                                         4499.480
+ CELL_REF| Vector a [angstrom    16.509     0.000     0.000    |a| =      16.509
+ CELL_REF| Vector b [angstrom     0.000    16.509     0.000    |b| =      16.509
+ CELL_REF| Vector c [angstrom     0.000     0.000    16.509    |c| =      16.509
+ CELL_REF| Angle (b,c), alpha [degree]:                                   90.000
+ CELL_REF| Angle (a,c), beta  [degree]:                                   90.000
+ CELL_REF| Angle (a,b), gamma [degree]:                                   90.000
+ CELL_REF| Numerically orthorhombic:                                         YES
+
+ *******************************************************************************
+ *******************************************************************************
+ **                                                                           **
+ **     #####                         ##              ##                      **
+ **    ##   ##            ##          ##              ##                      **
+ **   ##     ##                       ##            ######                    **
+ **   ##     ##  ##   ##  ##   #####  ##  ##   ####   ##    #####    #####    **
+ **   ##     ##  ##   ##  ##  ##      ## ##   ##      ##   ##   ##  ##   ##   **
+ **   ##  ## ##  ##   ##  ##  ##      ####     ###    ##   ######   ######    **
+ **    ##  ###   ##   ##  ##  ##      ## ##      ##   ##   ##       ##        **
+ **     #######   #####   ##   #####  ##  ##  ####    ##    #####   ##        **
+ **           ##                                                    ##        **
+ **                                                                           **
+ **                                                ... make the atoms dance   **
+ **                                                                           **
+ **            Copyright (C) by CP2K developers group (2000 - 2016)           **
+ **                                                                           **
+ *******************************************************************************
+
+ DFT| Spin restricted Kohn-Sham (RKS) calculation                            RKS
+ DFT| Multiplicity                                                             1
+ DFT| Number of spin states                                                    1
+ DFT| Charge                                                                   0
+ DFT| Self-interaction correction (SIC)                                       NO
+ DFT| Cutoffs: density                                              1.000000E-10
+ DFT|          gradient                                             1.000000E-10
+ DFT|          tau                                                  1.000000E-10
+ DFT|          cutoff_smoothing_range                               0.000000E+00
+ DFT| XC density smoothing                                                  NN50
+ DFT| XC derivatives                                                 NN50_SMOOTH
+ FUNCTIONAL| ROUTINE=NEW
+ FUNCTIONAL| BECKE88:
+ FUNCTIONAL| A. Becke, Phys. Rev. A 38, 3098 (1988) {LDA version}               
+ FUNCTIONAL| LYP:
+ FUNCTIONAL| C. Lee, W. Yang, R.G. Parr, Phys. Rev. B, 37, 785 (1988) {LDA versi
+ FUNCTIONAL| on}                                                                
+ vdW POTENTIAL|                                                   Pair Potential
+ vdW POTENTIAL|          DFT-D3 (Version 3.1)
+ vdW POTENTIAL|          Potential Form: S. Grimme et al, JCP 132: 154104 (2010)
+ vdW POTENTIAL|          Zero Damping
+ vdW POTENTIAL|          Cutoff Radius [Bohr]:                             20.00
+ vdW POTENTIAL|          s6 Scaling Factor:                               1.0000
+ vdW POTENTIAL|          sr6 Scaling Factor:                              1.0940
+ vdW POTENTIAL|          s8 Scaling Factor:                               1.6820
+ vdW POTENTIAL|          Cutoff for CN calculation:                   0.1000E-05
+
+ QS| Method:                                                                 GPW
+ QS| Density plane wave grid type                        NON-SPHERICAL FULLSPACE
+ QS| Number of grid levels:                                                    4
+ QS| Density cutoff [a.u.]:                                                250.0
+ QS| Multi grid cutoff [a.u.]: 1) grid level                               250.0
+ QS|                           2) grid level                                83.3
+ QS|                           3) grid level                                27.8
+ QS|                           4) grid level                                 9.3
+ QS| Grid level progression factor:                                          3.0
+ QS| Relative density cutoff [a.u.]:                                        30.0
+ QS| Consistent realspace mapping and integration 
+ QS| Interaction thresholds: eps_pgf_orb:                                1.0E-15
+ QS|                         eps_filter_matrix:                          0.0E+00
+ QS|                         eps_core_charge:                            1.0E-14
+ QS|                         eps_rho_gspace:                             1.0E-12
+ QS|                         eps_rho_rspace:                             1.0E-12
+ QS|                         eps_gvg_rspace:                             1.0E-06
+ QS|                         eps_ppl:                                    1.0E-02
+ QS|                         eps_ppnl:                                   1.0E-08
+
+
+ ATOMIC KIND INFORMATION
+
+  1. Atomic kind: C                                     Number of atoms:       4
+
+     Orbital Basis Set                                                  DZVP-GTH
+
+       Number of orbital shell sets:                                           2
+       Number of orbital shells:                                               5
+       Number of primitive Cartesian functions:                                5
+       Number of Cartesian basis functions:                                   14
+       Number of spherical basis functions:                                   13
+       Norm type:                                                              2
+
+       Normalised Cartesian orbitals:
+
+                        Set   Shell   Orbital            Exponent    Coefficient
+
+                          1       1    2s                4.336238       0.319274
+                                                         1.288184      -0.025219
+                                                         0.403777      -0.248447
+                                                         0.118788      -0.057170
+
+                          1       2    3s                4.336238       0.000000
+                                                         1.288184       0.000000
+                                                         0.403777       0.000000
+                                                         0.118788       0.144208
+
+                          1       3    3px               4.336238      -0.783226
+                                                         1.288184      -0.542954
+                                                         0.403777      -0.216197
+                                                         0.118788      -0.040339
+                          1       3    3py               4.336238      -0.783226
+                                                         1.288184      -0.542954
+                                                         0.403777      -0.216197
+                                                         0.118788      -0.040339
+                          1       3    3pz               4.336238      -0.783226
+                                                         1.288184      -0.542954
+                                                         0.403777      -0.216197
+                                                         0.118788      -0.040339
+
+                          1       4    4px               4.336238       0.000000
+                                                         1.288184       0.000000
+                                                         0.403777       0.000000
+                                                         0.118788       0.099404
+                          1       4    4py               4.336238       0.000000
+                                                         1.288184       0.000000
+                                                         0.403777       0.000000
+                                                         0.118788       0.099404
+                          1       4    4pz               4.336238       0.000000
+                                                         1.288184       0.000000
+                                                         0.403777       0.000000
+                                                         0.118788       0.099404
+
+                          2       1    3dx2              0.550000       0.578155
+                          2       1    3dxy              0.550000       1.001394
+                          2       1    3dxz              0.550000       1.001394
+                          2       1    3dy2              0.550000       0.578155
+                          2       1    3dyz              0.550000       1.001394
+                          2       1    3dz2              0.550000       0.578155
+
+     Potential information for                                       GTH-BLYP-q4
+
+       Description:                       Goedecker-Teter-Hutter pseudopotential
+                                           Goedecker et al., PRB 54, 1703 (1996)
+                                          Hartwigsen et al., PRB 58, 3641 (1998)
+                                                      Krack, TCA 114, 145 (2005)
+
+       Gaussian exponent of the core charge distribution:               4.374886
+       Electronic configuration (s p d ...):                               2   2
+
+       Parameters of the local part of the GTH pseudopotential:
+
+                          rloc        C1          C2          C3          C4
+                        0.338066   -9.136269    1.429260
+
+       Parameters of the non-local part of the GTH pseudopotential:
+
+                   l      r(l)      h(i,j,l)
+
+                   0    0.302322    9.665512
+                   1    0.286379
+
+  2. Atomic kind: H                                     Number of atoms:       6
+
+     Orbital Basis Set                                                  DZVP-GTH
+
+       Number of orbital shell sets:                                           2
+       Number of orbital shells:                                               3
+       Number of primitive Cartesian functions:                                5
+       Number of Cartesian basis functions:                                    5
+       Number of spherical basis functions:                                    5
+       Norm type:                                                              2
+
+       Normalised Cartesian orbitals:
+
+                        Set   Shell   Orbital            Exponent    Coefficient
+
+                          1       1    1s                8.374435      -0.099425
+                                                         1.805868      -0.148088
+                                                         0.485253      -0.165568
+                                                         0.165824      -0.102436
+
+                          1       2    2s                8.374435       0.000000
+                                                         1.805868       0.000000
+                                                         0.485253       0.000000
+                                                         0.165824       0.185202
+
+                          2       1    2px               0.727000       0.956881
+                          2       1    2py               0.727000       0.956881
+                          2       1    2pz               0.727000       0.956881
+
+     Potential information for                                       GTH-BLYP-q1
+
+       Description:                       Goedecker-Teter-Hutter pseudopotential
+                                           Goedecker et al., PRB 54, 1703 (1996)
+                                          Hartwigsen et al., PRB 58, 3641 (1998)
+                                                      Krack, TCA 114, 145 (2005)
+
+       Gaussian exponent of the core charge distribution:              12.500000
+       Electronic configuration (s p d ...):                                   1
+
+       Parameters of the local part of the GTH pseudopotential:
+
+                          rloc        C1          C2          C3          C4
+                        0.200000   -4.195961    0.730498
+
+  3. Atomic kind: O                                     Number of atoms:       3
+
+     Orbital Basis Set                                                  DZVP-GTH
+
+       Number of orbital shell sets:                                           2
+       Number of orbital shells:                                               5
+       Number of primitive Cartesian functions:                                5
+       Number of Cartesian basis functions:                                   14
+       Number of spherical basis functions:                                   13
+       Norm type:                                                              2
+
+       Normalised Cartesian orbitals:
+
+                        Set   Shell   Orbital            Exponent    Coefficient
+
+                          1       1    2s                8.304386       0.526521
+                                                         2.457948      -0.055011
+                                                         0.759737      -0.404341
+                                                         0.213639      -0.086026
+
+                          1       2    3s                8.304386       0.000000
+                                                         2.457948       0.000000
+                                                         0.759737       0.000000
+                                                         0.213639       0.223960
+
+                          1       3    3px               8.304386      -2.000755
+                                                         2.457948      -1.321076
+                                                         0.759737      -0.480332
+                                                         0.213639      -0.078647
+                          1       3    3py               8.304386      -2.000755
+                                                         2.457948      -1.321076
+                                                         0.759737      -0.480332
+                                                         0.213639      -0.078647
+                          1       3    3pz               8.304386      -2.000755
+                                                         2.457948      -1.321076
+                                                         0.759737      -0.480332
+                                                         0.213639      -0.078647
+
+                          1       4    4px               8.304386       0.000000
+                                                         2.457948       0.000000
+                                                         0.759737       0.000000
+                                                         0.213639       0.207033
+                          1       4    4py               8.304386       0.000000
+                                                         2.457948       0.000000
+                                                         0.759737       0.000000
+                                                         0.213639       0.207033
+                          1       4    4pz               8.304386       0.000000
+                                                         2.457948       0.000000
+                                                         0.759737       0.000000
+                                                         0.213639       0.207033
+
+                          2       1    3dx2              1.185000       2.215218
+                          2       1    3dxy              1.185000       3.836871
+                          2       1    3dxz              1.185000       3.836871
+                          2       1    3dy2              1.185000       2.215218
+                          2       1    3dyz              1.185000       3.836871
+                          2       1    3dz2              1.185000       2.215218
+
+     Potential information for                                       GTH-BLYP-q6
+
+       Description:                       Goedecker-Teter-Hutter pseudopotential
+                                           Goedecker et al., PRB 54, 1703 (1996)
+                                          Hartwigsen et al., PRB 58, 3641 (1998)
+                                                      Krack, TCA 114, 145 (2005)
+
+       Gaussian exponent of the core charge distribution:               8.438331
+       Electronic configuration (s p d ...):                               2   4
+
+       Parameters of the local part of the GTH pseudopotential:
+
+                          rloc        C1          C2          C3          C4
+                        0.243420  -16.991892    2.566142
+
+       Parameters of the non-local part of the GTH pseudopotential:
+
+                   l      r(l)      h(i,j,l)
+
+                   0    0.220831   18.388851
+                   1    0.217201
+
+
+ MOLECULE KIND INFORMATION
+
+
+ All atoms are their own molecule, skipping detailed information
+
+
+ TOTAL NUMBERS AND MAXIMUM NUMBERS
+
+  Total number of            - Atomic kinds:                                   3
+                             - Atoms:                                         13
+                             - Shell sets:                                    26
+                             - Shells:                                        53
+                             - Primitive Cartesian functions:                 65
+                             - Cartesian basis functions:                    128
+                             - Spherical basis functions:                    121
+
+  Maximum angular momentum of- Orbital basis functions:                        2
+                             - Local part of the GTH pseudopotential:          2
+                             - Non-local part of the GTH pseudopotential:      0
+
+
+ MODULE QUICKSTEP:  ATOMIC COORDINATES IN angstrom
+
+  Atom  Kind  Element       X           Y           Z          Z(eff)       Mass
+
+       1     1 C    6    8.502557   13.615841   13.959087      4.00      12.0107
+       2     1 C    6    7.337961   15.436979   13.231602      4.00      12.0107
+       3     1 C    6    7.898228   15.711577   14.610790      4.00      12.0107
+       4     2 H    1    6.191067   15.347699   13.085878      1.00       1.0079
+       5     3 O    8    7.966143   14.222136   12.790193      6.00      15.9994
+       6     1 C    6    7.734765   16.557145   12.069222      4.00      12.0107
+       7     2 H    1    7.130790   15.862453   15.339187      1.00       1.0079
+       8     2 H    1    8.737614   16.468567   14.497932      1.00       1.0079
+       9     3 O    8    8.496264   14.451055   14.990319      6.00      15.9994
+      10     3 O    8    8.899322   12.523607   13.901094      6.00      15.9994
+      11     2 H    1    7.514778   17.615787   12.389690      1.00       1.0079
+      12     2 H    1    8.850553   16.479587   11.921136      1.00       1.0079
+      13     2 H    1    7.059051   16.153899   11.247693      1.00       1.0079
+
+
+
+
+ SCF PARAMETERS         Density guess:                                   RESTART
+                        --------------------------------------------------------
+                        max_scf:                                              50
+                        max_scf_history:                                       0
+                        max_diis:                                              4
+                        --------------------------------------------------------
+                        eps_scf:                                        1.00E-06
+                        eps_scf_history:                                0.00E+00
+                        eps_diis:                                       1.00E-01
+                        eps_eigval:                                     1.00E-05
+                        --------------------------------------------------------
+                        level_shift [a.u.]:                                 0.00
+                        --------------------------------------------------------
+                        Outer loop SCF in use 
+                        No variables optimised in outer loop
+                        eps_scf                                         1.00E-06
+                        max_scf                                               10
+                        No outer loop optimization
+                        step_size                                       3.00E-02
+
+ PW_GRID| Information for grid number                                          1
+ PW_GRID| Grid distributed over                                    28 processors
+ PW_GRID| Real space group dimensions                                    28    1
+ PW_GRID| the grid is blocked:                                                NO
+ PW_GRID| Cutoff [a.u.]                                                    250.0
+ PW_GRID| spherical cutoff:                                                   NO
+ PW_GRID|   Bounds   1           -112     112                Points:         225
+ PW_GRID|   Bounds   2           -112     112                Points:         225
+ PW_GRID|   Bounds   3           -112     112                Points:         225
+ PW_GRID| Volume element (a.u.^3)  0.2666E-02     Volume (a.u.^3)     30363.9949
+ PW_GRID| Grid span                                                    FULLSPACE
+ PW_GRID|   Distribution                         Average         Max         Min
+ PW_GRID|   G-Vectors                           406808.0      407025      406800
+ PW_GRID|   G-Rays                                1808.0        1809        1808
+ PW_GRID|   Real Space Points                   406808.0      455625      405000
+
+ PW_GRID| Information for grid number                                          2
+ PW_GRID| Grid distributed over                                    28 processors
+ PW_GRID| Real space group dimensions                                    28    1
+ PW_GRID| the grid is blocked:                                                NO
+ PW_GRID| Cutoff [a.u.]                                                     83.3
+ PW_GRID| spherical cutoff:                                                   NO
+ PW_GRID|   Bounds   1            -67      67                Points:         135
+ PW_GRID|   Bounds   2            -67      67                Points:         135
+ PW_GRID|   Bounds   3            -67      67                Points:         135
+ PW_GRID| Volume element (a.u.^3)  0.1234E-01     Volume (a.u.^3)     30363.9949
+ PW_GRID| Grid span                                                    FULLSPACE
+ PW_GRID|   Distribution                         Average         Max         Min
+ PW_GRID|   G-Vectors                            87870.5       88020       87750
+ PW_GRID|   G-Rays                                 650.9         652         650
+ PW_GRID|   Real Space Points                    87870.5       91125       72900
+
+ PW_GRID| Information for grid number                                          3
+ PW_GRID| Grid distributed over                                    28 processors
+ PW_GRID| Real space group dimensions                                    28    1
+ PW_GRID| the grid is blocked:                                                NO
+ PW_GRID| Cutoff [a.u.]                                                     27.8
+ PW_GRID| spherical cutoff:                                                   NO
+ PW_GRID|   Bounds   1            -37      37                Points:          75
+ PW_GRID|   Bounds   2            -37      37                Points:          75
+ PW_GRID|   Bounds   3            -37      37                Points:          75
+ PW_GRID| Volume element (a.u.^3)  0.7197E-01     Volume (a.u.^3)     30363.9949
+ PW_GRID| Grid span                                                    FULLSPACE
+ PW_GRID|   Distribution                         Average         Max         Min
+ PW_GRID|   G-Vectors                            15067.0       15150       14850
+ PW_GRID|   G-Rays                                 200.9         202         198
+ PW_GRID|   Real Space Points                    15067.0       16875       11250
+
+ PW_GRID| Information for grid number                                          4
+ PW_GRID| Grid distributed over                                    28 processors
+ PW_GRID| Real space group dimensions                                    28    1
+ PW_GRID| the grid is blocked:                                                NO
+ PW_GRID| Cutoff [a.u.]                                                      9.3
+ PW_GRID| spherical cutoff:                                                   NO
+ PW_GRID|   Bounds   1            -22      22                Points:          45
+ PW_GRID|   Bounds   2            -22      22                Points:          45
+ PW_GRID|   Bounds   3            -22      22                Points:          45
+ PW_GRID| Volume element (a.u.^3)  0.3332         Volume (a.u.^3)     30363.9949
+ PW_GRID| Grid span                                                    FULLSPACE
+ PW_GRID|   Distribution                         Average         Max         Min
+ PW_GRID|   G-Vectors                             3254.5        3285        3195
+ PW_GRID|   G-Rays                                  72.3          73          71
+ PW_GRID|   Real Space Points                     3254.5        4050        2025
+
+ POISSON| Solver                                                        PERIODIC
+ POISSON| Periodicity                                                        XYZ
+
+ RS_GRID| Information for grid number                                          1
+ RS_GRID|   Bounds   1           -112     112                Points:         225
+ RS_GRID|   Bounds   2           -112     112                Points:         225
+ RS_GRID|   Bounds   3           -112     112                Points:         225
+ RS_GRID| Real space distribution over                                  4 groups
+ RS_GRID| Real space distribution along direction                              2
+ RS_GRID| Border size                                                         25
+ RS_GRID| Real space distribution over                                  7 groups
+ RS_GRID| Real space distribution along direction                              3
+ RS_GRID| Border size                                                         25
+ RS_GRID|   Distribution                         Average         Max         Min
+ RS_GRID|   Planes                                 106.2         107         106
+ RS_GRID|   Distribution                         Average         Max         Min
+ RS_GRID|   Planes                                  82.1          83          82
+
+ RS_GRID| Information for grid number                                          2
+ RS_GRID|   Bounds   1            -67      67                Points:         135
+ RS_GRID|   Bounds   2            -67      67                Points:         135
+ RS_GRID|   Bounds   3            -67      67                Points:         135
+ RS_GRID| Real space distribution over                                  4 groups
+ RS_GRID| Real space distribution along direction                              2
+ RS_GRID| Border size                                                         28
+ RS_GRID| Real space distribution over                                  7 groups
+ RS_GRID| Real space distribution along direction                              3
+ RS_GRID| Border size                                                         28
+ RS_GRID|   Distribution                         Average         Max         Min
+ RS_GRID|   Planes                                  89.8          90          89
+ RS_GRID|   Distribution                         Average         Max         Min
+ RS_GRID|   Planes                                  75.3          76          75
+
+ RS_GRID| Information for grid number                                          3
+ RS_GRID|   Bounds   1            -37      37                Points:          75
+ RS_GRID|   Bounds   2            -37      37                Points:          75
+ RS_GRID|   Bounds   3            -37      37                Points:          75
+ RS_GRID| Real space fully replicated
+ RS_GRID| Group size                                                           1
+
+ RS_GRID| Information for grid number                                          4
+ RS_GRID|   Bounds   1            -22      22                Points:          45
+ RS_GRID|   Bounds   2            -22      22                Points:          45
+ RS_GRID|   Bounds   3            -22      22                Points:          45
+ RS_GRID| Real space fully replicated
+ RS_GRID| Group size                                                           1
+
+ DISTRIBUTION OF THE PARTICLES (ROWS)
+              Process row      Number of particles         Number of matrix rows
+                        0                        7                            -1
+                        1                        6                            -1
+                      Sum                       13                            -1
+
+ DISTRIBUTION OF THE PARTICLES (COLUMNS)
+              Process col      Number of particles      Number of matrix columns
+                        0                        1                            -1
+                        1                        1                            -1
+                        2                        1                            -1
+                        3                        1                            -1
+                        4                        1                            -1
+                        5                        1                            -1
+                        6                        1                            -1
+                        7                        1                            -1
+                        8                        1                            -1
+                        9                        1                            -1
+                       10                        1                            -1
+                       11                        1                            -1
+                       12                        1                            -1
+                       13                        0                            -1
+                      Sum                       13                            -1
+
+ DISTRIBUTION OF THE NEIGHBOR LISTS
+              Total number of particle pairs:                                261
+              Total number of matrix elements:                             26357
+              Average number of particle pairs:                               10
+              Maximum number of particle pairs:                               25
+              Average number of matrix element:                              942
+              Maximum number of matrix elements:                            3393
+
+
+ DISTRIBUTION OF THE OVERLAP MATRIX
+              Number  of non-zero blocks:                                     91
+              Percentage non-zero blocks:                                 100.00
+              Average number of blocks per CPU:                                4
+              Maximum number of blocks per CPU:                                5
+              Average number of matrix elements per CPU:                     295
+              Maximum number of matrix elements per CPU:                     647
+
+ Number of electrons:                                                         40
+ Number of occupied orbitals:                                                 20
+ Number of molecular orbitals:                                                20
+
+ Number of orbital functions:                                                121
+ Number of independent orbital functions:                                    121
+
+ Extrapolation method: initial_guess
+
+ *** WARNING in qs_initial_guess.F:262 :: User requested to restart the    ***
+ *** wavefunction from the file named: ./Solv_0.37-0.0-RESTART.wfn. This   ***
+ *** file does not exist. Please check the existence of the file or change ***
+ *** properly the value of the keyword WFN_RESTART_FILE_NAME. Calculation  ***
+ *** continues using ATOMIC GUESS.                                         ***
+
+
+ Atomic guess: The first density matrix is obtained in terms of atomic orbitals
+               and electronic configurations assigned to each atomic kind
+
+ Guess for atomic kind: C
+
+ Electronic structure
+    Total number of core electrons                                          2.00
+    Total number of valence electrons                                       4.00
+    Total number of electrons                                               6.00
+    Multiplicity                                                   not specified
+    S   [  2.00] 2.00
+    P      2.00
+ 
+
+ *******************************************************************************
+                  Iteration          Convergence                     Energy [au]
+ *******************************************************************************
+                          1        0.327231                      -5.171846354414
+                          2        0.243406                      -5.237407211855
+                          3        0.585645E-03                  -5.283736081319
+                          4        0.113344E-04                  -5.283736390449
+                          5        0.562146E-05                  -5.283736390525
+                          6        0.373780E-05                  -5.283736390538
+                          7        0.387614E-07                  -5.283736390549
+
+ Energy components [Hartree]           Total Energy ::           -5.283736390549
+                                        Band Energy ::           -1.318690543615
+                                     Kinetic Energy ::            3.419941553466
+                                   Potential Energy ::           -8.703677944015
+                                      Virial (-V/T) ::            2.544978564091
+                                        Core Energy ::           -8.294092137394
+                                          XC Energy ::           -1.376676470246
+                                     Coulomb Energy ::            4.387032217090
+                       Total Pseudopotential Energy ::          -11.748318778537
+                       Local Pseudopotential Energy ::          -12.388386202901
+                    Nonlocal Pseudopotential Energy ::            0.640067424364
+                                        Confinement ::            0.342850876775
+
+ Orbital energies  State     L     Occupation   Energy[a.u.]          Energy[eV]
+
+                       1     0          2.000      -0.483269          -13.150417
+ 
+                       1     1          2.000      -0.176076           -4.791281
+ 
+
+ Total Electron Density at R=0:                                         0.000246
+
+ Guess for atomic kind: H
+
+ Electronic structure
+    Total number of core electrons                                          0.00
+    Total number of valence electrons                                       1.00
+    Total number of electrons                                               1.00
+    Multiplicity                                                   not specified
+    S      1.00
+ 
+
+ *******************************************************************************
+                  Iteration          Convergence                     Energy [au]
+ *******************************************************************************
+                          1        0.146049E-02                  -0.421767924009
+                          2        0.155986E-03                  -0.421770124406
+                          3        0.193312E-07                  -0.421770149791
+
+ Energy components [Hartree]           Total Energy ::           -0.421770149791
+                                        Band Energy ::           -0.187795475903
+                                     Kinetic Energy ::            0.476713143506
+                                   Potential Energy ::           -0.898483293297
+                                      Virial (-V/T) ::            1.884746215910
+                                        Core Energy ::           -0.480212605621
+                                          XC Energy ::           -0.252068122890
+                                     Coulomb Energy ::            0.310510578720
+                       Total Pseudopotential Energy ::           -0.973576798689
+                       Local Pseudopotential Energy ::           -0.973576798689
+                    Nonlocal Pseudopotential Energy ::            0.000000000000
+                                        Confinement ::            0.166510495623
+
+ Orbital energies  State     L     Occupation   Energy[a.u.]          Energy[eV]
+
+                       1     0          1.000      -0.187795           -5.110175
+ 
+
+ Total Electron Density at R=0:                                         0.223082
+
+ Guess for atomic kind: O
+
+ Electronic structure
+    Total number of core electrons                                          2.00
+    Total number of valence electrons                                       6.00
+    Total number of electrons                                               8.00
+    Multiplicity                                                   not specified
+    S   [  2.00] 2.00
+    P      4.00
+ 
+
+ *******************************************************************************
+                  Iteration          Convergence                     Energy [au]
+ *******************************************************************************
+                          1         1.69938                     -14.798518114414
+                          2         2.16886                     -14.874253792865
+                          3        0.907499E-01                 -15.651960249323
+                          4        0.348940E-02                 -15.653277219447
+                          5        0.142526E-02                 -15.653278829294
+                          6        0.884102E-03                 -15.653279027439
+                          7        0.268715E-04                 -15.653279151165
+                          8        0.171415E-06                 -15.653279151285
+
+ Energy components [Hartree]           Total Energy ::          -15.653279151285
+                                        Band Energy ::           -2.985013233435
+                                     Kinetic Energy ::           11.847839736451
+                                   Potential Energy ::          -27.501118887736
+                                      Virial (-V/T) ::            2.321192681492
+                                        Core Energy ::          -26.146913442065
+                                          XC Energy ::           -3.156740274181
+                                     Coulomb Energy ::           13.650374564961
+                       Total Pseudopotential Energy ::          -38.029576734215
+                       Local Pseudopotential Energy ::          -39.318981387664
+                    Nonlocal Pseudopotential Energy ::            1.289404653450
+                                        Confinement ::            0.348235556985
+
+ Orbital energies  State     L     Occupation   Energy[a.u.]          Energy[eV]
+
+                       1     0          2.000      -0.860035          -23.402743
+ 
+                       1     1          4.000      -0.316236           -8.605214
+ 
+
+ Total Electron Density at R=0:                                         0.000665
+ Re-scaling the density matrix to get the right number of electrons
+                  # Electrons              Trace(P)               Scaling factor
+                           40                40.000                        1.000
+
+
+ SCF WAVEFUNCTION OPTIMIZATION
+
+  ----------------------------------- OT ---------------------------------------
+  Minimizer      : DIIS                : direct inversion
+                                         in the iterative subspace
+                                         using   7 DIIS vectors
+                                         safer DIIS on
+  Preconditioner : FULL_SINGLE_INVERSE : inversion of 
+                                         H + eS - 2*(Sc)(c^T*H*c+const)(Sc)^T
+  Precond_solver : DEFAULT
+  stepsize       :    0.08000000                  energy_gap     :    0.10000000
+  eps_taylor     :   0.10000E-15                  max_taylor     :             4
+  ----------------------------------- OT ---------------------------------------
+
+  Step     Update method      Time    Convergence         Total energy    Change
+  ------------------------------------------------------------------------------
+
+  Trace(PS):                                   40.0000000000
+  Electronic density on regular grids:        -40.0000000000        0.0000000000
+  Core density on regular grids:               40.0000000000       -0.0000000000
+  Total charge density on r-space grids:       -0.0000000000
+  Total charge density g-space grids:          -0.0000000000
+
+     1 OT DIIS     0.80E-01    0.6     0.12211697       -69.9227646320 -6.99E+01
+
+  Trace(PS):                                   40.0000000000
+  Electronic density on regular grids:        -40.0000000000        0.0000000000
+  Core density on regular grids:               40.0000000000       -0.0000000000
+  Total charge density on r-space grids:       -0.0000000000
+  Total charge density g-space grids:          -0.0000000000
+
+     2 OT DIIS     0.80E-01    0.8     0.08397991       -71.5488849278 -1.63E+00
+
+  Trace(PS):                                   40.0000000000
+  Electronic density on regular grids:        -40.0000000000        0.0000000000
+  Core density on regular grids:               40.0000000000       -0.0000000000
+  Total charge density on r-space grids:       -0.0000000000
+  Total charge density g-space grids:          -0.0000000000
+
+     3 OT DIIS     0.80E-01    0.8     0.06432705       -72.3568418033 -8.08E-01
+
+  Trace(PS):                                   40.0000000000
+  Electronic density on regular grids:        -40.0000000000        0.0000000000
+  Core density on regular grids:               40.0000000000       -0.0000000000
+  Total charge density on r-space grids:       -0.0000000000
+  Total charge density g-space grids:          -0.0000000000
+
+     4 OT DIIS     0.80E-01    0.8     0.05737364       -73.1900458544 -8.33E-01
+
+  Trace(PS):                                   40.0000000000
+  Electronic density on regular grids:        -40.0000000000        0.0000000000
+  Core density on regular grids:               40.0000000000       -0.0000000000
+  Total charge density on r-space grids:       -0.0000000000
+  Total charge density g-space grids:          -0.0000000000
+
+     5 OT DIIS     0.80E-01    0.8     0.03623630       -73.7413152872 -5.51E-01
+
+  Trace(PS):                                   40.0000000000
+  Electronic density on regular grids:        -40.0000000000        0.0000000000
+  Core density on regular grids:               40.0000000000       -0.0000000000
+  Total charge density on r-space grids:       -0.0000000000
+  Total charge density g-space grids:          -0.0000000000
+
+     6 OT DIIS     0.80E-01    0.8     0.02687733       -73.9835995051 -2.42E-01
+
+  Trace(PS):                                   40.0000000000
+  Electronic density on regular grids:        -40.0000000000        0.0000000000
+  Core density on regular grids:               40.0000000000       -0.0000000000
+  Total charge density on r-space grids:       -0.0000000000
+  Total charge density g-space grids:          -0.0000000000
+
+     7 OT DIIS     0.80E-01    0.8     0.01682164       -74.0451613466 -6.16E-02
+
+  Trace(PS):                                   40.0000000000
+  Electronic density on regular grids:        -40.0000000000        0.0000000000
+  Core density on regular grids:               40.0000000000       -0.0000000000
+  Total charge density on r-space grids:       -0.0000000000
+  Total charge density g-space grids:          -0.0000000000
+
+     8 OT DIIS     0.80E-01    0.8     0.01172379       -74.1060462003 -6.09E-02
+
+  Trace(PS):                                   40.0000000000
+  Electronic density on regular grids:        -40.0000000000        0.0000000000
+  Core density on regular grids:               40.0000000000       -0.0000000000
+  Total charge density on r-space grids:       -0.0000000000
+  Total charge density g-space grids:          -0.0000000000
+
+     9 OT DIIS     0.80E-01    0.9     0.00685204       -74.1347934213 -2.87E-02
+
+  Trace(PS):                                   40.0000000000
+  Electronic density on regular grids:        -40.0000000000        0.0000000000
+  Core density on regular grids:               40.0000000000       -0.0000000000
+  Total charge density on r-space grids:       -0.0000000000
+  Total charge density g-space grids:          -0.0000000000
+
+    10 OT DIIS     0.80E-01    0.8     0.00557939       -74.1452592701 -1.05E-02
+
+  Trace(PS):                                   40.0000000000
+  Electronic density on regular grids:        -40.0000000000        0.0000000000
+  Core density on regular grids:               40.0000000000       -0.0000000000
+  Total charge density on r-space grids:       -0.0000000000
+  Total charge density g-space grids:          -0.0000000000
+
+    11 OT DIIS     0.80E-01    0.8     0.00529907       -74.1545329360 -9.27E-03
+
+  Trace(PS):                                   40.0000000000
+  Electronic density on regular grids:        -40.0000000000        0.0000000000
+  Core density on regular grids:               40.0000000000       -0.0000000000
+  Total charge density on r-space grids:       -0.0000000000
+  Total charge density g-space grids:          -0.0000000000
+
+    12 OT DIIS     0.80E-01    0.8     0.00204013       -74.1583772496 -3.84E-03
+
+  Trace(PS):                                   40.0000000000
+  Electronic density on regular grids:        -40.0000000000        0.0000000000
+  Core density on regular grids:               40.0000000000       -0.0000000000
+  Total charge density on r-space grids:       -0.0000000000
+  Total charge density g-space grids:          -0.0000000000
+
+    13 OT DIIS     0.80E-01    0.8     0.00125361       -74.1604256086 -2.05E-03
+
+  Trace(PS):                                   40.0000000000
+  Electronic density on regular grids:        -40.0000000000        0.0000000000
+  Core density on regular grids:               40.0000000000       -0.0000000000
+  Total charge density on r-space grids:       -0.0000000000
+  Total charge density g-space grids:          -0.0000000000
+
+    14 OT DIIS     0.80E-01    0.8     0.00081727       -74.1611323749 -7.07E-04
+
+  Trace(PS):                                   40.0000000000
+  Electronic density on regular grids:        -40.0000000000        0.0000000000
+  Core density on regular grids:               40.0000000000       -0.0000000000
+  Total charge density on r-space grids:       -0.0000000000
+  Total charge density g-space grids:          -0.0000000000
+
+    15 OT DIIS     0.80E-01    0.8     0.00059499       -74.1614246428 -2.92E-04
+
+  Trace(PS):                                   40.0000000000
+  Electronic density on regular grids:        -40.0000000000        0.0000000000
+  Core density on regular grids:               40.0000000000       -0.0000000000
+  Total charge density on r-space grids:       -0.0000000000
+  Total charge density g-space grids:          -0.0000000000
+
+    16 OT DIIS     0.80E-01    0.8     0.00040833       -74.1616124349 -1.88E-04
+
+  Trace(PS):                                   40.0000000000
+  Electronic density on regular grids:        -40.0000000000        0.0000000000
+  Core density on regular grids:               40.0000000000       -0.0000000000
+  Total charge density on r-space grids:       -0.0000000000
+  Total charge density g-space grids:          -0.0000000000
+
+    17 OT DIIS     0.80E-01    0.8     0.00032383       -74.1616836330 -7.12E-05
+
+  Trace(PS):                                   40.0000000000
+  Electronic density on regular grids:        -40.0000000000        0.0000000000
+  Core density on regular grids:               40.0000000000       -0.0000000000
+  Total charge density on r-space grids:       -0.0000000000
+  Total charge density g-space grids:          -0.0000000000
+
+    18 OT DIIS     0.80E-01    0.8     0.00024259       -74.1617425930 -5.90E-05
+
+  Trace(PS):                                   40.0000000000
+  Electronic density on regular grids:        -40.0000000000        0.0000000000
+  Core density on regular grids:               40.0000000000       -0.0000000000
+  Total charge density on r-space grids:       -0.0000000000
+  Total charge density g-space grids:          -0.0000000000
+
+    19 OT DIIS     0.80E-01    0.8     0.00019028       -74.1617752692 -3.27E-05
+
+  Trace(PS):                                   40.0000000000
+  Electronic density on regular grids:        -40.0000000000        0.0000000000
+  Core density on regular grids:               40.0000000000       -0.0000000000
+  Total charge density on r-space grids:       -0.0000000000
+  Total charge density g-space grids:          -0.0000000000
+
+    20 OT DIIS     0.80E-01    0.8     0.00014769       -74.1617987237 -2.35E-05
+
+  Trace(PS):                                   40.0000000000
+  Electronic density on regular grids:        -40.0000000000        0.0000000000
+  Core density on regular grids:               40.0000000000       -0.0000000000
+  Total charge density on r-space grids:       -0.0000000000
+  Total charge density g-space grids:          -0.0000000000
+
+    21 OT DIIS     0.80E-01    0.8     0.00011570       -74.1618110663 -1.23E-05
+
+  Trace(PS):                                   40.0000000000
+  Electronic density on regular grids:        -40.0000000000        0.0000000000
+  Core density on regular grids:               40.0000000000       -0.0000000000
+  Total charge density on r-space grids:       -0.0000000000
+  Total charge density g-space grids:          -0.0000000000
+
+    22 OT DIIS     0.80E-01    0.8     0.00009372       -74.1618181547 -7.09E-06
+
+  Trace(PS):                                   40.0000000000
+  Electronic density on regular grids:        -40.0000000000        0.0000000000
+  Core density on regular grids:               40.0000000000       -0.0000000000
+  Total charge density on r-space grids:       -0.0000000000
+  Total charge density g-space grids:          -0.0000000000
+
+    23 OT DIIS     0.80E-01    0.8     0.00007276       -74.1618237906 -5.64E-06
+
+  Trace(PS):                                   40.0000000000
+  Electronic density on regular grids:        -40.0000000000        0.0000000000
+  Core density on regular grids:               40.0000000000       -0.0000000000
+  Total charge density on r-space grids:       -0.0000000000
+  Total charge density g-space grids:          -0.0000000000
+
+    24 OT DIIS     0.80E-01    0.8     0.00005773       -74.1618267716 -2.98E-06
+
+  Trace(PS):                                   40.0000000000
+  Electronic density on regular grids:        -40.0000000000        0.0000000000
+  Core density on regular grids:               40.0000000000       -0.0000000000
+  Total charge density on r-space grids:       -0.0000000000
+  Total charge density g-space grids:          -0.0000000000
+
+    25 OT DIIS     0.80E-01    0.8     0.00004629       -74.1618286021 -1.83E-06
+
+  Trace(PS):                                   40.0000000000
+  Electronic density on regular grids:        -40.0000000000        0.0000000000
+  Core density on regular grids:               40.0000000000       -0.0000000000
+  Total charge density on r-space grids:       -0.0000000000
+  Total charge density g-space grids:          -0.0000000000
+
+    26 OT DIIS     0.80E-01    0.8     0.00003663       -74.1618296881 -1.09E-06
+
+  Trace(PS):                                   40.0000000000
+  Electronic density on regular grids:        -40.0000000000        0.0000000000
+  Core density on regular grids:               40.0000000000       -0.0000000000
+  Total charge density on r-space grids:       -0.0000000000
+  Total charge density g-space grids:          -0.0000000000
+
+    27 OT DIIS     0.80E-01    0.8     0.00002919       -74.1618303402 -6.52E-07
+
+  Trace(PS):                                   40.0000000000
+  Electronic density on regular grids:        -40.0000000000        0.0000000000
+  Core density on regular grids:               40.0000000000       -0.0000000000
+  Total charge density on r-space grids:       -0.0000000000
+  Total charge density g-space grids:          -0.0000000000
+
+    28 OT DIIS     0.80E-01    0.8     0.00002316       -74.1618307348 -3.95E-07
+
+  Trace(PS):                                   40.0000000000
+  Electronic density on regular grids:        -40.0000000000        0.0000000000
+  Core density on regular grids:               40.0000000000       -0.0000000000
+  Total charge density on r-space grids:       -0.0000000000
+  Total charge density g-space grids:          -0.0000000000
+
+    29 OT DIIS     0.80E-01    0.8     0.00001912       -74.1618309323 -1.98E-07
+
+  Trace(PS):                                   40.0000000000
+  Electronic density on regular grids:        -40.0000000000        0.0000000000
+  Core density on regular grids:               40.0000000000       -0.0000000000
+  Total charge density on r-space grids:       -0.0000000000
+  Total charge density g-space grids:          -0.0000000000
+
+    30 OT DIIS     0.80E-01    0.8     0.00001585       -74.1618310522 -1.20E-07
+
+  Trace(PS):                                   40.0000000000
+  Electronic density on regular grids:        -40.0000000000        0.0000000000
+  Core density on regular grids:               40.0000000000       -0.0000000000
+  Total charge density on r-space grids:       -0.0000000000
+  Total charge density g-space grids:          -0.0000000000
+
+    31 OT DIIS     0.80E-01    0.8     0.00001283       -74.1618311407 -8.86E-08
+
+  Trace(PS):                                   40.0000000000
+  Electronic density on regular grids:        -40.0000000000        0.0000000000
+  Core density on regular grids:               40.0000000000       -0.0000000000
+  Total charge density on r-space grids:       -0.0000000000
+  Total charge density g-space grids:          -0.0000000000
+
+    32 OT DIIS     0.80E-01    0.8     0.00001054       -74.1618311976 -5.69E-08
+
+  Trace(PS):                                   40.0000000000
+  Electronic density on regular grids:        -40.0000000000        0.0000000000
+  Core density on regular grids:               40.0000000000       -0.0000000000
+  Total charge density on r-space grids:       -0.0000000000
+  Total charge density g-space grids:          -0.0000000000
+
+    33 OT DIIS     0.80E-01    0.8     0.00000864       -74.1618312407 -4.31E-08
+
+  Trace(PS):                                   40.0000000000
+  Electronic density on regular grids:        -40.0000000000        0.0000000000
+  Core density on regular grids:               40.0000000000       -0.0000000000
+  Total charge density on r-space grids:       -0.0000000000
+  Total charge density g-space grids:          -0.0000000000
+
+    34 OT DIIS     0.80E-01    0.8     0.00000720       -74.1618312662 -2.54E-08
+
+  Trace(PS):                                   40.0000000000
+  Electronic density on regular grids:        -40.0000000000        0.0000000000
+  Core density on regular grids:               40.0000000000       -0.0000000000
+  Total charge density on r-space grids:       -0.0000000000
+  Total charge density g-space grids:          -0.0000000000
+
+    35 OT DIIS     0.80E-01    0.8     0.00000603       -74.1618312851 -1.89E-08
+
+  Trace(PS):                                   40.0000000000
+  Electronic density on regular grids:        -40.0000000000        0.0000000000
+  Core density on regular grids:               40.0000000000       -0.0000000000
+  Total charge density on r-space grids:       -0.0000000000
+  Total charge density g-space grids:          -0.0000000000
+
+    36 OT DIIS     0.80E-01    0.8     0.00000510       -74.1618313004 -1.53E-08
+
+  Trace(PS):                                   40.0000000000
+  Electronic density on regular grids:        -40.0000000000        0.0000000000
+  Core density on regular grids:               40.0000000000       -0.0000000000
+  Total charge density on r-space grids:       -0.0000000000
+  Total charge density g-space grids:          -0.0000000000
+
+    37 OT DIIS     0.80E-01    0.8     0.00000446       -74.1618313105 -1.01E-08
+
+  Trace(PS):                                   40.0000000000
+  Electronic density on regular grids:        -40.0000000000        0.0000000000
+  Core density on regular grids:               40.0000000000       -0.0000000000
+  Total charge density on r-space grids:       -0.0000000000
+  Total charge density g-space grids:          -0.0000000000
+
+    38 OT DIIS     0.80E-01    0.8     0.00000385       -74.1618313187 -8.25E-09
+
+  Trace(PS):                                   40.0000000000
+  Electronic density on regular grids:        -40.0000000000        0.0000000000
+  Core density on regular grids:               40.0000000000       -0.0000000000
+  Total charge density on r-space grids:       -0.0000000000
+  Total charge density g-space grids:          -0.0000000000
+
+    39 OT DIIS     0.80E-01    0.8     0.00000332       -74.1618313255 -6.75E-09
+
+  Trace(PS):                                   40.0000000000
+  Electronic density on regular grids:        -40.0000000000        0.0000000000
+  Core density on regular grids:               40.0000000000       -0.0000000000
+  Total charge density on r-space grids:       -0.0000000000
+  Total charge density g-space grids:          -0.0000000000
+
+    40 OT DIIS     0.80E-01    0.8     0.00000288       -74.1618313308 -5.30E-09
+
+  Trace(PS):                                   40.0000000000
+  Electronic density on regular grids:        -40.0000000000        0.0000000000
+  Core density on regular grids:               40.0000000000       -0.0000000000
+  Total charge density on r-space grids:       -0.0000000000
+  Total charge density g-space grids:          -0.0000000000
+
+    41 OT DIIS     0.80E-01    0.8     0.00000245       -74.1618313356 -4.81E-09
+
+  Trace(PS):                                   40.0000000000
+  Electronic density on regular grids:        -40.0000000000        0.0000000000
+  Core density on regular grids:               40.0000000000       -0.0000000000
+  Total charge density on r-space grids:       -0.0000000000
+  Total charge density g-space grids:          -0.0000000000
+
+    42 OT DIIS     0.80E-01    0.8     0.00000212       -74.1618313387 -3.05E-09
+
+  Trace(PS):                                   40.0000000000
+  Electronic density on regular grids:        -40.0000000000        0.0000000000
+  Core density on regular grids:               40.0000000000       -0.0000000000
+  Total charge density on r-space grids:       -0.0000000000
+  Total charge density g-space grids:          -0.0000000000
+
+    43 OT DIIS     0.80E-01    0.8     0.00000178       -74.1618313411 -2.49E-09
+
+  Trace(PS):                                   40.0000000000
+  Electronic density on regular grids:        -40.0000000000        0.0000000000
+  Core density on regular grids:               40.0000000000       -0.0000000000
+  Total charge density on r-space grids:       -0.0000000000
+  Total charge density g-space grids:          -0.0000000000
+
+    44 OT DIIS     0.80E-01    0.8     0.00000148       -74.1618313429 -1.80E-09
+
+  Trace(PS):                                   40.0000000000
+  Electronic density on regular grids:        -40.0000000000        0.0000000000
+  Core density on regular grids:               40.0000000000       -0.0000000000
+  Total charge density on r-space grids:       -0.0000000000
+  Total charge density g-space grids:          -0.0000000000
+
+    45 OT DIIS     0.80E-01    0.8     0.00000124       -74.1618313441 -1.15E-09
+
+  Trace(PS):                                   40.0000000000
+  Electronic density on regular grids:        -40.0000000000        0.0000000000
+  Core density on regular grids:               40.0000000000       -0.0000000000
+  Total charge density on r-space grids:       -0.0000000000
+  Total charge density g-space grids:          -0.0000000000
+
+    46 OT DIIS     0.80E-01    0.9     0.00000101       -74.1618313448 -7.33E-10
+
+  Trace(PS):                                   40.0000000000
+  Electronic density on regular grids:        -40.0000000000        0.0000000000
+  Core density on regular grids:               40.0000000000       -0.0000000000
+  Total charge density on r-space grids:       -0.0000000000
+  Total charge density g-space grids:          -0.0000000000
+
+    47 OT DIIS     0.80E-01    0.8     0.00000081       -74.1618313453 -4.29E-10
+
+  *** SCF run converged in    47 steps ***
+
+
+  Electronic density on regular grids:        -40.0000000000        0.0000000000
+  Core density on regular grids:               40.0000000000       -0.0000000000
+  Total charge density on r-space grids:       -0.0000000000
+  Total charge density g-space grids:          -0.0000000000
+
+  Overlap energy of the core charge distribution:               0.00000242417664
+  Self energy of the core charge distribution:               -187.02580487381152
+  Core Hamiltonian energy:                                     55.54257423380538
+  Hartree energy:                                              76.76711718225495
+  Exchange-correlation energy:                                -19.43594060717809
+  Dispersion energy:                                           -0.00977970450525
+
+  Total energy:                                               -74.16183134525791
+
+  outer SCF iter =    1 RMS gradient =   0.81E-06 energy =        -74.1618313453
+  outer SCF loop converged in   1 iterations or   47 steps
+
+
+ !-----------------------------------------------------------------------------!
+                     Mulliken Population Analysis
+
+ #  Atom  Element  Kind  Atomic population                           Net charge
+       1     C        1          3.984867                              0.015133
+       2     C        1          4.077879                             -0.077879
+       3     C        1          3.913577                              0.086423
+       4     H        2          0.898355                              0.101645
+       5     O        3          6.208620                             -0.208620
+       6     C        1          4.255056                             -0.255056
+       7     H        2          0.878166                              0.121834
+       8     H        2          0.895576                              0.104424
+       9     O        3          6.133234                             -0.133234
+      10     O        3          6.093371                             -0.093371
+      11     H        2          0.894525                              0.105475
+      12     H        2          0.886697                              0.113303
+      13     H        2          0.880075                              0.119925
+ # Total charge                             40.000000                  0.000000
+
+ !-----------------------------------------------------------------------------!
+
+ !-----------------------------------------------------------------------------!
+                           Hirshfeld Charges
+
+  #Atom  Element  Kind  Ref Charge     Population                    Net charge
+      1       C      1       4.000          3.350                         0.650
+      2       C      1       4.000          3.767                         0.233
+      3       C      1       4.000          3.835                         0.165
+      4       H      2       1.000          0.952                         0.048
+      5       O      3       6.000          6.476                        -0.476
+      6       C      1       4.000          4.086                        -0.086
+      7       H      2       1.000          0.909                         0.091
+      8       H      2       1.000          0.929                         0.071
+      9       O      3       6.000          6.428                        -0.428
+     10       O      3       6.000          6.407                        -0.407
+     11       H      2       1.000          0.961                         0.039
+     12       H      2       1.000          0.952                         0.048
+     13       H      2       1.000          0.948                         0.052
+
+  Total Charge                                                            0.000
+ !-----------------------------------------------------------------------------!
+
+  Trace(PS):                                   40.0000000000
+  Electronic density on regular grids:        -40.0000000000        0.0000000000
+  Core density on regular grids:               40.0000000000       -0.0000000000
+  Total charge density on r-space grids:       -0.0000000000
+  Total charge density g-space grids:          -0.0000000000
+
+
+ ENERGY| Total FORCE_EVAL ( QS ) energy (a.u.):              -74.161831345521179
+
+
+ ATOMIC FORCES in [a.u.]
+
+ # Atom   Kind   Element          X              Y              Z
+      1      1      C          -0.02543205     0.04647274    -0.04576210
+      2      1      C          -0.02384518     0.04070368    -0.06382020
+      3      1      C           0.02413716     0.00267013    -0.01594700
+      4      2      H           0.02331229    -0.00303660     0.01752014
+      5      3      O          -0.00330258    -0.00031879     0.01926047
+      6      1      C          -0.01124607    -0.02554273     0.02814433
+      7      2      H          -0.01321314     0.01947427     0.01821504
+      8      2      H          -0.01528903    -0.00477150     0.01334457
+      9      3      O           0.00705728     0.00564402     0.03059922
+     10      3      O           0.03607999    -0.08625169     0.01012960
+     11      2      H          -0.00531559    -0.01159595    -0.00486571
+     12      2      H          -0.01370828    -0.00250871    -0.00716084
+     13      2      H           0.02104090     0.01869862     0.00050029
+ SUM OF ATOMIC FORCES           0.00027571    -0.00036251     0.00015781     0.00048201
+
+ -------------------------------------------------------------------------------
+ -                                                                             -
+ -                                DBCSR STATISTICS                             -
+ -                                                                             -
+ -------------------------------------------------------------------------------
+ COUNTER                                    TOTAL       BLAS       SMM       ACC
+ flops    5 x   20 x   20                   24000     100.0%      0.0%      0.0%
+ flops   13 x   20 x   20                   72800     100.0%      0.0%      0.0%
+ flops    5 x    5 x   20                 1050000     100.0%      0.0%      0.0%
+ flops    5 x   13 x   20                 2730000     100.0%      0.0%      0.0%
+ flops   13 x    5 x   20                 2730000     100.0%      0.0%      0.0%
+ flops   54 x   20 x    5                 3110400     100.0%      0.0%      0.0%
+ flops    5 x   20 x    5                 3636000     100.0%      0.0%      0.0%
+ flops   67 x   20 x    5                 3859200     100.0%      0.0%      0.0%
+ flops   20 x   20 x    5                 4512000     100.0%      0.0%      0.0%
+ flops   20 x   20 x   20                 6672000     100.0%      0.0%      0.0%
+ flops   54 x   20 x   13                 9434880     100.0%      0.0%      0.0%
+ flops   13 x   13 x   20                 9464000     100.0%      0.0%      0.0%
+ flops   54 x   20 x   20                10108800     100.0%      0.0%      0.0%
+ flops    5 x   20 x   13                11029200     100.0%      0.0%      0.0%
+ flops   13 x   20 x    5                11029200     100.0%      0.0%      0.0%
+ flops   67 x   20 x   13                11706240     100.0%      0.0%      0.0%
+ flops   67 x   20 x   20                12542400     100.0%      0.0%      0.0%
+ flops   20 x   20 x   13                13686400     100.0%      0.0%      0.0%
+ flops   13 x   20 x   13                33455240     100.0%      0.0%      0.0%
+ flops total                       150.852760E+06     100.0%      0.0%      0.0%
+ flops max/rank                     87.058120E+06     100.0%      0.0%      0.0%
+ matmuls inhomo. stacks                         0       0.0%      0.0%      0.0%
+ matmuls total                              26209     100.0%      0.0%      0.0%
+ number of processed stacks                 12233     100.0%      0.0%      0.0%
+ average stack size                                     2.1       0.0       0.0
+ marketing flops                   164.257696E+06
+ -------------------------------------------------------------------------------
+ # multiplications                           1040
+ max memory usage/rank             311.861248E+06
+ # max total images/rank                        7
+ # MPI messages exchanged                 3028480
+ # MPI messages filtered                        0
+ MPI messages size (elements):
+  total size                        60.974020E+06
+  min size                           0.000000E+00
+  max size                           1.340000E+03
+  average size                      20.133539E+00
+ MPI breakdown and total messages size (bytes):
+             size <=      128             2859636                        0
+       128 < size <=     8192              161434                416063336
+      8192 < size <=    32768                7410                 71728800
+     32768 < size <=   131072                   0                        0
+    131072 < size <=  4194304                   0                        0
+   4194304 < size <= 16777216                   0                        0
+  16777216 < size                               0                        0
+ -------------------------------------------------------------------------------
+ Warning: using a non-square number of MPI ranks might lead to poor performance.
+          used ranks: 28
+          suggested : 25 49
+ -------------------------------------------------------------------------------
+ 
+ MEMORY| Estimated peak process memory [MiB]                                 298
+
+ -------------------------------------------------------------------------------
+ ----                             MULTIGRID INFO                            ----
+ -------------------------------------------------------------------------------
+ count for grid        1:         110888          cutoff [a.u.]          250.00
+ count for grid        2:          67832          cutoff [a.u.]           83.33
+ count for grid        3:          38068          cutoff [a.u.]           27.78
+ count for grid        4:           7104          cutoff [a.u.]            9.26
+ total gridlevel count  :         223892
+
+ -------------------------------------------------------------------------------
+ -                                                                             -
+ -                         MESSAGE PASSING PERFORMANCE                         -
+ -                                                                             -
+ -------------------------------------------------------------------------------
+
+ ROUTINE             CALLS  TOT TIME [s]  AVE VOLUME [Bytes]  PERFORMANCE [MB/s]
+ MP_Group                5         0.000
+ MP_Bcast             2370         0.009             120247.            30442.16
+ MP_Allreduce         8751         1.290                181.                1.23
+ MP_Sync                51         0.003
+ MP_Alltoall          4123         1.548            1382531.             3682.81
+ MP_SendRecv           876         0.907             355083.              342.97
+ MP_ISendRecv         5184         0.013              83700.            34235.90
+ MP_Wait            145452         2.740
+ MP_comm_split          47         0.001
+ MP_ISend           230604         0.097              10294.            24486.66
+ MP_IRecv           227748         0.046              10386.            51680.72
+ MP_Recv                27         0.000               1936.             2128.59
+ MP_Memory          153498         0.028
+ -------------------------------------------------------------------------------
+
+
+ -------------------------------------------------------------------------------
+ -                                                                             -
+ -                           R E F E R E N C E S                               -
+ -                                                                             -
+ -------------------------------------------------------------------------------
+ 
+ CP2K version 4.1, the CP2K developers group (2016).
+ CP2K is freely available from https://www.cp2k.org/ .
+
+ Schuett, Ole; Messmer, Peter; Hutter, Juerg; VandeVondele, Joost. 
+ Electronic Structure Calculations on Graphics Processing Units, John Wiley & Sons, Ltd, 173-190 (2016). 
+ GPU-Accelerated Sparse Matrix-Matrix Multiplication for Linear Scaling Density Functional Theory.
+ http://dx.doi.org/10.1002/9781118670712.ch8
+
+
+ Borstnik, U; VandeVondele, J; Weber, V; Hutter, J. 
+ PARALLEL COMPUTING, 40 (5-6), 47-58 (2014). 
+ Sparse matrix multiplication: The distributed block-compressed sparse
+ row library.
+ http://dx.doi.org/10.1016/j.parco.2014.03.012
+
+
+ Hutter, J; Iannuzzi, M; Schiffmann, F; VandeVondele, J. 
+ WILEY INTERDISCIPLINARY REVIEWS-COMPUTATIONAL MOLECULAR SCIENCE, 4 (1), 15-25 (2014). 
+ CP2K: atomistic simulations of condensed matter systems.
+ http://dx.doi.org/10.1002/wcms.1159
+
+
+ Grimme, S; Ehrlich, S; Goerigk, L. 
+ JOURNAL OF COMPUTATIONAL CHEMISTRY, 32, 1456 (2011). 
+ Effect of the damping function in dispersion corrected density functional theory.
+ http://dx.doi.org/10.1002/jcc.21759
+
+
+ Grimme, S; Antony, J; Ehrlich, S; Krieg, H. 
+ JOURNAL OF CHEMICAL PHYSICS, 132 (15), 154104 (2010). 
+ A consistent and accurate ab initio parametrization of density
+ functional dispersion correction (DFT-D) for the 94 elements H-Pu.
+ http://dx.doi.org/10.1063/1.3382344
+
+
+ Krack, M. 
+ THEORETICAL CHEMISTRY ACCOUNTS, 114 (1-3), 145-152 (2005). 
+ Pseudopotentials for H to Kr optimized for gradient-corrected
+ exchange-correlation functionals.
+ http://dx.doi.org/10.1007/s00214-005-0655-y
+
+
+ VandeVondele, J; Krack, M; Mohamed, F; Parrinello, M; Chassaing, T;
+ Hutter, J. COMPUTER PHYSICS COMMUNICATIONS, 167 (2), 103-128 (2005). 
+ QUICKSTEP: Fast and accurate density functional calculations using a
+ mixed Gaussian and plane waves approach.
+ http://dx.doi.org/10.1016/j.cpc.2004.12.014
+
+
+ Frigo, M; Johnson, SG. 
+ PROCEEDINGS OF THE IEEE, 93 (2), 216-231 (2005). 
+ The design and implementation of FFTW3.
+ http://dx.doi.org/10.1109/JPROC.2004.840301
+
+
+ VandeVondele, J; Hutter, J. 
+ JOURNAL OF CHEMICAL PHYSICS, 118 (10), 4365-4369 (2003). 
+ An efficient orbital transformation method for electronic structure
+ calculations.
+ http://dx.doi.org/10.1063/1.1543154
+
+
+ Hartwigsen, C; Goedecker, S; Hutter, J. 
+ PHYSICAL REVIEW B, 58 (7), 3641-3662 (1998). 
+ Relativistic separable dual-space Gaussian pseudopotentials from H to Rn.
+ http://dx.doi.org/10.1103/PhysRevB.58.3641
+
+
+ Lippert, G; Hutter, J; Parrinello, M. 
+ MOLECULAR PHYSICS, 92 (3), 477-487 (1997). 
+ A hybrid Gaussian and plane wave density functional scheme.
+ http://dx.doi.org/10.1080/002689797170220
+
+
+ Goedecker, S; Teter, M; Hutter, J. 
+ PHYSICAL REVIEW B, 54 (3), 1703-1710 (1996). 
+ Separable dual-space Gaussian pseudopotentials.
+ http://dx.doi.org/10.1103/PhysRevB.54.1703
+
+
+ BECKE, AD. PHYSICAL REVIEW A, 38 (6), 3098-3100 (1988). 
+ DENSITY-FUNCTIONAL EXCHANGE-ENERGY APPROXIMATION WITH CORRECT
+ ASYMPTOTIC-BEHAVIOR.
+ http://dx.doi.org/10.1103/PhysRevA.38.3098
+
+
+ LEE, CT; YANG, WT; PARR, RG. 
+ PHYSICAL REVIEW B, 37 (2), 785-789 (1988). 
+ DEVELOPMENT OF THE COLLE-SALVETTI CORRELATION-ENERGY FORMULA INTO A
+ FUNCTIONAL OF THE ELECTRON-DENSITY.
+ http://dx.doi.org/10.1103/PhysRevB.37.785
+
+
+ -------------------------------------------------------------------------------
+ -                                                                             -
+ -                                T I M I N G                                  -
+ -                                                                             -
+ -------------------------------------------------------------------------------
+ SUBROUTINE                       CALLS  ASD         SELF TIME        TOTAL TIME
+                                MAXIMUM       AVERAGE  MAXIMUM  AVERAGE  MAXIMUM
+ CP2K                                 1  1.0    0.019    0.025   39.922   39.924
+ qs_forces                            1  2.0    0.000    0.000   39.637   39.637
+ qs_energies                          1  3.0    0.000    0.000   38.957   38.957
+ scf_env_do_scf                       1  4.0    0.000    0.000   38.327   38.327
+ scf_env_do_scf_inner_loop           47  5.0    0.001    0.005   37.802   37.802
+ rebuild_ks_matrix                   48  6.9    0.000    0.000   23.473   23.482
+ qs_ks_build_kohn_sham_matrix        48  7.9    0.007    0.019   23.473   23.482
+ qs_ks_update_qs_env                 48  6.0    0.001    0.001   22.800   22.809
+ pw_transfer                        577 10.1    0.036    0.046   14.984   16.075
+ fft_wrap_pw1pw2                    481 11.2    0.004    0.005   14.528   15.602
+ fft_wrap_pw1pw2_250                193 11.7    1.131    1.163   13.168   14.450
+ qs_rho_update_rho                   48  6.0    0.000    0.000   13.711   13.711
+ calculate_rho_elec                  48  7.0    0.274    1.101   13.711   13.711
+ fft3d_ps                           481 13.2    7.329    8.819   11.213   12.356
+ density_rs2pw                       48  8.0    0.002    0.003   11.575   12.218
+ sum_up_and_integrate                48  8.9    0.228    0.259   10.386   10.429
+ integrate_v_rspace                  48  9.9    0.141    0.758   10.158   10.205
+ rs_pw_transfer                     388 10.4    0.004    0.005    9.600    9.797
+ potential_pw2rs                     48 10.9    0.021    0.022    9.421    9.433
+ qs_vxc_create                       48  8.9    0.001    0.002    7.730    7.831
+ xc_vxc_pw_create                    48  9.9    0.492    0.555    7.729    7.829
+ pw_nn_compose_r                    384 11.4    4.267    4.305    5.466    5.844
+ xc_rho_set_and_dset_create          48 10.9    0.570    0.626    4.004    4.710
+ rs_pw_transfer_PW2RS_250            50 12.8    1.750    1.811    3.392    3.494
+ mp_waitany                        6464 12.4    2.891    3.200    2.891    3.200
+ rs_pw_transfer_RS2PW_250            50  9.9    1.491    1.642    2.775    2.984
+ mp_alltoall_z22v                   481 15.2    2.139    2.779    2.139    2.779
+ rs_grid_zero                       292 10.0    2.509    2.571    2.509    2.571
+ dbcsr_multiply_generic            1040 11.1    0.024    0.026    1.794    2.384
+ x_to_yz                            240 14.8    1.019    1.087    2.154    2.252
+ yz_to_x                            241 13.6    0.717    0.847    1.720    1.981
+ qs_scf_new_mos                      47  6.0    0.000    0.000    1.844    1.846
+ qs_scf_loop_do_ot                   47  7.0    0.000    0.000    1.844    1.846
+ ot_scf_mini                         47  8.0    0.001    0.001    1.759    1.761
+ rs_pw_transfer_PW2RS_90             48 12.9    0.579    0.614    1.488    1.608
+ mp_sendrecv_dm2                    768 12.4    1.200    1.590    1.200    1.590
+ fft_wrap_pw1pw2_90                  96 12.5    0.080    0.101    1.141    1.498
+ pw_poisson_solve                    48  8.9    0.890    0.904    1.376    1.377
+ mp_sum_d                          2457 10.1    0.852    1.334    0.852    1.334
+ make_m2s                          2080 12.1    0.026    0.026    0.646    1.215
+ pw_scatter_p                       240 13.8    1.113    1.188    1.113    1.188
+ ot_mini                             47  9.0    0.000    0.000    1.171    1.173
+ rs_pw_transfer_RS2PW_90             48 10.0    0.663    0.697    1.130    1.154
+ xc_functional_eval                  96 11.9    0.001    0.001    0.540    1.082
+ qs_ot_get_derivative                47 10.0    0.001    0.001    1.057    1.059
+ make_images                       2080 13.1    0.130    0.140    0.455    1.027
+ pw_gather_p                        241 12.6    0.970    1.016    0.970    1.016
+ multiply_cannon                   1040 12.1    0.137    0.145    0.885    0.972
+ mp_waitall_1                    138988 14.3    0.603    0.825    0.603    0.825
+ qs_ot_get_derivative_diag           46 11.0    0.002    0.002    0.807    0.808
+ -------------------------------------------------------------------------------
+
+ The number of warnings for this run is : 1
+ 
+ -------------------------------------------------------------------------------
+  **** **** ******  **  PROGRAM ENDED AT                 2019-08-10 12:44:21.899
+ ***** ** ***  *** **   PROGRAM RAN ON                                      c038
+ **    ****   ******    PROGRAM RAN BY                                     fengw
+ ***** **    ** ** **   PROGRAM PROCESS ID                                 21094
+  **** **  *******  **  PROGRAM STOPPED IN /data/fengw/PC-LiTFSI/energy/BLYP/0.3
+                                           7_CBM_VBM/KS/29000/test

--- a/tests/cp2k/test.py
+++ b/tests/cp2k/test.py
@@ -1,29 +1,56 @@
-
 import dpdata
 import numpy as np
 
-cp2k_output = dpdata.LabeledSystem('output_40847', fmt = 'cp2k/output')
+
+# simple test for cp2k
+# first case: with force and virial information
+print("first case")
+print("--------------------------------------------------------------")
+cp2k_output = dpdata.LabeledSystem('cp2k_output', fmt = 'cp2k/output')
 print("atom name")
 print(cp2k_output['atom_names'])
 print("atom number")
 print(cp2k_output['atom_numbs'])
 print("atom type")
 print(cp2k_output['atom_types'])
-np.savetxt("ref_type", cp2k_output['atom_types'])
 print("atom cell")
 print(cp2k_output['cells'])
-np.savetxt("ref_cell", cp2k_output['cells'][0])
 print("atom coord")
 print(cp2k_output['coords'])
-np.savetxt("ref_coord", cp2k_output['coords'][0])
 print("energyies")
 print(cp2k_output['energies'])
 print("forces")
 print(cp2k_output['forces'])
-np.savetxt("ref_force", cp2k_output['forces'][0])
 print("virials")
 print(cp2k_output['virials'])
-np.savetxt("ref_virial", cp2k_output['virials'][0])
 # no virial
-#cp2k_output.to_deepmd_raw('dpmd_raw')
-#cp2k_output.to_deepmd_npy('dpmd_npy')
+
+cp2k_output.to_deepmd_raw('dpmd_raw')
+cp2k_output.to_deepmd_npy('dpmd_npy')
+
+# second case: with force and no! virial information
+# double header information is contained, to test robustness of this parser
+print("\n")
+print("\n")
+print("second case")
+print("---------------------------------------------------------------")
+
+cp2k_output = dpdata.LabeledSystem('cp2k_output_2', fmt = 'cp2k/output')
+print("atom name")
+print(cp2k_output['atom_names'])
+print("atom number")
+print(cp2k_output['atom_numbs'])
+print("atom type")
+print(cp2k_output['atom_types'])
+#np.savetxt("ref_type", cp2k_output['atom_types'])
+print("atom cell")
+print(cp2k_output['cells'])
+#np.savetxt("ref_cell", cp2k_output['cells'][0])
+print("atom coord")
+print(cp2k_output['coords'])
+#np.savetxt("ref_coord", cp2k_output['coords'][0])
+print("energyies")
+print(cp2k_output['energies'])
+print("forces")
+print(cp2k_output['forces'])
+


### PR DESCRIPTION
- fix the double cell information read from duplicated header case in cp2k.
- virial information of cp2k is not necessary thus, add the condition for check virial in system.py
- small example of how to use cp2k parser is also placed in `./test/cp2k/test.py`