### PR TITLE
keep atom types when using DP models

### DIFF
--- a/dpdata/plugins/deepmd.py
+++ b/dpdata/plugins/deepmd.py
@@ -394,8 +394,10 @@ class DPDriver(Driver):
         type_map = self.dp.get_type_map()
 
         ori_sys = dpdata.System.from_dict({"data": data})
+        ori_sys_copy = ori_sys.copy()
         ori_sys.sort_atom_names(type_map=type_map)
         atype = ori_sys["atom_types"]
+        ori_sys = ori_sys_copy
 
         if not self.enable_auto_batch_size:
             labeled_sys = dpdata.LabeledSystem()


### PR DESCRIPTION
Before this PR, when using DP models to predict energies and forces, the atom types were changed in the returned system according to the type map in the model. This is not an expected behavior. The changed atom types should only be used for internal inference.