### PR TITLE
Remove os.mknod in deepmd/{raw.py,comp.py}

### DIFF
--- a/dpdata/deepmd/comp.py
+++ b/dpdata/deepmd/comp.py
@@ -110,5 +110,7 @@ def dump(folder,
     except OSError:
         pass
     if data.get("nopbc", False):
-        os.mknod(os.path.join(folder, "nopbc"))
+        #os.mknod(os.path.join(folder, "nopbc"))
+        with open(os.path.join(folder, "nopbc"), "w") as fw_nopbc:
+            fw_nopbc.write("")
         

--- a/dpdata/deepmd/comp.py
+++ b/dpdata/deepmd/comp.py
@@ -110,7 +110,6 @@ def dump(folder,
     except OSError:
         pass
     if data.get("nopbc", False):
-        #os.mknod(os.path.join(folder, "nopbc"))
         with open(os.path.join(folder, "nopbc"), "w") as fw_nopbc:
-            fw_nopbc.write("")
+            pass
         

--- a/dpdata/deepmd/raw.py
+++ b/dpdata/deepmd/raw.py
@@ -74,5 +74,7 @@ def dump (folder, data) :
     except OSError:
         pass
     if data.get("nopbc", False):
-        os.mknod(os.path.join(folder, "nopbc"))
+        #os.mknod(os.path.join(folder, "nopbc"))
+        with open(os.path.join(folder, "nopbc"), "w") as fw_nopbc:
+            fw_nopbc.write("")
 

--- a/dpdata/deepmd/raw.py
+++ b/dpdata/deepmd/raw.py
@@ -74,7 +74,6 @@ def dump (folder, data) :
     except OSError:
         pass
     if data.get("nopbc", False):
-        #os.mknod(os.path.join(folder, "nopbc"))
         with open(os.path.join(folder, "nopbc"), "w") as fw_nopbc:
-            fw_nopbc.write("")
+            pass
 


### PR DESCRIPTION
os.mknod method is not supported on MacOS and Windows.
See
https://stackoverflow.com/questions/32115715/os-mknod-fails-on-macos

Suggest use "with open" method