### PR TITLE
fix reading SQM minimization output

### DIFF
--- a/dpdata/amber/sqm.py
+++ b/dpdata/amber/sqm.py
@@ -25,15 +25,18 @@ def parse_sqm_out(fname):
         for line in f:
             if line.startswith(" Total SCF energy"):
                 energy = float(line.strip().split()[-2])
-                energies.append(energy)
+                energies = [energy]
             elif line.startswith("  Atom    Element       Mulliken Charge"):
                 flag = READ_CHARGE
+                charges = []
             elif line.startswith(" Total Mulliken Charge"):
                 flag = START
             elif line.startswith(" Final Structure"):
                 flag = READ_COORDS_START
+                coords = []
             elif line.startswith("QMMM: Forces on QM atoms"):
                 flag = READ_FORCES
+                forces = []
             elif flag == READ_CHARGE:
                 ls = line.strip().split()
                 atom_symbols.append(ls[-2])
@@ -46,6 +49,9 @@ def parse_sqm_out(fname):
                     flag = START
             elif flag == READ_FORCES:
                 ll = line.strip()
+                if not ll.startswith("QMMM: Atm "):
+                    flag = START
+                    continue
                 forces.append([float(ll[-60:-40]), float(ll[-40:-20]), float(ll[-20:])])
                 if len(forces) == len(charges):
                     flag = START

--- a/tests/amber/sqm_opt.out
+++ b/tests/amber/sqm_opt.out
@@ -1,0 +1,771 @@
+            --------------------------------------------------------
+                             AMBER SQM VERSION 19
+ 
+                                     By
+              Ross C. Walker, Michael F. Crowley, Scott Brozell,
+                         Tim Giese, Andreas W. Goetz,
+                        Tai-Sung Lee and David A. Case
+ 
+            --------------------------------------------------------
+ 
+
+--------------------------------------------------------------------------------
+  QM CALCULATION INFO
+--------------------------------------------------------------------------------
+
+| QMMM: Citation for AMBER QMMM Run:
+| QMMM: R.C. Walker, M.F. Crowley and D.A. Case, J. COMP. CHEM. 29:1019, 2008
+
+| QMMM: DFTB Calculation - Additional citation for AMBER DFTB QMMM Run:
+| QMMM:   Seabra, G.M., Walker, R.C. et al., J. PHYS. CHEM. A., 111, 5655, (2007)
+
+| QMMM: DFTB3 - Additional citation to follow. Implementation by:
+| QMMM:   A.W. Goetz
+| QMMM:
+| QMMM: DFTB3 method citation: 
+| QMMM:   M. Gaus, Q. Cui, M. Elstner, J. CHEM. THEORY COMPUT. 7, 931 (2011)
+| QMMM:
+| QMMM: DFTB3 dispersion correction [D3(BJ)] and halogen correction not available.
+
+| QMMM: Please cite also the appropriate references for the DFTB parameters
+| QMMM: that you are using (see the manual and www.dftb.org).
+
+
+QMMM: SINGLET STATE CALCULATION
+QMMM: RHF CALCULATION, NO. OF DOUBLY OCCUPIED LEVELS =  4
+
+| QMMM: *** SCF convergence criteria ***
+| QMMM: Energy change                :  0.1D-07 kcal/mol
+| QMMM: Error matrix |FP-PF|         :  0.1D+00 au
+| QMMM: Density matrix change        :  0.5D-05
+| QMMM: Maximum number of SCF cycles :     1000
+ DFTB: Number of atom types =    2
+
+ Parameter files:
+     TYP (AT)  TYP (AT)     SK integral FILE
+|  1  1  (C )   1  (C )     /usr/local/amber20/dat/slko/3ob-3-1/C-C.skf
+|  2  1  (C )   2  (H )     /usr/local/amber20/dat/slko/3ob-3-1/C-H.skf
+|  3  2  (H )   1  (C )     /usr/local/amber20/dat/slko/3ob-3-1/H-C.skf
+|  4  2  (H )   2  (H )     /usr/local/amber20/dat/slko/3ob-3-1/H-H.skf
+
+QMMM: Hubbard Derivatives dU/dq:
+QMMM:   C    -0.149200
+QMMM:   H    -0.185700
+
+QMMM: zeta =   4.000000
+
+  QMMM: QM Region Cartesian Coordinates (*=link atom) 
+  QMMM: QM_NO.   MM_NO.  ATOM         X         Y         Z
+  QMMM:     1        1      C       -0.0221    0.0032    0.0165
+  QMMM:     2        2      H       -0.6690    0.8894   -0.1009
+  QMMM:     3        3      H       -0.3778   -0.8578   -0.5883
+  QMMM:     4        4      H        0.0964   -0.3151    1.0638
+  QMMM:     5        5      H        0.9725    0.2803   -0.3911
+
+--------------------------------------------------------------------------------
+  RESULTS
+--------------------------------------------------------------------------------
+
+ QMMM SCC-DFTB: No external charges defined.
+
+ QMMM SCC-DFTB: QM Region Input Cartesian Coordinates 
+ QMMM SCC-DFTB:     NO.  TYP  L  AT#  SYM          X                Y                Z             Charge
+ QMMM SCC-DFTB:      1    1   2   6    C      -0.0221000000    0.0032000000    0.0165000000    0.0000000000
+ QMMM SCC-DFTB:      2    2   1   1    H      -0.6690000000    0.8894000000   -0.1009000000    0.0000000000
+ QMMM SCC-DFTB:      3    2   1   1    H      -0.3778000000   -0.8578000000   -0.5883000000    0.0000000000
+ QMMM SCC-DFTB:      4    2   1   1    H       0.0964000000   -0.3151000000    1.0638000000    0.0000000000
+ QMMM SCC-DFTB:      5    2   1   1    H       0.9725000000    0.2803000000   -0.3911000000    0.0000000000
+
+ QMMM SCC-DFTB:  SCC convergence criteria: 
+ QMMM SCC-DFTB:      Energy:   1.0E-08
+ QMMM SCC-DFTB:      Charge:   5.0E-06
+ QMMM SCC-DFTB:      Telec :     0.000K
+ QMMM SCC-DFTB:  It#                    Energy                   Diff              MaxChDiff   At#   Index   Symb   MullikCh
+ QMMM SCC-DFTB:    1        -3.157799880131646
+ QMMM SCC-DFTB:    2        -3.157824613290581     -0.000024733158935      0.298293766328793     1       1   C      -0.37250
+ QMMM SCC-DFTB:    3        -3.158199563935489     -0.000374950644908      0.019934591031811     1       1   C      -0.39847
+ QMMM SCC-DFTB:    4        -3.158238966380289     -0.000039402444800      0.002476750818148     1       1   C      -0.40133
+ QMMM SCC-DFTB:    5        -3.158255573884495     -0.000016607504205      0.004585404872750     1       1   C      -0.40251
+ QMMM SCC-DFTB:    6        -3.158245092771366      0.000010481113129      0.000107585599371     1       1   C      -0.40174
+ QMMM SCC-DFTB:    7        -3.158244836495692      0.000000256275674      0.000002411826609     1       1   C      -0.40172
+ QMMM SCC-DFTB:    8        -3.158244842549473     -0.000000006053781      0.000000199663518     1       1   C      -0.40172
+ QMMM SCC-DFTB: SCC-DFTB for step     0 converged in   8 cycles.
+
+ QMMM SCC-DFTB:
+ QMMM SCC-DFTB:    Atomization Energy (eV)       =     -69.728891832600
+ QMMM SCC-DFTB:    Electronic Energy  (eV)       =     -85.935842165771
+ QMMM SCC-DFTB:    Repulsive Energy   (eV)       =      -1.924790869738
+ QMMM SCC-DFTB:    Total Energy       (eV)       =     -87.860633035509
+ QMMM SCC-DFTB:    SCF Energy         (eV)       =     -18.131741202909
+ QMMM SCC-DFTB:
+ QMMM SCC-DFTB:
+ QMMM SCC-DFTB:    Atomization Energy (a.u.)     =      -2.562620060000
+ QMMM SCC-DFTB:    Electronic Energy  (a.u.)     =      -3.158244842549
+ QMMM SCC-DFTB:    Repulsive Energy   (a.u.)     =      -0.070738363460
+ QMMM SCC-DFTB:    Total Energy       (a.u.)     =      -3.228983206009
+ QMMM SCC-DFTB:    SCF Energy         (a.u.)     =      -0.666363146009
+ QMMM SCC-DFTB:
+QMMM:
+QMMM: SCF Energy =   -418.13608388028837 KCal/mol,   -1749.48137495512651 KJ/mol
+QMMM:
+QMMM:        Electronic energy =       -85.93584217 eV (    -1981.76645618 KCal/mol)
+QMMM:         Repulsive energy =        -1.92479087 eV (      -44.38760225 KCal/mol)
+QMMM:             Total energy =       -87.86063304 eV (    -2026.15405843 KCal/mol)
+QMMM:
+QMMM: Forces on QM atoms from SCF calculation
+QMMM: Atm      1:   -13.74670327739973    3.65547862388900   13.81483034563851
+QMMM: Atm      2:    -4.90340977577246   16.35088467587560   -5.20621249045626
+QMMM: Atm      3:    -1.43273040245665  -17.63544875270559  -11.91662605007330
+QMMM: Atm      4:     4.44538283013336   -7.38377343857182   12.75287244204118
+QMMM: Atm      5:    15.63746062570429    5.01285889151487   -9.44486424761330
+ QMMM SCC-DFTB: No external charges defined.
+
+ QMMM SCC-DFTB: QM Region Input Cartesian Coordinates 
+ QMMM SCC-DFTB:     NO.  TYP  L  AT#  SYM          X                Y                Z             Charge
+ QMMM SCC-DFTB:      1    1   2   6    C      -0.0220999687    0.0031999917    0.0164999685   -0.4017199086
+ QMMM SCC-DFTB:      2    2   1   1    H      -0.6689999888    0.8893999627   -0.1008999881    0.1047408987
+ QMMM SCC-DFTB:      3    2   1   1    H      -0.3777999967   -0.8577999598   -0.5882999728    0.0991061487
+ QMMM SCC-DFTB:      4    2   1   1    H       0.0963999899   -0.3150999832    1.0637999709    0.1043123572
+ QMMM SCC-DFTB:      5    2   1   1    H       0.9724999643    0.2802999886   -0.3910999785    0.0935605041
+
+ QMMM SCC-DFTB:  SCC convergence criteria: 
+ QMMM SCC-DFTB:      Energy:   1.0E-08
+ QMMM SCC-DFTB:      Charge:   5.0E-06
+ QMMM SCC-DFTB:      Telec :     0.000K
+ QMMM SCC-DFTB:  It#                    Energy                   Diff              MaxChDiff   At#   Index   Symb   MullikCh
+ QMMM SCC-DFTB:    1        -3.158244872256237
+ QMMM SCC-DFTB:    2        -3.158244872254534      0.000000000001703      0.000000015122551     4       4   H       0.10431
+ QMMM SCC-DFTB: SCC-DFTB for step     0 converged in   2 cycles.
+
+ QMMM SCC-DFTB:
+ QMMM SCC-DFTB:    Atomization Energy (eV)       =     -69.728891832600
+ QMMM SCC-DFTB:    Electronic Energy  (eV)       =     -85.935842974046
+ QMMM SCC-DFTB:    Repulsive Energy   (eV)       =      -1.924790223407
+ QMMM SCC-DFTB:    Total Energy       (eV)       =     -87.860633197453
+ QMMM SCC-DFTB:    SCF Energy         (eV)       =     -18.131741364853
+ QMMM SCC-DFTB:
+ QMMM SCC-DFTB:
+ QMMM SCC-DFTB:    Atomization Energy (a.u.)     =      -2.562620060000
+ QMMM SCC-DFTB:    Electronic Energy  (a.u.)     =      -3.158244872255
+ QMMM SCC-DFTB:    Repulsive Energy   (a.u.)     =      -0.070738339706
+ QMMM SCC-DFTB:    Total Energy       (a.u.)     =      -3.228983211961
+ QMMM SCC-DFTB:    SCF Energy         (a.u.)     =      -0.666363151961
+ QMMM SCC-DFTB:
+QMMM:
+QMMM: SCF Energy =   -418.13608761487853 KCal/mol,   -1749.48139058065181 KJ/mol
+QMMM:
+QMMM:        Electronic energy =       -85.93584297 eV (    -1981.76647482 KCal/mol)
+QMMM:         Repulsive energy =        -1.92479022 eV (      -44.38758734 KCal/mol)
+QMMM:             Total energy =       -87.86063320 eV (    -2026.15406217 KCal/mol)
+QMMM:
+QMMM: Forces on QM atoms from SCF calculation
+QMMM: Atm      1:   -13.74666278262608    3.65546521339185   13.81478479550825
+QMMM: Atm      2:    -4.90340646058408   16.35087377436513   -5.20620722220688
+QMMM: Atm      3:    -1.43272261896924  -17.63541726762958  -11.91660188136875
+QMMM: Atm      4:     4.44537812583215   -7.38376888783980   12.75286665628583
+QMMM: Atm      5:    15.63741373622763    5.01284716771441   -9.44484234833637
+ QMMM SCC-DFTB: No external charges defined.
+
+ QMMM SCC-DFTB: QM Region Input Cartesian Coordinates 
+ QMMM SCC-DFTB:     NO.  TYP  L  AT#  SYM          X                Y                Z             Charge
+ QMMM SCC-DFTB:      1    1   2   6    C      -0.0221000121    0.0032000084    0.0165000217   -0.4017199009
+ QMMM SCC-DFTB:      2    2   1   1    H      -0.6689999826    0.8893999415   -0.1008999849    0.1047408876
+ QMMM SCC-DFTB:      3    2   1   1    H      -0.3778000082   -0.8577999755   -0.5882999891    0.0991061590
+ QMMM SCC-DFTB:      4    2   1   1    H       0.0963999875   -0.3150999729    1.0637999491    0.1043123380
+ QMMM SCC-DFTB:      5    2   1   1    H       0.9725000154    0.2802999985   -0.3910999967    0.0935605164
+
+ QMMM SCC-DFTB:  SCC convergence criteria: 
+ QMMM SCC-DFTB:      Energy:   1.0E-08
+ QMMM SCC-DFTB:      Charge:   5.0E-06
+ QMMM SCC-DFTB:      Telec :     0.000K
+ QMMM SCC-DFTB:  It#                    Energy                   Diff              MaxChDiff   At#   Index   Symb   MullikCh
+ QMMM SCC-DFTB:    1        -3.158244864097563
+ QMMM SCC-DFTB:    2        -3.158244864091829      0.000000000005735      0.000000028544296     5       5   H       0.09356
+ QMMM SCC-DFTB: SCC-DFTB for step     0 converged in   2 cycles.
+
+ QMMM SCC-DFTB:
+ QMMM SCC-DFTB:    Atomization Energy (eV)       =     -69.728891832600
+ QMMM SCC-DFTB:    Electronic Energy  (eV)       =     -85.935842751939
+ QMMM SCC-DFTB:    Repulsive Energy   (eV)       =      -1.924790352857
+ QMMM SCC-DFTB:    Total Energy       (eV)       =     -87.860633104795
+ QMMM SCC-DFTB:    SCF Energy         (eV)       =     -18.131741272195
+ QMMM SCC-DFTB:
+ QMMM SCC-DFTB:
+ QMMM SCC-DFTB:    Atomization Energy (a.u.)     =      -2.562620060000
+ QMMM SCC-DFTB:    Electronic Energy  (a.u.)     =      -3.158244864092
+ QMMM SCC-DFTB:    Repulsive Energy   (a.u.)     =      -0.070738344464
+ QMMM SCC-DFTB:    Total Energy       (a.u.)     =      -3.228983208556
+ QMMM SCC-DFTB:    SCF Energy         (a.u.)     =      -0.666363148556
+ QMMM SCC-DFTB:
+QMMM:
+QMMM: SCF Energy =   -418.13608547809997 KCal/mol,   -1749.48138164037027 KJ/mol
+QMMM:
+QMMM:        Electronic energy =       -85.93584275 eV (    -1981.76646970 KCal/mol)
+QMMM:         Repulsive energy =        -1.92479035 eV (      -44.38759033 KCal/mol)
+QMMM:             Total energy =       -87.86063310 eV (    -2026.15406003 KCal/mol)
+QMMM:
+QMMM: Forces on QM atoms from SCF calculation
+QMMM: Atm      1:   -13.74674292408972    3.65549549628298   13.81488140458653
+QMMM: Atm      2:    -4.90338368522172   16.35084405392652   -5.20620836094378
+QMMM: Atm      3:    -1.43272964586336  -17.63544295426037  -11.91662475897387
+QMMM: Atm      4:     4.44537778375399   -7.38375816312764   12.75282322394532
+QMMM: Atm      5:    15.63747847251340    5.01286156692956   -9.44487150789251
+ QMMM SCC-DFTB: No external charges defined.
+
+ QMMM SCC-DFTB: QM Region Input Cartesian Coordinates 
+ QMMM SCC-DFTB:     NO.  TYP  L  AT#  SYM          X                Y                Z             Charge
+ QMMM SCC-DFTB:      1    1   2   6    C      -0.0220999770    0.0031999942    0.0164999786   -0.4017198929
+ QMMM SCC-DFTB:      2    2   1   1    H      -0.6690000286    0.8893999644   -0.1008999763    0.1047409081
+ QMMM SCC-DFTB:      3    2   1   1    H      -0.3778000356   -0.8577999896   -0.5883000054    0.0991061407
+ QMMM SCC-DFTB:      4    2   1   1    H       0.0963999854   -0.3150999728    1.0638000028    0.1043123640
+ QMMM SCC-DFTB:      5    2   1   1    H       0.9725000558    0.2803000039   -0.3910999998    0.0935604801
+
+ QMMM SCC-DFTB:  SCC convergence criteria: 
+ QMMM SCC-DFTB:      Energy:   1.0E-08
+ QMMM SCC-DFTB:      Charge:   5.0E-06
+ QMMM SCC-DFTB:      Telec :     0.000K
+ QMMM SCC-DFTB:  It#                    Energy                   Diff              MaxChDiff   At#   Index   Symb   MullikCh
+ QMMM SCC-DFTB:    1        -3.158244838402994
+ QMMM SCC-DFTB:    2        -3.158244838395710      0.000000000007284      0.000000023300674     4       4   H       0.10431
+ QMMM SCC-DFTB: SCC-DFTB for step     0 converged in   2 cycles.
+
+ QMMM SCC-DFTB:
+ QMMM SCC-DFTB:    Atomization Energy (eV)       =     -69.728891832600
+ QMMM SCC-DFTB:    Electronic Energy  (eV)       =     -85.935842052747
+ QMMM SCC-DFTB:    Repulsive Energy   (eV)       =      -1.924790997617
+ QMMM SCC-DFTB:    Total Energy       (eV)       =     -87.860633050364
+ QMMM SCC-DFTB:    SCF Energy         (eV)       =     -18.131741217764
+ QMMM SCC-DFTB:
+ QMMM SCC-DFTB:
+ QMMM SCC-DFTB:    Atomization Energy (a.u.)     =      -2.562620060000
+ QMMM SCC-DFTB:    Electronic Energy  (a.u.)     =      -3.158244838396
+ QMMM SCC-DFTB:    Repulsive Energy   (a.u.)     =      -0.070738368159
+ QMMM SCC-DFTB:    Total Energy       (a.u.)     =      -3.228983206555
+ QMMM SCC-DFTB:    SCF Energy         (a.u.)     =      -0.666363146555
+ QMMM SCC-DFTB:
+QMMM:
+QMMM: SCF Energy =   -418.13608422286637 KCal/mol,   -1749.48137638847288 KJ/mol
+QMMM:
+QMMM:        Electronic energy =       -85.93584205 eV (    -1981.76645358 KCal/mol)
+QMMM:         Repulsive energy =        -1.92479100 eV (      -44.38760520 KCal/mol)
+QMMM:             Total energy =       -87.86063305 eV (    -2026.15405877 KCal/mol)
+QMMM:
+QMMM: Forces on QM atoms from SCF calculation
+QMMM: Atm      1:   -13.74670305475924    3.65547229171135   13.81481909316784
+QMMM: Atm      2:    -4.90341744044170   16.35087993595888   -5.20620701223694
+QMMM: Atm      3:    -1.43273826196118  -17.63544523659553  -11.91662485212175
+QMMM: Atm      4:     4.44537952259198   -7.38376958855279   12.75287923818410
+QMMM: Atm      5:    15.63747923478301    5.01286259730783   -9.44486646623504
+ QMMM SCC-DFTB: No external charges defined.
+
+ QMMM SCC-DFTB: QM Region Input Cartesian Coordinates 
+ QMMM SCC-DFTB:     NO.  TYP  L  AT#  SYM          X                Y                Z             Charge
+ QMMM SCC-DFTB:      1    1   2   6    C      -0.0022758867   -0.0007767586   -0.0007109555   -0.4017198684
+ QMMM SCC-DFTB:      2    2   1   1    H      -0.6673769496    0.8463624077   -0.0844628839    0.1047408826
+ QMMM SCC-DFTB:      3    2   1   1    H      -0.3882629741   -0.8284725465   -0.5733587230    0.0991061497
+ QMMM SCC-DFTB:      4    2   1   1    H       0.0840834583   -0.2923013588    1.0377587851    0.1043123345
+ QMMM SCC-DFTB:      5    2   1   1    H       0.9738324351    0.2751884580   -0.3792280081    0.0935605016
+
+ QMMM SCC-DFTB:  SCC convergence criteria: 
+ QMMM SCC-DFTB:      Energy:   1.0E-08
+ QMMM SCC-DFTB:      Charge:   5.0E-06
+ QMMM SCC-DFTB:      Telec :     0.000K
+ QMMM SCC-DFTB:  It#                    Energy                   Diff              MaxChDiff   At#   Index   Symb   MullikCh
+ QMMM SCC-DFTB:    1        -3.177019277204838
+ QMMM SCC-DFTB:    2        -3.177025052002878     -0.000005774798040      0.010493789293413     1       1   C      -0.41474
+ QMMM SCC-DFTB:    3        -3.177047239463107     -0.000022187460229      0.002204125798446     1       1   C      -0.41618
+ QMMM SCC-DFTB:    4        -3.177053122189775     -0.000005882726668      0.000021626035352     2       2   H       0.10441
+ QMMM SCC-DFTB:    5        -3.177053178549945     -0.000000056360170      0.000001222939759     2       2   H       0.10441
+ QMMM SCC-DFTB:    6        -3.177053178489194      0.000000000060751      0.000000018760599     1       1   C      -0.41657
+ QMMM SCC-DFTB: SCC-DFTB for step     0 converged in   6 cycles.
+
+ QMMM SCC-DFTB:
+ QMMM SCC-DFTB:    Atomization Energy (eV)       =     -69.728891832600
+ QMMM SCC-DFTB:    Electronic Energy  (eV)       =     -86.447616986691
+ QMMM SCC-DFTB:    Repulsive Energy   (eV)       =      -1.471967370268
+ QMMM SCC-DFTB:    Total Energy       (eV)       =     -87.919584356959
+ QMMM SCC-DFTB:    SCF Energy         (eV)       =     -18.190692524359
+ QMMM SCC-DFTB:
+ QMMM SCC-DFTB:
+ QMMM SCC-DFTB:    Atomization Energy (a.u.)     =      -2.562620060000
+ QMMM SCC-DFTB:    Electronic Energy  (a.u.)     =      -3.177053178489
+ QMMM SCC-DFTB:    Repulsive Energy   (a.u.)     =      -0.054096558996
+ QMMM SCC-DFTB:    Total Energy       (a.u.)     =      -3.231149737485
+ QMMM SCC-DFTB:    SCF Energy         (a.u.)     =      -0.668529677485
+ QMMM SCC-DFTB:
+QMMM:
+QMMM: SCF Energy =   -419.49556030423253 KCal/mol,   -1755.16942431290886 KJ/mol
+QMMM:
+QMMM:        Electronic energy =       -86.44761699 eV (    -1993.56849533 KCal/mol)
+QMMM:         Repulsive energy =        -1.47196737 eV (      -33.94503953 KCal/mol)
+QMMM:             Total energy =       -87.91958436 eV (    -2027.51353486 KCal/mol)
+QMMM:
+QMMM: Forces on QM atoms from SCF calculation
+QMMM: Atm      1:    -3.00001738071813   -1.50619543749513   -1.58741102759545
+QMMM: Atm      2:     0.60135963409961    0.36993708543853    0.02617975416810
+QMMM: Atm      3:     1.00751030160294    0.98592419104974    1.13885513088302
+QMMM: Atm      4:     0.13675393072060   -0.51889044079648    1.02882655685741
+QMMM: Atm      5:     1.25439351430015    0.66922460179871   -0.60645041442821
+ QMMM SCC-DFTB: No external charges defined.
+
+ QMMM SCC-DFTB: QM Region Input Cartesian Coordinates 
+ QMMM SCC-DFTB:     NO.  TYP  L  AT#  SYM          X                Y                Z             Charge
+ QMMM SCC-DFTB:      1    1   2   6    C      -0.0022758254   -0.0007767336   -0.0007109343   -0.4165722368
+ QMMM SCC-DFTB:      2    2   1   1    H      -0.6673769737    0.8463623871   -0.0844628744    0.1044109119
+ QMMM SCC-DFTB:      3    2   1   1    H      -0.3882630080   -0.8284725620   -0.5733587476    0.1048882360
+ QMMM SCC-DFTB:      4    2   1   1    H       0.0840834501   -0.2923013382    1.0377587695    0.1038385532
+ QMMM SCC-DFTB:      5    2   1   1    H       0.9738324400    0.2751884484   -0.3792279986    0.1034345357
+
+ QMMM SCC-DFTB:  SCC convergence criteria: 
+ QMMM SCC-DFTB:      Energy:   1.0E-08
+ QMMM SCC-DFTB:      Charge:   5.0E-06
+ QMMM SCC-DFTB:      Telec :     0.000K
+ QMMM SCC-DFTB:  It#                    Energy                   Diff              MaxChDiff   At#   Index   Symb   MullikCh
+ QMMM SCC-DFTB:    1        -3.177053176423371
+ QMMM SCC-DFTB:    2        -3.177053176424210     -0.000000000000839      0.000000021241782     5       5   H       0.10343
+ QMMM SCC-DFTB: SCC-DFTB for step     0 converged in   2 cycles.
+
+ QMMM SCC-DFTB:
+ QMMM SCC-DFTB:    Atomization Energy (eV)       =     -69.728891832600
+ QMMM SCC-DFTB:    Electronic Energy  (eV)       =     -86.447616930503
+ QMMM SCC-DFTB:    Repulsive Energy   (eV)       =      -1.471967444611
+ QMMM SCC-DFTB:    Total Energy       (eV)       =     -87.919584375114
+ QMMM SCC-DFTB:    SCF Energy         (eV)       =     -18.190692542514
+ QMMM SCC-DFTB:
+ QMMM SCC-DFTB:
+ QMMM SCC-DFTB:    Atomization Energy (a.u.)     =      -2.562620060000
+ QMMM SCC-DFTB:    Electronic Energy  (a.u.)     =      -3.177053176424
+ QMMM SCC-DFTB:    Repulsive Energy   (a.u.)     =      -0.054096561728
+ QMMM SCC-DFTB:    Total Energy       (a.u.)     =      -3.231149738152
+ QMMM SCC-DFTB:    SCF Energy         (a.u.)     =      -0.668529678152
+ QMMM SCC-DFTB:
+QMMM:
+QMMM: SCF Energy =   -419.49556072291301 KCal/mol,   -1755.16942606466819 KJ/mol
+QMMM:
+QMMM:        Electronic energy =       -86.44761693 eV (    -1993.56849403 KCal/mol)
+QMMM:         Repulsive energy =        -1.47196744 eV (      -33.94504124 KCal/mol)
+QMMM:             Total energy =       -87.91958438 eV (    -2027.51353527 KCal/mol)
+QMMM:
+QMMM: Forces on QM atoms from SCF calculation
+QMMM: Atm      1:    -2.99993072311282   -1.50614849359069   -1.58736044544401
+QMMM: Atm      2:     0.60134391066191    0.36993942396946    0.02617856069717
+QMMM: Atm      3:     1.00748094020025    0.98587971470655    1.13882119827186
+QMMM: Atm      4:     0.13674581727437   -0.51888280486258    1.02879998530180
+QMMM: Atm      5:     1.25436005443588    0.66921216009831   -0.60643929883291
+ QMMM SCC-DFTB: No external charges defined.
+
+ QMMM SCC-DFTB: QM Region Input Cartesian Coordinates 
+ QMMM SCC-DFTB:     NO.  TYP  L  AT#  SYM          X                Y                Z             Charge
+ QMMM SCC-DFTB:      1    1   2   6    C      -0.0022758759   -0.0007767626   -0.0007109613   -0.4165722380
+ QMMM SCC-DFTB:      2    2   1   1    H      -0.6673769734    0.8463623560   -0.0844628783    0.1044109015
+ QMMM SCC-DFTB:      3    2   1   1    H      -0.3882629907   -0.8284725004   -0.5733587378    0.1048882103
+ QMMM SCC-DFTB:      4    2   1   1    H       0.0840834733   -0.2923013234    1.0377587795    0.1038385635
+ QMMM SCC-DFTB:      5    2   1   1    H       0.9738324498    0.2751884322   -0.3792279874    0.1034345627
+
+ QMMM SCC-DFTB:  SCC convergence criteria: 
+ QMMM SCC-DFTB:      Energy:   1.0E-08
+ QMMM SCC-DFTB:      Charge:   5.0E-06
+ QMMM SCC-DFTB:      Telec :     0.000K
+ QMMM SCC-DFTB:  It#                    Energy                   Diff              MaxChDiff   At#   Index   Symb   MullikCh
+ QMMM SCC-DFTB:    1        -3.177053189902282
+ QMMM SCC-DFTB:    2        -3.177053189906454     -0.000000000004173      0.000000029572285     3       3   H       0.10489
+ QMMM SCC-DFTB: SCC-DFTB for step     0 converged in   2 cycles.
+
+ QMMM SCC-DFTB:
+ QMMM SCC-DFTB:    Atomization Energy (eV)       =     -69.728891832600
+ QMMM SCC-DFTB:    Electronic Energy  (eV)       =     -86.447617297355
+ QMMM SCC-DFTB:    Repulsive Energy   (eV)       =      -1.471967063523
+ QMMM SCC-DFTB:    Total Energy       (eV)       =     -87.919584360878
+ QMMM SCC-DFTB:    SCF Energy         (eV)       =     -18.190692528278
+ QMMM SCC-DFTB:
+ QMMM SCC-DFTB:
+ QMMM SCC-DFTB:    Atomization Energy (a.u.)     =      -2.562620060000
+ QMMM SCC-DFTB:    Electronic Energy  (a.u.)     =      -3.177053189906
+ QMMM SCC-DFTB:    Repulsive Energy   (a.u.)     =      -0.054096547722
+ QMMM SCC-DFTB:    Total Energy       (a.u.)     =      -3.231149737629
+ QMMM SCC-DFTB:    SCF Energy         (a.u.)     =      -0.668529677629
+ QMMM SCC-DFTB:
+QMMM:
+QMMM: SCF Energy =   -419.49556039461277 KCal/mol,   -1755.16942469105993 KJ/mol
+QMMM:
+QMMM:        Electronic energy =       -86.44761730 eV (    -1993.56850249 KCal/mol)
+QMMM:         Repulsive energy =        -1.47196706 eV (      -33.94503245 KCal/mol)
+QMMM:             Total energy =       -87.91958436 eV (    -2027.51353495 KCal/mol)
+QMMM:
+QMMM: Forces on QM atoms from SCF calculation
+QMMM: Atm      1:    -3.00001595789464   -1.50619959497283   -1.58741808638720
+QMMM: Atm      2:     0.60135965944853    0.36992131728738    0.02618177329187
+QMMM: Atm      3:     1.00751092479538    0.98594231266698    1.13885924141731
+QMMM: Atm      4:     0.13675562187275   -0.51888230503968    1.02882105346303
+QMMM: Atm      5:     1.25438975749003    0.66921826988072   -0.60644398225300
+ QMMM SCC-DFTB: No external charges defined.
+
+ QMMM SCC-DFTB: QM Region Input Cartesian Coordinates 
+ QMMM SCC-DFTB:     NO.  TYP  L  AT#  SYM          X                Y                Z             Charge
+ QMMM SCC-DFTB:      1    1   2   6    C      -0.0022759240   -0.0007767665   -0.0007109443   -0.4165722482
+ QMMM SCC-DFTB:      2    2   1   1    H      -0.6673769688    0.8463624208   -0.0844629104    0.1044109120
+ QMMM SCC-DFTB:      3    2   1   1    H      -0.3882629652   -0.8284725266   -0.5733587547    0.1048882478
+ QMMM SCC-DFTB:      4    2   1   1    H       0.0840835104   -0.2923013583    1.0377588146    0.1038385508
+ QMMM SCC-DFTB:      5    2   1   1    H       0.9738324306    0.2751884323   -0.3792279905    0.1034345376
+
+ QMMM SCC-DFTB:  SCC convergence criteria: 
+ QMMM SCC-DFTB:      Energy:   1.0E-08
+ QMMM SCC-DFTB:      Charge:   5.0E-06
+ QMMM SCC-DFTB:      Telec :     0.000K
+ QMMM SCC-DFTB:  It#                    Energy                   Diff              MaxChDiff   At#   Index   Symb   MullikCh
+ QMMM SCC-DFTB:    1        -3.177053171661357
+ QMMM SCC-DFTB:    2        -3.177053171655763      0.000000000005594      0.000000010752099     5       5   H       0.10343
+ QMMM SCC-DFTB: SCC-DFTB for step     0 converged in   2 cycles.
+
+ QMMM SCC-DFTB:
+ QMMM SCC-DFTB:    Atomization Energy (eV)       =     -69.728891832600
+ QMMM SCC-DFTB:    Electronic Energy  (eV)       =     -86.447616800753
+ QMMM SCC-DFTB:    Repulsive Energy   (eV)       =      -1.471967554219
+ QMMM SCC-DFTB:    Total Energy       (eV)       =     -87.919584354973
+ QMMM SCC-DFTB:    SCF Energy         (eV)       =     -18.190692522373
+ QMMM SCC-DFTB:
+ QMMM SCC-DFTB:
+ QMMM SCC-DFTB:    Atomization Energy (a.u.)     =      -2.562620060000
+ QMMM SCC-DFTB:    Electronic Energy  (a.u.)     =      -3.177053171656
+ QMMM SCC-DFTB:    Repulsive Energy   (a.u.)     =      -0.054096565756
+ QMMM SCC-DFTB:    Total Energy       (a.u.)     =      -3.231149737412
+ QMMM SCC-DFTB:    SCF Energy         (a.u.)     =      -0.668529677412
+ QMMM SCC-DFTB:
+QMMM:
+QMMM: SCF Energy =   -419.49556025843816 KCal/mol,   -1755.16942412130538 KJ/mol
+QMMM:
+QMMM:        Electronic energy =       -86.44761680 eV (    -1993.56849104 KCal/mol)
+QMMM:         Repulsive energy =        -1.47196755 eV (      -33.94504377 KCal/mol)
+QMMM:             Total energy =       -87.91958435 eV (    -2027.51353481 KCal/mol)
+QMMM:
+QMMM: Forces on QM atoms from SCF calculation
+QMMM: Atm      1:    -3.00004968153394   -1.50620963619432   -1.58741778817088
+QMMM: Atm      2:     0.60135657004798    0.36994265717245    0.02617394714159
+QMMM: Atm      3:     1.00751788058786    0.98593536590786    1.13885373849680
+QMMM: Atm      4:     0.13676701341870   -0.51889254828514    1.02884259812090
+QMMM: Atm      5:     1.25440821726414    0.66922416139912   -0.60645249570357
+ QMMM SCC-DFTB: No external charges defined.
+
+ QMMM SCC-DFTB: QM Region Input Cartesian Coordinates 
+ QMMM SCC-DFTB:     NO.  TYP  L  AT#  SYM          X                Y                Z             Charge
+ QMMM SCC-DFTB:      1    1   2   6    C       0.0000038338   -0.0000741137   -0.0000915666   -0.4165722357
+ QMMM SCC-DFTB:      2    2   1   1    H      -0.6690925881    0.8440618468   -0.0841048801    0.1044109150
+ QMMM SCC-DFTB:      3    2   1   1    H      -0.3899330263   -0.8274220054   -0.5748810102    0.1048882424
+ QMMM SCC-DFTB:      4    2   1   1    H       0.0845718862   -0.2904408216    1.0372016233    0.1038385542
+ QMMM SCC-DFTB:      5    2   1   1    H       0.9744495465    0.2738752702   -0.3781262149    0.1034345240
+
+ QMMM SCC-DFTB:  SCC convergence criteria: 
+ QMMM SCC-DFTB:      Energy:   1.0E-08
+ QMMM SCC-DFTB:      Charge:   5.0E-06
+ QMMM SCC-DFTB:      Telec :     0.000K
+ QMMM SCC-DFTB:  It#                    Energy                   Diff              MaxChDiff   At#   Index   Symb   MullikCh
+ QMMM SCC-DFTB:    1        -3.177297107065937
+ QMMM SCC-DFTB:    2        -3.177297189242046     -0.000000082176109      0.000714476993429     5       5   H       0.10434
+ QMMM SCC-DFTB:    3        -3.177297448974965     -0.000000259732919      0.000050374225117     1       1   C      -0.41677
+ QMMM SCC-DFTB:    4        -3.177297583444879     -0.000000134469914      0.000000664777074     1       1   C      -0.41678
+ QMMM SCC-DFTB:    5        -3.177297585243204     -0.000000001798325      0.000000010687417     4       4   H       0.10417
+ QMMM SCC-DFTB: SCC-DFTB for step     0 converged in   5 cycles.
+
+ QMMM SCC-DFTB:
+ QMMM SCC-DFTB:    Atomization Energy (eV)       =     -69.728891832600
+ QMMM SCC-DFTB:    Electronic Energy  (eV)       =     -86.454267294468
+ QMMM SCC-DFTB:    Repulsive Energy   (eV)       =      -1.465661705715
+ QMMM SCC-DFTB:    Total Energy       (eV)       =     -87.919929000182
+ QMMM SCC-DFTB:    SCF Energy         (eV)       =     -18.191037167582
+ QMMM SCC-DFTB:
+ QMMM SCC-DFTB:
+ QMMM SCC-DFTB:    Atomization Energy (a.u.)     =      -2.562620060000
+ QMMM SCC-DFTB:    Electronic Energy  (a.u.)     =      -3.177297585243
+ QMMM SCC-DFTB:    Repulsive Energy   (a.u.)     =      -0.053864818292
+ QMMM SCC-DFTB:    Total Energy       (a.u.)     =      -3.231162403535
+ QMMM SCC-DFTB:    SCF Energy         (a.u.)     =      -0.668542343535
+ QMMM SCC-DFTB:
+QMMM:
+QMMM: SCF Energy =   -419.50350812161315 KCal/mol,   -1755.20267798082955 KJ/mol
+QMMM:
+QMMM:        Electronic energy =       -86.45426729 eV (    -1993.72185808 KCal/mol)
+QMMM:         Repulsive energy =        -1.46566171 eV (      -33.79962460 KCal/mol)
+QMMM:             Total energy =       -87.91992900 eV (    -2027.52148267 KCal/mol)
+QMMM:
+QMMM: Forces on QM atoms from SCF calculation
+QMMM: Atm      1:    -0.08397438585120   -0.11992372445546   -0.11648100404662
+QMMM: Atm      2:     0.02413338666108   -0.01213651509183    0.01920691201260
+QMMM: Atm      3:     0.04594261530503    0.10271287370538    0.09299635501682
+QMMM: Atm      4:    -0.02000842001580   -0.00089167325386    0.01917324403620
+QMMM: Atm      5:     0.03390680653361    0.03023903909095   -0.01489550500940
+ QMMM SCC-DFTB: No external charges defined.
+
+ QMMM SCC-DFTB: QM Region Input Cartesian Coordinates 
+ QMMM SCC-DFTB:     NO.  TYP  L  AT#  SYM          X                Y                Z             Charge
+ QMMM SCC-DFTB:      1    1   2   6    C       0.0000038243   -0.0000740764   -0.0000915287   -0.4167784643
+ QMMM SCC-DFTB:      2    2   1   1    H      -0.6690926075    0.8440618473   -0.0841048975    0.1041805592
+ QMMM SCC-DFTB:      3    2   1   1    H      -0.3899330395   -0.8274220238   -0.5748810590    0.1042383015
+ QMMM SCC-DFTB:      4    2   1   1    H       0.0845719235   -0.2904408174    1.0372016385    0.1041707783
+ QMMM SCC-DFTB:      5    2   1   1    H       0.9744495513    0.2738752466   -0.3781262018    0.1041888253
+
+ QMMM SCC-DFTB:  SCC convergence criteria: 
+ QMMM SCC-DFTB:      Energy:   1.0E-08
+ QMMM SCC-DFTB:      Charge:   5.0E-06
+ QMMM SCC-DFTB:      Telec :     0.000K
+ QMMM SCC-DFTB:  It#                    Energy                   Diff              MaxChDiff   At#   Index   Symb   MullikCh
+ QMMM SCC-DFTB:    1        -3.177297572848879
+ QMMM SCC-DFTB:    2        -3.177297572844566      0.000000000004313      0.000000020485338     3       3   H       0.10424
+ QMMM SCC-DFTB: SCC-DFTB for step     0 converged in   2 cycles.
+
+ QMMM SCC-DFTB:
+ QMMM SCC-DFTB:    Atomization Energy (eV)       =     -69.728891832600
+ QMMM SCC-DFTB:    Electronic Energy  (eV)       =     -86.454266957101
+ QMMM SCC-DFTB:    Repulsive Energy   (eV)       =      -1.465662044402
+ QMMM SCC-DFTB:    Total Energy       (eV)       =     -87.919929001502
+ QMMM SCC-DFTB:    SCF Energy         (eV)       =     -18.191037168902
+ QMMM SCC-DFTB:
+ QMMM SCC-DFTB:
+ QMMM SCC-DFTB:    Atomization Energy (a.u.)     =      -2.562620060000
+ QMMM SCC-DFTB:    Electronic Energy  (a.u.)     =      -3.177297572845
+ QMMM SCC-DFTB:    Repulsive Energy   (a.u.)     =      -0.053864830739
+ QMMM SCC-DFTB:    Total Energy       (a.u.)     =      -3.231162403583
+ QMMM SCC-DFTB:    SCF Energy         (a.u.)     =      -0.668542343583
+ QMMM SCC-DFTB:
+QMMM:
+QMMM: SCF Energy =   -419.50350815205553 KCal/mol,   -1755.20267810820042 KJ/mol
+QMMM:
+QMMM:        Electronic energy =       -86.45426696 eV (    -1993.72185030 KCal/mol)
+QMMM:         Repulsive energy =        -1.46566204 eV (      -33.79963241 KCal/mol)
+QMMM:             Total energy =       -87.91992900 eV (    -2027.52148270 KCal/mol)
+QMMM:
+QMMM: Forces on QM atoms from SCF calculation
+QMMM: Atm      1:    -0.08396941860273   -0.11985835095379   -0.11642882888525
+QMMM: Atm      2:     0.02413760202554   -0.01214907360599    0.01920165485925
+QMMM: Atm      3:     0.04592229065449    0.10266729765707    0.09295742713355
+QMMM: Atm      4:    -0.02000172847949   -0.00089224660803    0.01916687245340
+QMMM: Atm      5:     0.03391125450313    0.03023237989853   -0.01489712556091
+ QMMM SCC-DFTB: No external charges defined.
+
+ QMMM SCC-DFTB: QM Region Input Cartesian Coordinates 
+ QMMM SCC-DFTB:     NO.  TYP  L  AT#  SYM          X                Y                Z             Charge
+ QMMM SCC-DFTB:      1    1   2   6    C       0.0000038614   -0.0000741309   -0.0000915578   -0.4167784546
+ QMMM SCC-DFTB:      2    2   1   1    H      -0.6690926261    0.8440618880   -0.0841049009    0.1041805702
+ QMMM SCC-DFTB:      3    2   1   1    H      -0.3899330240   -0.8274220040   -0.5748810378    0.1042382755
+ QMMM SCC-DFTB:      4    2   1   1    H       0.0845719215   -0.2904408219    1.0372016410    0.1041707902
+ QMMM SCC-DFTB:      5    2   1   1    H       0.9744495193    0.2738752451   -0.3781261931    0.1041888187
+
+ QMMM SCC-DFTB:  SCC convergence criteria: 
+ QMMM SCC-DFTB:      Energy:   1.0E-08
+ QMMM SCC-DFTB:      Charge:   5.0E-06
+ QMMM SCC-DFTB:      Telec :     0.000K
+ QMMM SCC-DFTB:  It#                    Energy                   Diff              MaxChDiff   At#   Index   Symb   MullikCh
+ QMMM SCC-DFTB:    1        -3.177297575948840
+ QMMM SCC-DFTB:    2        -3.177297575949379     -0.000000000000539      0.000000028770979     2       2   H       0.10418
+ QMMM SCC-DFTB: SCC-DFTB for step     0 converged in   2 cycles.
+
+ QMMM SCC-DFTB:
+ QMMM SCC-DFTB:    Atomization Energy (eV)       =     -69.728891832600
+ QMMM SCC-DFTB:    Electronic Energy  (eV)       =     -86.454267041583
+ QMMM SCC-DFTB:    Repulsive Energy   (eV)       =      -1.465661958868
+ QMMM SCC-DFTB:    Total Energy       (eV)       =     -87.919929000450
+ QMMM SCC-DFTB:    SCF Energy         (eV)       =     -18.191037167850
+ QMMM SCC-DFTB:
+ QMMM SCC-DFTB:
+ QMMM SCC-DFTB:    Atomization Energy (a.u.)     =      -2.562620060000
+ QMMM SCC-DFTB:    Electronic Energy  (a.u.)     =      -3.177297575949
+ QMMM SCC-DFTB:    Repulsive Energy   (a.u.)     =      -0.053864827595
+ QMMM SCC-DFTB:    Total Energy       (a.u.)     =      -3.231162403545
+ QMMM SCC-DFTB:    SCF Energy         (a.u.)     =      -0.668542343545
+ QMMM SCC-DFTB:
+QMMM:
+QMMM: SCF Energy =   -419.50350812779499 KCal/mol,   -1755.20267800669421 KJ/mol
+QMMM:
+QMMM:        Electronic energy =       -86.45426704 eV (    -1993.72185225 KCal/mol)
+QMMM:         Repulsive energy =        -1.46566196 eV (      -33.79963043 KCal/mol)
+QMMM:             Total energy =       -87.91992900 eV (    -2027.52148268 KCal/mol)
+QMMM:
+QMMM: Forces on QM atoms from SCF calculation
+QMMM: Atm      1:    -0.08389606940974   -0.11995651422258   -0.11648189816041
+QMMM: Atm      2:     0.02409298945252   -0.01208920057537    0.01919866286834
+QMMM: Atm      3:     0.04593742903092    0.10270854098333    0.09298669811655
+QMMM: Atm      4:    -0.02000477088421   -0.00089063282067    0.01917739144805
+QMMM: Atm      5:     0.03387042191143    0.03022780663044   -0.01488085456804
+ QMMM SCC-DFTB: No external charges defined.
+
+ QMMM SCC-DFTB: QM Region Input Cartesian Coordinates 
+ QMMM SCC-DFTB:     NO.  TYP  L  AT#  SYM          X                Y                Z             Charge
+ QMMM SCC-DFTB:      1    1   2   6    C       0.0000038176   -0.0000741005   -0.0000915615   -0.4167784558
+ QMMM SCC-DFTB:      2    2   1   1    H      -0.6690925757    0.8440618436   -0.0841048900    0.1041805336
+ QMMM SCC-DFTB:      3    2   1   1    H      -0.3899329958   -0.8274219846   -0.5748810036    0.1042383039
+ QMMM SCC-DFTB:      4    2   1   1    H       0.0845719140   -0.2904408194    1.0372015916    0.1041707818
+ QMMM SCC-DFTB:      5    2   1   1    H       0.9744494919    0.2738752371   -0.3781261851    0.1041888366
+
+ QMMM SCC-DFTB:  SCC convergence criteria: 
+ QMMM SCC-DFTB:      Energy:   1.0E-08
+ QMMM SCC-DFTB:      Charge:   5.0E-06
+ QMMM SCC-DFTB:      Telec :     0.000K
+ QMMM SCC-DFTB:  It#                    Energy                   Diff              MaxChDiff   At#   Index   Symb   MullikCh
+ QMMM SCC-DFTB:    1        -3.177297609890104
+ QMMM SCC-DFTB:    2        -3.177297609902009     -0.000000000011905      0.000000031528976     2       2   H       0.10418
+ QMMM SCC-DFTB: SCC-DFTB for step     0 converged in   2 cycles.
+
+ QMMM SCC-DFTB:
+ QMMM SCC-DFTB:    Atomization Energy (eV)       =     -69.728891832600
+ QMMM SCC-DFTB:    Electronic Energy  (eV)       =     -86.454267965434
+ QMMM SCC-DFTB:    Repulsive Energy   (eV)       =      -1.465661033211
+ QMMM SCC-DFTB:    Total Energy       (eV)       =     -87.919928998644
+ QMMM SCC-DFTB:    SCF Energy         (eV)       =     -18.191037166044
+ QMMM SCC-DFTB:
+ QMMM SCC-DFTB:
+ QMMM SCC-DFTB:    Atomization Energy (a.u.)     =      -2.562620060000
+ QMMM SCC-DFTB:    Electronic Energy  (a.u.)     =      -3.177297609902
+ QMMM SCC-DFTB:    Repulsive Energy   (a.u.)     =      -0.053864793576
+ QMMM SCC-DFTB:    Total Energy       (a.u.)     =      -3.231162403478
+ QMMM SCC-DFTB:    SCF Energy         (a.u.)     =      -0.668542343478
+ QMMM SCC-DFTB:
+QMMM:
+QMMM: SCF Energy =   -419.50350808614820 KCal/mol,   -1755.20267783244412 KJ/mol
+QMMM:
+QMMM:        Electronic energy =       -86.45426797 eV (    -1993.72187355 KCal/mol)
+QMMM:         Repulsive energy =        -1.46566103 eV (      -33.79960909 KCal/mol)
+QMMM:             Total energy =       -87.91992900 eV (    -2027.52148264 KCal/mol)
+QMMM:
+QMMM: Forces on QM atoms from SCF calculation
+QMMM: Atm      1:    -0.08396699091083   -0.11991097989157   -0.11648255229622
+QMMM: Atm      2:     0.02414617070286   -0.01215050708276    0.01920612150528
+QMMM: Atm      3:     0.04595307066413    0.10272477147955    0.09300363203994
+QMMM: Atm      4:    -0.02000388964462   -0.00088812436557    0.01915299001483
+QMMM: Atm      5:     0.03387164178397    0.03022483954725   -0.01488018434134
+ QMMM SCC-DFTB: No external charges defined.
+
+ QMMM SCC-DFTB: QM Region Input Cartesian Coordinates 
+ QMMM SCC-DFTB:     NO.  TYP  L  AT#  SYM          X                Y                Z             Charge
+ QMMM SCC-DFTB:      1    1   2   6    C       0.0000028335   -0.0000024337    0.0000027987   -0.4167784825
+ QMMM SCC-DFTB:      2    2   1   1    H      -0.6691668036    0.8441000307   -0.0841661042    0.1041805735
+ QMMM SCC-DFTB:      3    2   1   1    H      -0.3899499108   -0.8274546196   -0.5750132435    0.1042383013
+ QMMM SCC-DFTB:      4    2   1   1    H       0.0846969405   -0.2904312731    1.0372413187    0.1041707840
+ QMMM SCC-DFTB:      5    2   1   1    H       0.9744164720    0.2737884277   -0.3780667942    0.1041888237
+
+ QMMM SCC-DFTB:  SCC convergence criteria: 
+ QMMM SCC-DFTB:      Energy:   1.0E-08
+ QMMM SCC-DFTB:      Charge:   5.0E-06
+ QMMM SCC-DFTB:      Telec :     0.000K
+ QMMM SCC-DFTB:  It#                    Energy                   Diff              MaxChDiff   At#   Index   Symb   MullikCh
+ QMMM SCC-DFTB:    1        -3.177269698695105
+ QMMM SCC-DFTB:    2        -3.177269688959342      0.000000009735763      0.000046807800887     3       3   H       0.10418
+ QMMM SCC-DFTB:    3        -3.177269657215860      0.000000031743483      0.000005855871898     1       1   C      -0.41675
+ QMMM SCC-DFTB:    4        -3.177269641375190      0.000000015840670      0.000000000735283     3       3   H       0.10419
+ QMMM SCC-DFTB:    5        -3.177269641376874     -0.000000000001684      0.000000000023997     2       2   H       0.10419
+ QMMM SCC-DFTB: SCC-DFTB for step     0 converged in   5 cycles.
+
+ QMMM SCC-DFTB:
+ QMMM SCC-DFTB:    Atomization Energy (eV)       =     -69.728891832600
+ QMMM SCC-DFTB:    Electronic Energy  (eV)       =     -86.453506941865
+ QMMM SCC-DFTB:    Repulsive Energy   (eV)       =      -1.466423047235
+ QMMM SCC-DFTB:    Total Energy       (eV)       =     -87.919929989100
+ QMMM SCC-DFTB:    SCF Energy         (eV)       =     -18.191038156500
+ QMMM SCC-DFTB:
+ QMMM SCC-DFTB:
+ QMMM SCC-DFTB:    Atomization Energy (a.u.)     =      -2.562620060000
+ QMMM SCC-DFTB:    Electronic Energy  (a.u.)     =      -3.177269641377
+ QMMM SCC-DFTB:    Repulsive Energy   (a.u.)     =      -0.053892798502
+ QMMM SCC-DFTB:    Total Energy       (a.u.)     =      -3.231162439879
+ QMMM SCC-DFTB:    SCF Energy         (a.u.)     =      -0.668542379879
+ QMMM SCC-DFTB:
+QMMM:
+QMMM: SCF Energy =   -419.50353092704279 KCal/mol,   -1755.20277339874701 KJ/mol
+QMMM:
+QMMM:        Electronic energy =       -86.45350694 eV (    -1993.70432359 KCal/mol)
+QMMM:         Repulsive energy =        -1.46642305 eV (      -33.81718189 KCal/mol)
+QMMM:             Total energy =       -87.91992999 eV (    -2027.52150548 KCal/mol)
+QMMM:
+QMMM: Forces on QM atoms from SCF calculation
+QMMM: Atm      1:     0.00197580770225   -0.00035980687995    0.00070646556414
+QMMM: Atm      2:     0.00046647101156   -0.00106870093684   -0.00079556384126
+QMMM: Atm      3:    -0.00072529720144    0.00096065618636   -0.00077488088056
+QMMM: Atm      4:    -0.00020413609271    0.00017694635464    0.00105468965912
+QMMM: Atm      5:    -0.00151284761905    0.00029090519209   -0.00019071050406
+ QMMM SCC-DFTB: No external charges defined.
+
+ QMMM SCC-DFTB: QM Region Input Cartesian Coordinates 
+ QMMM SCC-DFTB:     NO.  TYP  L  AT#  SYM          X                Y                Z             Charge
+ QMMM SCC-DFTB:      1    1   2   6    C       0.0000028335   -0.0000024337    0.0000027987   -0.4167535319
+ QMMM SCC-DFTB:      2    2   1   1    H      -0.6691668036    0.8441000307   -0.0841661042    0.1041874493
+ QMMM SCC-DFTB:      3    2   1   1    H      -0.3899499108   -0.8274546196   -0.5750132435    0.1041881140
+ QMMM SCC-DFTB:      4    2   1   1    H       0.0846969405   -0.2904312731    1.0372413187    0.1041892284
+ QMMM SCC-DFTB:      5    2   1   1    H       0.9744164720    0.2737884277   -0.3780667942    0.1041887402
+
+ QMMM SCC-DFTB:  SCC convergence criteria: 
+ QMMM SCC-DFTB:      Energy:   1.0E-08
+ QMMM SCC-DFTB:      Charge:   5.0E-06
+ QMMM SCC-DFTB:      Telec :     0.000K
+ QMMM SCC-DFTB:  It#                    Energy                   Diff              MaxChDiff   At#   Index   Symb   MullikCh
+ QMMM SCC-DFTB:    1        -3.177269641376872
+ QMMM SCC-DFTB:    2        -3.177269641376872     -0.000000000000000      0.000000000005430     2       2   H       0.10419
+ QMMM SCC-DFTB: SCC-DFTB for step     0 converged in   2 cycles.
+
+ QMMM SCC-DFTB:
+ QMMM SCC-DFTB:    Atomization Energy (eV)       =     -69.728891832600
+ QMMM SCC-DFTB:    Electronic Energy  (eV)       =     -86.453506941865
+ QMMM SCC-DFTB:    Repulsive Energy   (eV)       =      -1.466423047235
+ QMMM SCC-DFTB:    Total Energy       (eV)       =     -87.919929989100
+ QMMM SCC-DFTB:    SCF Energy         (eV)       =     -18.191038156500
+ QMMM SCC-DFTB:
+ QMMM SCC-DFTB:
+ QMMM SCC-DFTB:    Atomization Energy (a.u.)     =      -2.562620060000
+ QMMM SCC-DFTB:    Electronic Energy  (a.u.)     =      -3.177269641377
+ QMMM SCC-DFTB:    Repulsive Energy   (a.u.)     =      -0.053892798502
+ QMMM SCC-DFTB:    Total Energy       (a.u.)     =      -3.231162439879
+ QMMM SCC-DFTB:    SCF Energy         (a.u.)     =      -0.668542379879
+ QMMM SCC-DFTB:
+QMMM:
+QMMM: SCF Energy =   -419.50353092704194 KCal/mol,   -1755.20277339874360 KJ/mol
+QMMM:
+QMMM:        Electronic energy =       -86.45350694 eV (    -1993.70432359 KCal/mol)
+QMMM:         Repulsive energy =        -1.46642305 eV (      -33.81718189 KCal/mol)
+QMMM:             Total energy =       -87.91992999 eV (    -2027.52150548 KCal/mol)
+QMMM:
+QMMM: Forces on QM atoms from SCF calculation
+QMMM: Atm      1:     0.00197580855841   -0.00035980761466    0.00070646591546
+QMMM: Atm      2:     0.00046647069005   -0.00106870058785   -0.00079556392153
+QMMM: Atm      3:    -0.00072529733534    0.00096065631988   -0.00077488092885
+QMMM: Atm      4:    -0.00020413624517    0.00017694651691    0.00105468945196
+QMMM: Atm      5:    -0.00151284786736    0.00029090528194   -0.00019071051969
+  ... geometry converged !
+ 
+ Final MO eigenvalues (au):
+  -0.5724   -0.3317   -0.3317   -0.3317    0.3784    0.3784    0.3784    0.6704
+
+
+ Heat of formation   =       -419.50353093 kcal/mol  (      -18.19103816 eV)
+
+ Total SCF energy    =      -2027.52150548 kcal/mol  (      -87.91992999 eV)
+ Electronic energy   =      -1993.70432359 kcal/mol  (      -86.45350694 eV)
+ Core-core repulsion =        -33.81718189 kcal/mol  (       -1.46642305 eV)
+ 
+    Atomic Charges for Step       1 :
+  Atom    Element       Mulliken Charge
+     1      C                 -0.417
+     2      H                  0.104
+     3      H                  0.104
+     4      H                  0.104
+     5      H                  0.104
+ Total Mulliken Charge =       0.000
+ 
+                  X        Y        Z     TOTAL  
+  QM DIPOLE    -0.000    0.000   -0.000    0.000
+ 
+ Final Structure
+
+  QMMM: QM Region Cartesian Coordinates (*=link atom) 
+  QMMM: QM_NO.   MM_NO.  ATOM         X         Y         Z
+  QMMM:     1        1      C        0.0000   -0.0000    0.0000
+  QMMM:     2        2      H       -0.6692    0.8441   -0.0842
+  QMMM:     3        3      H       -0.3899   -0.8275   -0.5750
+  QMMM:     4        4      H        0.0847   -0.2904    1.0372
+  QMMM:     5        5      H        0.9744    0.2738   -0.3781
+QMMM:
+QMMM: Forces on QM atoms from SCF calculation
+QMMM: Atm      1:     0.00197580855841   -0.00035980761466    0.00070646591546
+QMMM: Atm      2:     0.00046647069005   -0.00106870058785   -0.00079556392153
+QMMM: Atm      3:    -0.00072529733534    0.00096065631988   -0.00077488092885
+QMMM: Atm      4:    -0.00020413624517    0.00017694651691    0.00105468945196
+QMMM: Atm      5:    -0.00151284786736    0.00029090528194   -0.00019071051969
+
+           --------- Calculation Completed ----------
+

--- a/tests/test_amber_sqm.py
+++ b/tests/test_amber_sqm.py
@@ -39,6 +39,22 @@ class TestAmberSqmOutLabeled(unittest.TestCase, CompLabeledSys, IsNoPBC):
         if os.path.exists('tmp.sqm.forces'):
             shutil.rmtree('tmp.sqm.forces')
 
+
+class TestAmberSqmOutOpt(unittest.TestCase, CompLabeledSys, IsNoPBC):
+    def setUp(self) :
+        self.system_1 = dpdata.LabeledSystem('amber/sqm_opt.out', fmt = 'sqm/out')
+        self.system_1.to('deepmd/npy','tmp.sqm.opt')
+        self.system_2 = dpdata.LabeledSystem('tmp.sqm.opt', fmt = 'deepmd/npy')
+        self.places = 5
+        self.e_places = 4
+        self.f_places = 6
+        self.v_places = 6
+
+    def tearDown(self) :
+        if os.path.exists('tmp.sqm.opt'):
+            shutil.rmtree('tmp.sqm.opt')
+
+
 @unittest.skipIf(skip_bond_order_system, "dpdata does not have BondOrderSystem. One may install rdkit to fix.")
 class TestAmberSqmIn(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Before, only single-point calculation output is supported.