### PR TITLE
[Fix bug] dpdata.gaussian.log plugin can't locate the coords

### DIFF
--- a/dpdata/gaussian/log.py
+++ b/dpdata/gaussian/log.py
@@ -31,11 +31,17 @@ def to_system_data(file_name, md=False):
             ):
                 flag = 1
                 forces = []
-            elif line.startswith(
-                "                          Input orientation:"
-            ) or line.startswith("                         Z-Matrix orientation:"
-            ) or (line.strip() == "Standard orientation:" and not locals().get('coords', None)):  # TODO: Modified
-                flag = 11 if line.strip() == "Standard orientation:" else 5  # TODO: Modified
+            elif (
+                line.startswith("                          Input orientation:")
+                or line.startswith("                         Z-Matrix orientation:")
+                or (
+                    line.strip() == "Standard orientation:"
+                    and not locals().get("coords", None)
+                )
+            ):  # TODO: Modified
+                flag = (
+                    11 if line.strip() == "Standard orientation:" else 5
+                )  # TODO: Modified
                 coords = []
                 atom_symbols = []
                 cells = []

--- a/dpdata/gaussian/log.py
+++ b/dpdata/gaussian/log.py
@@ -33,13 +33,14 @@ def to_system_data(file_name, md=False):
                 forces = []
             elif line.startswith(
                 "                          Input orientation:"
-            ) or line.startswith("                         Z-Matrix orientation:"):
-                flag = 5
+            ) or line.startswith("                         Z-Matrix orientation:"
+            ) or (line.strip() == "Standard orientation:" and not locals().get('coords', None)):  # TODO: Modified
+                flag = 11 if line.strip() == "Standard orientation:" else 5  # TODO: Modified
                 coords = []
                 atom_symbols = []
                 cells = []
 
-            if 1 <= flag <= 3 or 5 <= flag <= 9:
+            if 1 <= flag <= 3 or 5 <= flag <= 9 or 11 <= flag <= 15:  # TODO: Modified
                 flag += 1
             elif flag == 4:
                 # forces
@@ -64,7 +65,7 @@ def to_system_data(file_name, md=False):
                         forces.append(
                             [float(line[23:38]), float(line[38:53]), float(line[53:68])]
                         )
-            elif flag == 10:
+            elif flag == 10 or flag == 16:  # TODO: Modified
                 # atom_symbols and coords
                 if line.startswith(" -------"):
                     flag = 0


### PR DESCRIPTION
At present, the plugin reading gaussian log file identifies the coords context by title: "Z-Matrix orientation:" and "Input orientation:". In general, it works fine. However, the log file, sometimes, might only record the "Standard orientation:" coords. In the case, the coords can't be localized by the current plugin and will raise the UnboundLocalError.

The following is the bug-raised code:
```python
import dpdata
ls = dpdata.LabeledSystem('pair_3.log', fmt='gaussian/md')
```
The error message:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/pub/conda3/envs/hpu/lib/python3.9/site-packages/dpdata/system.py", line 281, in __init__
    self.from_fmt(
  File "/home/pub/conda3/envs/hpu/lib/python3.9/site-packages/dpdata/system.py", line 318, in from_fmt
    return self.from_fmt_obj(load_format(fmt), file_name, **kwargs)
  File "/home/pub/conda3/envs/hpu/lib/python3.9/site-packages/dpdata/system.py", line 1162, in from_fmt_obj
    data = fmtobj.from_labeled_system(file_name, **kwargs)
  File "/home/pub/conda3/envs/hpu/lib/python3.9/site-packages/dpdata/plugins/gaussian.py", line 23, in from_labeled_system
    return GaussianLogFormat().from_labeled_system(file_name, md=True)
  File "/home/pub/conda3/envs/hpu/lib/python3.9/site-packages/dpdata/plugins/gaussian.py", line 15, in from_labeled_system
    return dpdata.gaussian.log.to_system_data(file_name, md=md)
  File "/home/pub/conda3/envs/hpu/lib/python3.9/site-packages/dpdata/gaussian/log.py", line 49, in to_system_data
    coords_t.append(coords)
UnboundLocalError: local variable 'coords' referenced before assignment
```

The system and envoriments:

- Operate System: Ubuntu 22.04 lts
- Python: 3.9.0
- dpdata version: 0.2.15

This error can be resolved by making a little modification to a portion of the code: 1) Add a new conditional branch to recognize "Standard orientation:" 2) read the Standard coordinates when meet the flag == 16

The modified code like the following (The modified have been marked by '# TODO: Modified'). **This modification would not make changes for the general case, where the "input orientation:" or "Z-Matrix orientation:" is in the text, because of the "Input orientation:" and "Z-Matrix orientation:" are always on the above of "Standard orientation:"**

The following modification has been **tested** on my machine and **works fine** in both the general case and the above bug-raised case. 