### PR TITLE
Fix: remove the reading of `ntype` in the parsing of abacus structure

### DIFF
--- a/dpdata/abacus/scf.py
+++ b/dpdata/abacus/scf.py
@@ -59,7 +59,7 @@ def get_cell(geometry_inlines):
     cell = celldm*np.array(cell)
     return celldm, cell
 
-def get_coords(celldm, cell, geometry_inlines, inlines):
+def get_coords(celldm, cell, geometry_inlines, inlines=None):
     coords_lines = get_block(geometry_inlines, "ATOMIC_POSITIONS", skip=0)
     # assuming that ATOMIC_POSITIONS is at the bottom of the STRU file
     coord_type = coords_lines[0].split()[0].lower() # cartisan or direct
@@ -67,13 +67,7 @@ def get_coords(celldm, cell, geometry_inlines, inlines):
     atom_types = [] # index of atom_names of each atom in the geometry
     atom_numbs = [] # of atoms for each element
     coords = [] # coordinations of atoms
-    ntype = 0
-    for line in inlines:
-        if "ntype" in line and "ntype"==line.split()[0]:
-            ntype = int(line.split()[1])
-            break
-    if ntype <= 0:
-        raise RuntimeError('ntype cannot be found in INPUT file.')
+    ntype = get_nele_from_stru(geometry_inlines)
     line_idx = 1 # starting line of first element
     for it in range(ntype):
         atom_names.append(coords_lines[line_idx].split()[0])

--- a/tests/abacus.md.nostress/INPUT
+++ b/tests/abacus.md.nostress/INPUT
@@ -1,8 +1,7 @@
 INPUT_PARAMETERS
 #Parameters	(General)
 suffix          autotest
-pseudo_dir		./
-ntype			1	
+pseudo_dir		./	
 nbands			8
 calculation     md
 

--- a/tests/abacus.md.unconv/INPUT
+++ b/tests/abacus.md.unconv/INPUT
@@ -1,6 +1,5 @@
 INPUT_PARAMETERS
 calculation 	md
-ntype 		2
 nbands 		8
 
 ecutwfc 	50.000000

--- a/tests/abacus.md/INPUT
+++ b/tests/abacus.md/INPUT
@@ -2,7 +2,6 @@ INPUT_PARAMETERS
 #Parameters (1.General)
 suffix                  abacus
 calculation             md
-ntype                   2
 nbands                  6
 symmetry                0
 

--- a/tests/abacus.relax/INPUT
+++ b/tests/abacus.relax/INPUT
@@ -2,7 +2,6 @@ INPUT_PARAMETERS
 #Parameters (1.General)
 suffix                  abacus
 calculation             cell-relax
-ntype                   2
 nbands                  6
 symmetry                1
 

--- a/tests/abacus.scf/INPUT.fail
+++ b/tests/abacus.scf/INPUT.fail
@@ -4,7 +4,6 @@ suffix 			ch4fail
 stru_file 	        STRU.ch4 #the filename of file containing atom positions
 kpoint_file        	KPT.ch4 #the name of file containing k points
 pseudo_dir		./
-ntype			2
 nbands		  	8
 #Parameters (Accuracy)
 ecutwfc			100

--- a/tests/abacus.scf/INPUT.ok
+++ b/tests/abacus.scf/INPUT.ok
@@ -4,7 +4,6 @@ suffix 			ch4
 stru_file 	        STRU.ch4 #the filename of file containing atom positions
 kpoint_file        	KPT.ch4 #the name of file containing k points
 pseudo_dir		./
-ntype			2
 nbands		  	8
 #Parameters (Accuracy)
 ecutwfc			100


### PR DESCRIPTION
The latest ABACUS 3.0.5 have removed the key word `ntype` in INPUT