### PR TITLE
Fix bug cp2k

### DIFF
--- a/dpdata/cp2k/output.py
+++ b/dpdata/cp2k/output.py
@@ -264,6 +264,7 @@ def get_frames (fname) :
     energy = float(energy) * eV
     energy = np.array(energy)
     energy = energy[np.newaxis]
+    assert(coord.shape==force.shape), print('shape of coord and force not match', coord.shape, force.shape)
     tmp_names, symbol_idx = np.unique(atom_symbol_list, return_index=True)
     atom_types = []
     atom_numbs = []

--- a/dpdata/gaussian/log.py
+++ b/dpdata/gaussian/log.py
@@ -27,7 +27,7 @@ def to_system_data(file_name, md=False):
             elif line.startswith(" Center     Atomic                   Forces (Hartrees/Bohr)"):
                 flag = 1
                 forces = []
-            elif line.startswith("                          Input orientation:") or line.startswith("                         Z-Matrix orientation:"):
+            elif line.startswith("                          Input orientation:") or line.startswith("                         Z-Matrix orientation:") or line.startswith("                         Standard orientation:"):
                 flag = 5
                 coords = []
                 atom_symbols = []


### PR DESCRIPTION
There is a bug for cp2k output, the dpdata package cannot recognize the error when the cp2k output prints the forces multiple times. So I add an Assert to check if the shape of coords match forces. A simple test is attached.
![image](https://user-images.githubusercontent.com/17216757/142573324-08b92185-c5ba-4fa7-b284-de163b29910f.png)
