### PR TITLE
identify frames with virials in Multisystems

### DIFF
--- a/dpdata/system.py
+++ b/dpdata/system.py
@@ -1154,6 +1154,8 @@ class MultiSystems:
             return
         self.check_atom_names(system)
         formula = system.formula
+        if 'virials' in system.data:
+            formula = formula + "_virials"
         if formula in self.systems:
             self.systems[formula].append(system)
         else:


### PR DESCRIPTION
Sometimes we came across with multisystem (such as quip/gap/xyz format files) which has both frames with virials labels and frames without virials labels. The current implementation of the Multisystems class will lead to error message:
```
RuntimeError: system has virial, but this does not
```
But this kind of Multisystems are in fact trainable, so I identify frames with virials in Multisystems, such that Systems will have names as:
```
C60  C60_virials
```
The former represents systems with 60 carbon atoms without virials labels, the latter represents systems with 60 carbon atoms with virials labels.
