### PR TITLE
add ML labeling option for vasp ml-aimd OUTCAR

### DIFF
--- a/dpdata/plugins/vasp.py
+++ b/dpdata/plugins/vasp.py
@@ -56,6 +56,11 @@ class VASPOutcarFormat(Format):
     @Format.post("rot_lower_triangular")
     def from_labeled_system(self, file_name, begin=0, step=1, **kwargs):
         data = {}
+        ml = False
+        if kwargs is not None:
+            for key, value in kwargs.items():
+                if key=="ml":
+                    ml = value
         data['atom_names'], \
             data['atom_numbs'], \
             data['atom_types'], \
@@ -64,7 +69,7 @@ class VASPOutcarFormat(Format):
             data['energies'], \
             data['forces'], \
             tmp_virial, \
-            = dpdata.vasp.outcar.get_frames(file_name, begin=begin, step=step)
+            = dpdata.vasp.outcar.get_frames(file_name, begin=begin, step=step,ml=ml)
         if tmp_virial is not None:
             data['virials'] = tmp_virial
         # scale virial to the unit of eV


### PR DESCRIPTION
This PR intends to add labeling option for VASP machine learning force field AIMD, the default setting is the same with the original repo, which selects the first principle calculation among the MD frames as energy, force and viral labels. But one can also add option in the LabeledSystem like
```
LabeledSystem(filename,fmt,ml=True)
```
to use the machine learned energy, force and viral labels.
This option obviously is not as accurate as the default fp labels, but the motivation for adding this option (for me) is mainly to sample the structures rather than use the labeled system as training set. And you only need to change a little bit to realize the function. Also, since the default setting is the same as the original one, there is little worry to use this option in a wrong way.