### PR TITLE
Raise error when from_deepmd_npy_mixed with not-a-directory para.

### DIFF
--- a/dpdata/plugins/deepmd.py
+++ b/dpdata/plugins/deepmd.py
@@ -136,7 +136,7 @@ class DeePMDMixedFormat(Format):
 
     def from_multi_systems(self, directory, **kwargs):
         sys_dir = []
-        assert os.path.isdir(directory), f'{directory} is not a directory!'
+        assert os.path.isdir(directory), f"{directory} is not a directory!"
         for root, dirs, files in os.walk(directory):
             if (
                 "type_map.raw" in files

--- a/dpdata/plugins/deepmd.py
+++ b/dpdata/plugins/deepmd.py
@@ -136,6 +136,7 @@ class DeePMDMixedFormat(Format):
 
     def from_multi_systems(self, directory, **kwargs):
         sys_dir = []
+        assert os.path.isdir(directory), f'{directory} is not a directory!'
         for root, dirs, files in os.walk(directory):
             if (
                 "type_map.raw" in files

--- a/dpdata/plugins/deepmd.py
+++ b/dpdata/plugins/deepmd.py
@@ -136,7 +136,8 @@ class DeePMDMixedFormat(Format):
 
     def from_multi_systems(self, directory, **kwargs):
         sys_dir = []
-        assert os.path.isdir(directory), f"{directory} is not a directory!"
+        if not os.path.isdir(directory):
+            raise FileNotFoundError(f"{directory} is not a directory!")
         for root, dirs, files in os.walk(directory):
             if (
                 "type_map.raw" in files


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when importing mixed-format data from an invalid path.
  * A clear `FileNotFoundError` is now raised when the supplied path is not a directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->