### PR TITLE
test: add UT for to_system for abacus interface

### DIFF
--- a/dpdata/abacus/scf.py
+++ b/dpdata/abacus/scf.py
@@ -233,7 +233,7 @@ def make_unlabeled_stru(data, frame_idx, pp_file=None, numerical_orbital=None, n
     for iele in range(len(data['atom_names'])):
         out += data['atom_names'][iele] + " "
         if mass is not None:
-            out += "%d "%mass[iele]
+            out += "%.3f "%mass[iele]
         else:
             out += "1 "
         if pp_file is not None:

--- a/tests/abacus.scf/stru_test
+++ b/tests/abacus.scf/stru_test
@@ -1,6 +1,6 @@
 ATOMIC_SPECIES
-C 12 C.upf
-H 1 H.upf
+C 12.000 C.upf
+H 1.000 H.upf
 
 NUMERICAL_ORBITAL
 C.orb

--- a/tests/test_abacus_md.py
+++ b/tests/test_abacus_md.py
@@ -85,12 +85,32 @@ class TestABACUSMD:
         np.testing.assert_almost_equal(self.system_water.data['energies'], ref_energy)
         np.testing.assert_almost_equal(self.system_Si.data['energies'], ref_energy2)
 
+    def test_to_system(self):
+        pp_file=["H.upf","O.upf"]
+        numerical_orbital=["H.upf","O.upf"]
+        numerical_descriptor="jle.orb"
+        mass=[1.008,15.994]
+        self.system_water.to(file_name="abacus.md/water_stru",fmt='abacus/stru',pp_file=pp_file,\
+                numerical_orbital=numerical_orbital,numerical_descriptor=numerical_descriptor,\
+                mass=mass)
+        self.assertTrue(os.path.isfile('abacus.md/water_stru'))
+        if os.path.isfile('abacus.md/water_stru'):
+            with open('abacus.md/water_stru') as f:
+                iline=0
+                for iline,l in enumerate(f):
+                    iline += 1
+                self.assertEqual(iline,30)
+
 
 class TestABACUSMDLabeledOutput(unittest.TestCase, TestABACUSMD):
 
     def setUp(self):
         self.system_water = dpdata.LabeledSystem('abacus.md',fmt='abacus/md') # system with stress
         self.system_Si = dpdata.LabeledSystem('abacus.md.nostress',fmt='abacus/md') # system without stress
+
+    def tearDown(self):
+        if os.path.isfile('abacus.md/water_stru'):
+            os.remove('abacus.md/water_stru')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
One additional unit test has been added in the file "tests/test_abacus_md.py" to cover two functions for the abacus interface:
(1) "to_system" in dpdata/plugins/abacus.py
(2) "make_unlabeled_stru" in dpdata/abacus/scf.py