### PR TITLE
fix codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,8 +22,8 @@ jobs:
     - name: Install rdkit
       run: python -m pip install rdkit openbabel-wheel
     - name: Install dependencies
-      run: python -m pip install .[amber,ase,pymatgen] coverage codecov
+      run: python -m pip install .[amber,ase,pymatgen] coverage
     - name: Test
       run: cd tests && coverage run --source=../dpdata -m unittest && cd .. && coverage combine tests/.coverage && coverage report
     - name: Run codecov
-      run: codecov
+      uses: codecov/codecov-action@v3


### PR DESCRIPTION
Codecov python package is deprecated does not work any more. This patch migrates it to another version.