### PR TITLE
add a param of 'labeled' in dpdata/system.py for MultiSystems

### DIFF
--- a/dpdata/system.py
+++ b/dpdata/system.py
@@ -1367,8 +1367,8 @@ def add_format_methods():
     for method, formatcls in Format.get_from_methods().items():
         def get_func(ff):
             # ff is not initized when defining from_format so cannot be polluted
-            def from_format(self, file_name, **kwargs):
-                return self.from_fmt_obj(ff(), file_name, **kwargs)
+            def from_format(self, file_name, labeled = True, **kwargs):
+                return self.from_fmt_obj(ff(), file_name, labeled, **kwargs)
             from_format.__doc__ = "Read data from :class:`%s` format." % (get_cls_name(ff))
             return from_format
 


### PR DESCRIPTION
When `dpgen simplify` calls `dpdata.MultiSystems().from_deepmd_npy(file_name)`, it mostly deals with System instead of LabeledSystem; however, in `from_fmt_obj`, `MultiSystems` is always treated as `LabeledSystem`, which leads to `DataError`.
Therefore, the `labeled` parameter is added to `from_format`, which decides if the systems are labeled. The `labeled` parameter defaults to True, so the original dependencies won't be affected.