### PR TITLE
fix outcar read bug

### DIFF
--- a/dpdata/vasp/outcar.py
+++ b/dpdata/vasp/outcar.py
@@ -128,5 +128,5 @@ def analyze_block(lines, ntot, nelm) :
                 tmp_l = lines[jj]
                 info = [float(ss) for ss in tmp_l.split()]
                 coord.append(info[:3])
-                force.append(info[3:])
+                force.append(info[3:6])
     return coord, cell, energy, force, virial, is_converge


### PR DESCRIPTION
Forces are read incorrectly when `FORCE -w/o vdW` tag is output. When appropriate VASP prints this additional tag. The old read system thus read 6 force components for each atom. This failed when `LabeledSystem` tried to convert it to lower triangular
which was in this case multiplying matrices forces=(Nx6) x tranform(3x3)

```
 POSITION                                       TOTAL-FORCE (eV/Angst),                                   FORCE-w/o vdW (eV/Angst)
 --------------------------------------------------------------------------------------------------------
      1.84643     -1.87564     13.81826        -0.056448      0.108946      0.296892        -0.056448      0.053966      0.296892
      0.86824      2.31451      1.69518        -0.003983      0.006375      0.161565        -0.003983      0.006375      0.161565
      ....
```