### PR TITLE
pin parmed version for py37

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,10 @@ dpdata = "dpdata.cli:dpdata_cli"
 
 [project.optional-dependencies]
 ase = ['ase']
-amber = ['parmed']
+amber = [
+    'parmed; python_version >= "3.8"',
+    'parmed<4; python_version < "3.8"',
+]
 pymatgen = ['pymatgen']
 docs = [
     'sphinx',


### PR DESCRIPTION
The new version of parmed drops Python 3.7. However, it did not set `requires-python`, making pip on Python 3.7 still installs the latest version.