### PR TITLE
add default cells when loading hdf5 data

### DIFF
--- a/dpdata/deepmd/hdf5.py
+++ b/dpdata/deepmd/hdf5.py
@@ -77,6 +77,9 @@ def to_system_data(f: h5py.File,
         
         if len(all_data) > 0 :
             data[dt] = np.concatenate(all_data, axis = 0)
+    if 'cells' not in data:
+        nframes = data['coords'].shape[0]
+        data['cells'] = np.zeros((nframes, 3, 3))
     return data
 
 def dump(f: h5py.File,


### PR DESCRIPTION
dpdata requires cells even in nopbc data.