### PR TITLE
Update for qe v7.2

### DIFF
--- a/dpdata/qe/scf.py
+++ b/dpdata/qe/scf.py
@@ -110,7 +110,7 @@ def get_energy(lines):
 def get_force(lines, natoms):
     blk = get_block(lines, "Forces acting on atoms", skip=1)
     ret = []
-    blk = blk[0:sum(natoms)]
+    blk = blk[0 : sum(natoms)]
     for ii in blk:
         ret.append([float(jj) for jj in ii.split("=")[1].split()])
     ret = np.array(ret)
@@ -147,7 +147,7 @@ def get_frame(fname):
     cell = get_cell(inlines)
     atom_names, natoms, types, coords = get_coords(inlines, cell)
     energy = get_energy(outlines)
-    force = get_force (outlines, natoms)
+    force = get_force(outlines, natoms)
     stress = get_stress(outlines) * np.linalg.det(cell)
     return (
         atom_names,

--- a/dpdata/qe/scf.py
+++ b/dpdata/qe/scf.py
@@ -107,9 +107,10 @@ def get_energy(lines):
     return energy
 
 
-def get_force(lines):
+def get_force(lines, natoms):
     blk = get_block(lines, "Forces acting on atoms", skip=1)
     ret = []
+    blk = blk[0:sum(natoms)]
     for ii in blk:
         ret.append([float(jj) for jj in ii.split("=")[1].split()])
     ret = np.array(ret)
@@ -146,7 +147,7 @@ def get_frame(fname):
     cell = get_cell(inlines)
     atom_names, natoms, types, coords = get_coords(inlines, cell)
     energy = get_energy(outlines)
-    force = get_force(outlines)
+    force = get_force (outlines, natoms)
     stress = get_stress(outlines) * np.linalg.det(cell)
     return (
         atom_names,


### PR DESCRIPTION
From QE v7.2, pw.x prints each contributions to forces acting on atoms (i.e. non-local, ionic, local, core correction, etc...), right after original 'Forces acting on atoms' without blank line. Thus, it make 'list index out of range' error, from ret.append(...) in get_force.

This changes make length of list blk in get_forces same as total number of atoms, avoiding out of range error.