### PR TITLE
avoid modifying appended system

### DIFF
--- a/dpdata/system.py
+++ b/dpdata/system.py
@@ -3,7 +3,7 @@ import glob
 import os
 from copy import deepcopy
 from enum import Enum, unique
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, Optional, Tuple, Union
 
 import numpy as np
 from monty.json import MSONable


### PR DESCRIPTION
When `sys1.append(sys2)`, we do not hope that `sys2` to be modified in any way.