### PR TITLE
fix: writing abacus stru.

### DIFF
--- a/dpdata/abacus/scf.py
+++ b/dpdata/abacus/scf.py
@@ -327,10 +327,11 @@ def make_unlabeled_stru(
         out += "0.0\n"
         out += str(data["atom_numbs"][iele]) + "\n"
         for iatom in range(data["atom_numbs"][iele]):
+            iatomtype = np.nonzero(data["atom_types"] == iele)[0][iatom]
             out += "%.12f %.12f %.12f %d %d %d\n" % (
-                data["coords"][frame_idx][natom_tot, 0],
-                data["coords"][frame_idx][natom_tot, 1],
-                data["coords"][frame_idx][natom_tot, 2],
+                data["coords"][frame_idx][iatomtype, 0],
+                data["coords"][frame_idx][iatomtype, 1],
+                data["coords"][frame_idx][iatomtype, 2],
                 1,
                 1,
                 1,


### PR DESCRIPTION
When using system.to() and convert data to write ABACUS `STRU` file, func `make_unlabeled_stru` won't use `atom_types` in data and miswriting the atom order. 
For example when using data from gaussian/log and other file using ungrouped atom coordinations,as the `atom_types=[0,1,1,1,2,1]` the func will write wrong coordinations and regard the atom as  `atom_types=[0,1,1,1,1,2]`  which cause serious problem.