### PR TITLE
fix: standardize the deepmd/npy/mixed format

### DIFF
--- a/dpdata/deepmd/mixed.py
+++ b/dpdata/deepmd/mixed.py
@@ -86,6 +86,7 @@ def to_system_data(folder, type_map=None, labels=True):
             (real_atom_types != real_atom_types[0]).any(-1)
         ]
         temp_data = data.copy()
+        temp_data["atom_names"] = data["atom_names"].copy()
         temp_data["atom_numbs"] = temp_atom_numbs
         temp_data["atom_types"] = real_atom_types[0]
         real_atom_types = real_atom_types[rest_idx]

--- a/dpdata/deepmd/mixed.py
+++ b/dpdata/deepmd/mixed.py
@@ -201,7 +201,10 @@ def dump(folder, data, set_size=2000, comp_prec=np.float32, remove_sets=True):
         if virials is not None:
             np.save(os.path.join(set_folder, "virial"), virials[set_stt:set_end])
         if real_atom_types is not None:
-            np.save(os.path.join(set_folder, "real_atom_types"), real_atom_types[set_stt:set_end])
+            np.save(
+                os.path.join(set_folder, "real_atom_types"),
+                real_atom_types[set_stt:set_end],
+            )
         if "atom_pref" in data:
             np.save(os.path.join(set_folder, "atom_pref"), atom_pref[set_stt:set_end])
     try:

--- a/dpdata/deepmd/mixed.py
+++ b/dpdata/deepmd/mixed.py
@@ -216,7 +216,7 @@ def dump(folder, data, set_size=2000, comp_prec=np.float32, remove_sets=True):
             pass
 
 
-def mix_system(*system, type_map, split_num=50000, **kwargs):
+def mix_system(*system, type_map, **kwargs):
     """Mix the systems into mixed_type ones according to the unified given type_map.
 
     Parameters
@@ -225,24 +225,19 @@ def mix_system(*system, type_map, split_num=50000, **kwargs):
         The systems to mix
     type_map : list of str
         Maps atom type to name
-    split_num : int
-        Number of max frames in each system
 
     Returns
     -------
     mixed_systems: dict
-        dict of mixed system with key 'atom_numbs.sys.xxx'
+        dict of mixed system with key 'atom_numbs'
     """
     mixed_systems = {}
     temp_systems = {}
-    atom_numbs_sys_index = {}  # index of sys
     atom_numbs_frame_index = {}  # index of frames in cur sys
     for sys in system:
         tmp_sys = sys.copy()
         natom = tmp_sys.get_natoms()
         tmp_sys.convert_to_mixed_type(type_map=type_map)
-        if str(natom) not in atom_numbs_sys_index:
-            atom_numbs_sys_index[str(natom)] = 0
         if str(natom) not in atom_numbs_frame_index:
             atom_numbs_frame_index[str(natom)] = 0
         atom_numbs_frame_index[str(natom)] += tmp_sys.get_nframes()
@@ -250,22 +245,9 @@ def mix_system(*system, type_map, split_num=50000, **kwargs):
             temp_systems[str(natom)] = tmp_sys
         else:
             temp_systems[str(natom)].append(tmp_sys)
-        if atom_numbs_frame_index[str(natom)] >= split_num:
-            while True:
-                sys_split, temp_systems[str(natom)], rest_num = split_system(
-                    temp_systems[str(natom)], split_num=split_num
-                )
-                sys_name = (
-                    f"{str(natom)}.sys." + "%.3d" % atom_numbs_sys_index[str(natom)]
-                )
-                mixed_systems[sys_name] = sys_split
-                atom_numbs_sys_index[str(natom)] += 1
-                if rest_num < split_num:
-                    atom_numbs_frame_index[str(natom)] = rest_num
-                    break
     for natom in temp_systems:
         if atom_numbs_frame_index[natom] > 0:
-            sys_name = f"{natom}.sys." + "%.3d" % atom_numbs_sys_index[natom]
+            sys_name = f"{natom}"
             mixed_systems[sys_name] = temp_systems[natom]
     return mixed_systems
 

--- a/dpdata/format.py
+++ b/dpdata/format.py
@@ -132,7 +132,7 @@ class Format(ABC):
             "%s doesn't support MultiSystems.to" % (self.__class__.__name__)
         )
 
-    def mix_system(self, *system, type_map, split_num=50000, **kwargs):
+    def mix_system(self, *system, type_map, **kwargs):
         """Mix the systems into mixed_type ones according to the unified given type_map.
 
         Parameters
@@ -141,13 +141,11 @@ class Format(ABC):
             The systems to mix
         type_map : list of str
             Maps atom type to name
-        split_num : int
-            Number of max frames in each system
 
         Returns
         -------
         mixed_systems: dict
-            dict of mixed system with key 'atom_numbs.sys.xxx'
+            dict of mixed system with key 'atom_numbs'
         """
         raise NotImplementedError(
             "%s doesn't support System.from" % (self.__class__.__name__)

--- a/dpdata/format.py
+++ b/dpdata/format.py
@@ -132,7 +132,7 @@ class Format(ABC):
             "%s doesn't support MultiSystems.to" % (self.__class__.__name__)
         )
 
-    def mix_system(self, *system, type_map, split_num=200, **kwargs):
+    def mix_system(self, *system, type_map, split_num=50000, **kwargs):
         """Mix the systems into mixed_type ones according to the unified given type_map.
 
         Parameters
@@ -142,12 +142,12 @@ class Format(ABC):
         type_map : list of str
             Maps atom type to name
         split_num : int
-            Number of frames in each system
+            Number of max frames in each system
 
         Returns
         -------
         mixed_systems: dict
-            dict of mixed system with key '{atom_numbs}/sys.xxx'
+            dict of mixed system with key 'atom_numbs.sys.xxx'
         """
         raise NotImplementedError(
             "%s doesn't support System.from" % (self.__class__.__name__)

--- a/dpdata/plugins/deepmd.py
+++ b/dpdata/plugins/deepmd.py
@@ -117,7 +117,7 @@ class DeePMDMixedFormat(Format):
             file_name, type_map=type_map, labels=True
         )
 
-    def mix_system(self, *system, type_map, split_num=50000, **kwargs):
+    def mix_system(self, *system, type_map, **kwargs):
         """Mix the systems into mixed_type ones according to the unified given type_map.
 
         Parameters
@@ -126,17 +126,22 @@ class DeePMDMixedFormat(Format):
             The systems to mix
         type_map : list of str
             Maps atom type to name
-        split_num : int
-            Number of max frames in each system
 
         Returns
         -------
         mixed_systems: dict
-            dict of mixed system with key 'atom_numbs.sys.xxx'
+            dict of mixed system with key 'atom_numbs'
         """
         return dpdata.deepmd.mixed.mix_system(
-            *system, type_map=type_map, split_num=split_num, **kwargs
+            *system, type_map=type_map, **kwargs
         )
+
+    def from_multi_systems(self, directory, **kwargs):
+        sys_dir = []
+        for root, dirs, files in os.walk(directory):
+            if "type_map.raw" in files:  # mixed_type format systems must have type_map.raw
+                sys_dir.append(root)
+        return sys_dir
 
     MultiMode = Format.MultiModes.Directory
 

--- a/dpdata/plugins/deepmd.py
+++ b/dpdata/plugins/deepmd.py
@@ -117,7 +117,7 @@ class DeePMDMixedFormat(Format):
             file_name, type_map=type_map, labels=True
         )
 
-    def mix_system(self, *system, type_map, split_num=200, **kwargs):
+    def mix_system(self, *system, type_map, split_num=50000, **kwargs):
         """Mix the systems into mixed_type ones according to the unified given type_map.
 
         Parameters
@@ -127,48 +127,16 @@ class DeePMDMixedFormat(Format):
         type_map : list of str
             Maps atom type to name
         split_num : int
-            Number of frames in each system
+            Number of max frames in each system
 
         Returns
         -------
         mixed_systems: dict
-            dict of mixed system with key '{atom_numbs}/sys.xxx'
+            dict of mixed system with key 'atom_numbs.sys.xxx'
         """
         return dpdata.deepmd.mixed.mix_system(
             *system, type_map=type_map, split_num=split_num, **kwargs
         )
-
-    def from_multi_systems(self, directory, **kwargs):
-        """MultiSystems.from
-
-        Parameters
-        ----------
-        directory : str
-            directory of system
-
-        Returns
-        -------
-        filenames: list[str]
-            list of filenames
-        """
-        if self.MultiMode == self.MultiModes.Directory:
-            level_1_dir = [
-                os.path.join(directory, name)
-                for name in os.listdir(directory)
-                if os.path.isdir(os.path.join(directory, name))
-                and os.path.isfile(os.path.join(directory, name, "type_map.raw"))
-            ]
-            level_2_dir = [
-                os.path.join(directory, name1, name2)
-                for name1 in os.listdir(directory)
-                for name2 in os.listdir(os.path.join(directory, name1))
-                if os.path.isdir(os.path.join(directory, name1))
-                and os.path.isdir(os.path.join(directory, name1, name2))
-                and os.path.isfile(
-                    os.path.join(directory, name1, name2, "type_map.raw")
-                )
-            ]
-            return level_1_dir + level_2_dir
 
     MultiMode = Format.MultiModes.Directory
 

--- a/dpdata/plugins/deepmd.py
+++ b/dpdata/plugins/deepmd.py
@@ -132,14 +132,14 @@ class DeePMDMixedFormat(Format):
         mixed_systems: dict
             dict of mixed system with key 'atom_numbs'
         """
-        return dpdata.deepmd.mixed.mix_system(
-            *system, type_map=type_map, **kwargs
-        )
+        return dpdata.deepmd.mixed.mix_system(*system, type_map=type_map, **kwargs)
 
     def from_multi_systems(self, directory, **kwargs):
         sys_dir = []
         for root, dirs, files in os.walk(directory):
-            if "type_map.raw" in files:  # mixed_type format systems must have type_map.raw
+            if (
+                "type_map.raw" in files
+            ):  # mixed_type format systems must have type_map.raw
                 sys_dir.append(root)
         return sys_dir
 

--- a/dpdata/system.py
+++ b/dpdata/system.py
@@ -1307,15 +1307,13 @@ class MultiSystems:
                 if labeled:
                     data_list = fmtobj.from_labeled_system_mix(dd, **kwargs)
                     for data_item in data_list:
-                        system_list.append(LabeledSystem(data=data_item))
+                        system_list.append(LabeledSystem(data=data_item, **kwargs))
                 else:
                     data_list = fmtobj.from_system_mix(dd, **kwargs)
                     for data_item in data_list:
-                        system_list.append(System(data=data_item))
-            return self.__class__(
-                *system_list,
-                type_map=kwargs["type_map"] if "type_map" in kwargs else None,
-            )
+                        system_list.append(System(data=data_item, **kwargs))
+            self.append(*system_list)
+            return self
 
     def to_fmt_obj(self, fmtobj, directory, *args, **kwargs):
         if not isinstance(fmtobj, dpdata.plugins.deepmd.DeePMDMixedFormat):

--- a/tests/test_deepmd_mixed.py
+++ b/tests/test_deepmd_mixed.py
@@ -9,7 +9,9 @@ from comp_sys import CompLabeledSys, CompSys, IsNoPBC, MultiSystems
 from context import dpdata
 
 
-class TestMixedMultiSystemsDumpLoad(unittest.TestCase, CompLabeledSys, MultiSystems, IsNoPBC):
+class TestMixedMultiSystemsDumpLoad(
+    unittest.TestCase, CompLabeledSys, MultiSystems, IsNoPBC
+):
     def setUp(self):
         self.places = 6
         self.e_places = 6
@@ -64,7 +66,9 @@ class TestMixedMultiSystemsDumpLoad(unittest.TestCase, CompLabeledSys, MultiSyst
         mixed_sets = glob("tmp.deepmd.mixed/*/set.*")
         self.assertEqual(len(mixed_sets), 2)
         for i in mixed_sets:
-            self.assertEqual(os.path.exists(os.path.join(i, 'real_atom_types.npy')), True)
+            self.assertEqual(
+                os.path.exists(os.path.join(i, "real_atom_types.npy")), True
+            )
 
         self.system_names = [
             "C1H4A0B0D0",
@@ -106,7 +110,9 @@ class TestMixedMultiSystemsDumpLoad(unittest.TestCase, CompLabeledSys, MultiSyst
         )
 
 
-class TestMixedMultiSystemsTypeChange(unittest.TestCase, CompLabeledSys, MultiSystems, IsNoPBC):
+class TestMixedMultiSystemsTypeChange(
+    unittest.TestCase, CompLabeledSys, MultiSystems, IsNoPBC
+):
     def setUp(self):
         self.places = 6
         self.e_places = 6
@@ -162,7 +168,9 @@ class TestMixedMultiSystemsTypeChange(unittest.TestCase, CompLabeledSys, MultiSy
         mixed_sets = glob("tmp.deepmd.mixed/*/set.*")
         self.assertEqual(len(mixed_sets), 2)
         for i in mixed_sets:
-            self.assertEqual(os.path.exists(os.path.join(i, 'real_atom_types.npy')), True)
+            self.assertEqual(
+                os.path.exists(os.path.join(i, "real_atom_types.npy")), True
+            )
 
         self.system_names = [
             "TOKEN0C1H4A0B0D0",

--- a/tests/test_deepmd_mixed.py
+++ b/tests/test_deepmd_mixed.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import unittest
+from glob import glob
 from itertools import permutations
 
 import numpy as np
@@ -8,7 +9,7 @@ from comp_sys import CompLabeledSys, CompSys, IsNoPBC, MultiSystems
 from context import dpdata
 
 
-class TestMixedMultiSystems(unittest.TestCase, CompLabeledSys, MultiSystems, IsNoPBC):
+class TestMixedMultiSystemsDumpLoad(unittest.TestCase, CompLabeledSys, MultiSystems, IsNoPBC):
     def setUp(self):
         self.places = 6
         self.e_places = 6
@@ -54,17 +55,16 @@ class TestMixedMultiSystems(unittest.TestCase, CompLabeledSys, MultiSystems, IsN
             system_1_modified_type_3,
         )
         self.ms.to_deepmd_npy_mixed("tmp.deepmd.mixed")
-        self.place_holder_ms = dpdata.MultiSystems().load_systems_from_file(
-            "tmp.deepmd.mixed/5", fmt="deepmd/npy"
-        )
-        self.place_holder_ms += dpdata.MultiSystems().load_systems_from_file(
-            "tmp.deepmd.mixed/4", fmt="deepmd/npy"
-        )
-        self.systems = dpdata.MultiSystems().load_systems_from_file(
-            "tmp.deepmd.mixed", fmt="deepmd/npy/mixed"
-        )
+        self.place_holder_ms = dpdata.MultiSystems()
+        self.place_holder_ms.from_deepmd_npy("tmp.deepmd.mixed", fmt="deepmd/npy")
+        self.systems = dpdata.MultiSystems()
+        self.systems.from_deepmd_npy_mixed("tmp.deepmd.mixed", fmt="deepmd/npy/mixed")
         self.system_1 = self.ms["C1H4A0B0D0"]
         self.system_2 = self.systems["C1H4A0B0D0"]
+        mixed_sets = glob("tmp.deepmd.mixed/*/set.*")
+        self.assertEqual(len(mixed_sets), 2)
+        for i in mixed_sets:
+            self.assertEqual(os.path.exists(os.path.join(i, 'real_atom_types.npy')), True)
 
         self.system_names = [
             "C1H4A0B0D0",
@@ -79,6 +79,104 @@ class TestMixedMultiSystems(unittest.TestCase, CompLabeledSys, MultiSystems, IsN
             "C1H1A1B2D0": 1,
             "C1H1A2B1D0": 1,
             "C1H1A1B0D2": 1,
+        }
+        self.atom_names = ["C", "H", "A", "B", "D"]
+
+    def tearDown(self):
+        if os.path.exists("tmp.deepmd.mixed"):
+            shutil.rmtree("tmp.deepmd.mixed")
+
+    def test_len(self):
+        self.assertEqual(len(self.ms), 5)
+        self.assertEqual(len(self.place_holder_ms), 2)
+        self.assertEqual(len(self.systems), 5)
+
+    def test_get_nframes(self):
+        self.assertEqual(self.ms.get_nframes(), 5)
+        self.assertEqual(self.place_holder_ms.get_nframes(), 5)
+        self.assertEqual(self.systems.get_nframes(), 5)
+
+    def test_str(self):
+        self.assertEqual(str(self.ms), "MultiSystems (5 systems containing 5 frames)")
+        self.assertEqual(
+            str(self.place_holder_ms), "MultiSystems (2 systems containing 5 frames)"
+        )
+        self.assertEqual(
+            str(self.systems), "MultiSystems (5 systems containing 5 frames)"
+        )
+
+
+class TestMixedMultiSystemsTypeChange(unittest.TestCase, CompLabeledSys, MultiSystems, IsNoPBC):
+    def setUp(self):
+        self.places = 6
+        self.e_places = 6
+        self.f_places = 6
+        self.v_places = 6
+
+        # C1H4
+        system_1 = dpdata.LabeledSystem(
+            "gaussian/methane.gaussianlog", fmt="gaussian/log"
+        )
+
+        # C1H3
+        system_2 = dpdata.LabeledSystem(
+            "gaussian/methane_sub.gaussianlog", fmt="gaussian/log"
+        )
+
+        tmp_data = system_1.data.copy()
+        tmp_data["atom_numbs"] = [1, 1, 1, 2]
+        tmp_data["atom_names"] = ["C", "H", "A", "B"]
+        tmp_data["atom_types"] = np.array([0, 1, 2, 3, 3])
+        # C1H1A1B2
+        system_1_modified_type_1 = dpdata.LabeledSystem(data=tmp_data)
+
+        tmp_data = system_1.data.copy()
+        tmp_data["atom_numbs"] = [1, 1, 2, 1]
+        tmp_data["atom_names"] = ["C", "H", "A", "B"]
+        tmp_data["atom_types"] = np.array([0, 1, 2, 2, 3])
+        # C1H1A2B1
+        system_1_modified_type_2 = dpdata.LabeledSystem(data=tmp_data)
+
+        tmp_data = system_1.data.copy()
+        tmp_data["atom_numbs"] = [1, 1, 1, 2]
+        tmp_data["atom_names"] = ["C", "H", "A", "D"]
+        tmp_data["atom_types"] = np.array([0, 1, 2, 3, 3])
+        # C1H1A1C2
+        system_1_modified_type_3 = dpdata.LabeledSystem(data=tmp_data)
+
+        self.ms = dpdata.MultiSystems(
+            system_1,
+            system_2,
+            system_1_modified_type_1,
+            system_1_modified_type_2,
+            system_1_modified_type_3,
+            type_map=["TOKEN"],
+        )
+        self.ms.to_deepmd_npy_mixed("tmp.deepmd.mixed")
+        self.place_holder_ms = dpdata.MultiSystems()
+        self.place_holder_ms.from_deepmd_npy("tmp.deepmd.mixed", fmt="deepmd/npy")
+        self.systems = dpdata.MultiSystems(type_map=["TOKEN"])
+        self.systems.from_deepmd_npy_mixed("tmp.deepmd.mixed", fmt="deepmd/npy/mixed")
+        self.system_1 = self.ms["TOKEN0C1H4A0B0D0"]
+        self.system_2 = self.systems["TOKEN0C1H4A0B0D0"]
+        mixed_sets = glob("tmp.deepmd.mixed/*/set.*")
+        self.assertEqual(len(mixed_sets), 2)
+        for i in mixed_sets:
+            self.assertEqual(os.path.exists(os.path.join(i, 'real_atom_types.npy')), True)
+
+        self.system_names = [
+            "TOKEN0C1H4A0B0D0",
+            "TOKEN0C1H3A0B0D0",
+            "TOKEN0C1H1A1B2D0",
+            "TOKEN0C1H1A2B1D0",
+            "TOKEN0C1H1A1B0D2",
+        ]
+        self.system_sizes = {
+            "TOKEN0C1H4A0B0D0": 1,
+            "TOKEN0C1H3A0B0D0": 1,
+            "TOKEN0C1H1A1B2D0": 1,
+            "TOKEN0C1H1A2B1D0": 1,
+            "TOKEN0C1H1A1B0D2": 1,
         }
         self.atom_names = ["C", "H", "A", "B", "D"]
 


### PR DESCRIPTION
This PR has concated two commits together:

1. Update the dpdata.MultiSystems() when from_deepmd_npy_mixed method is called;

dpdata.MultiSystems().from_deepmd_npy_mixed only returned the results before but did not change itself, which is fixed in this commit, to be consistent with other from methods. 
(another bug is also fixed: not using .copy() in data["atom_names"] may cause error when manually changing type_map for this system. UTs are added in the next commit.)


2. Allow multiple sets in mixed-type format;

Now for maximum 50000 frames in one sys and 2000 frames in one set.
The reason I did not use 5000 frames per set, is that I think maximum set frames will be much more often used in mixed-type format than other format, and 2000 will be enough for large batch and more friendly for memory.

Add UTs for type_map changing and mixed_type dir check.

