### PR TITLE
drop Python 3.6 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2"]
+requires = ["setuptools>=61", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -23,7 +23,7 @@ dependencies = [
     'wcmatch',
     'importlib_metadata>=1.4; python_version < "3.8"',
 ]
-requires-python = ">=3.6"
+requires-python = ">=3.7"
 readme = "README.md"
 keywords = ["lammps", "vasp", "deepmd-kit"]
 


### PR DESCRIPTION
Just realized that #366 requires setuptools>=61 and setuptools 59 has dropped Python 3.6.