### PR TITLE
fix cp2k/output format while parsing coord block info

### DIFF
--- a/dpdata/cp2k/output.py
+++ b/dpdata/cp2k/output.py
@@ -316,7 +316,7 @@ def get_frames (fname) :
                 
             # get the coord block info
             if coord_flag :
-                if (idx > coord_idx + 1) :
+                if (idx >= coord_idx + 1) :
                     if (ii == '\n') :
                         coord_flag = False
                     else :


### PR DESCRIPTION
This bug will lose the 1st atom while paring cp2k/output file.  As shown below, the `System` will lose the 1st `C` element.

```
 Atom  Kind  Element       X           Y           Z          Z(eff)       Mass
    1   1 C    6       5.251670    5.585280    0.799416       4.0000     12.0107
    2   2 H    1       1.875820    6.300150    9.933800       1.0000      1.0079
    3   2 H    1       7.538410    8.622640    5.030290       1.0000      1.0079
```

Change-Id: I8776c28ec055cec70299bd282206bdf4e956a7ff