### PR TITLE
replace the old data type with the same name and throw warning

### DIFF
--- a/dpdata/system.py
+++ b/dpdata/system.py
@@ -1,6 +1,7 @@
 # %%
 import glob
 import os
+import warning
 from copy import deepcopy
 from typing import Any, Dict, Optional, Tuple, Union
 
@@ -963,7 +964,13 @@ class System(MSONable):
         *data_type : tuple[DataType]
             data type to be regiestered
         """
-        cls.DTYPES = cls.DTYPES + tuple(data_type)
+        all_dtypes = cls.DTYPES + tuple(data_type)
+        dtypes_dict = {}
+        for dt in all_dtypes:
+            if dt.name in dtypes_dict:
+                warnings.warn(f"Data type {dt.name} is registered twice; only the newly registered one will be used.", UserWarning)
+            dtypes_dict[dt.name] = dt
+        cls.DTYPES = tuple(dtypes_dict.values())
 
 
 def get_cell_perturb_matrix(cell_pert_fraction):

--- a/dpdata/system.py
+++ b/dpdata/system.py
@@ -1,7 +1,6 @@
 # %%
 import glob
 import os
-import warning
 from copy import deepcopy
 from typing import Any, Dict, Optional, Tuple, Union
 
@@ -968,7 +967,10 @@ class System(MSONable):
         dtypes_dict = {}
         for dt in all_dtypes:
             if dt.name in dtypes_dict:
-                warnings.warn(f"Data type {dt.name} is registered twice; only the newly registered one will be used.", UserWarning)
+                warnings.warn(
+                    f"Data type {dt.name} is registered twice; only the newly registered one will be used.",
+                    UserWarning,
+                )
             dtypes_dict[dt.name] = dt
         cls.DTYPES = tuple(dtypes_dict.values())
 

--- a/dpdata/system.py
+++ b/dpdata/system.py
@@ -1,6 +1,7 @@
 # %%
 import glob
 import os
+import warnings
 from copy import deepcopy
 from typing import Any, Dict, Optional, Tuple, Union
 

--- a/tests/test_custom_data_type.py
+++ b/tests/test_custom_data_type.py
@@ -53,6 +53,7 @@ class TestDeepmdLoadDumpComp(unittest.TestCase):
         n_dtypes_new = len(dpdata.LabeledSystem.DTYPES)
         self.assertEqual(n_dtypes_old, n_dtypes_new)
 
+
 class TestDeepmdLoadDumpCompAny(unittest.TestCase):
     def setUp(self):
         self.system = dpdata.LabeledSystem("poscars/OUTCAR.h2o.md", fmt="vasp/outcar")

--- a/tests/test_custom_data_type.py
+++ b/tests/test_custom_data_type.py
@@ -4,6 +4,7 @@ import h5py
 import numpy as np
 
 import dpdata
+from dpdata.data_type import Axis, DataType
 
 
 class TestDeepmdLoadDumpComp(unittest.TestCase):
@@ -44,6 +45,13 @@ class TestDeepmdLoadDumpComp(unittest.TestCase):
         x = dpdata.LabeledSystem("data_foo.h5", fmt="deepmd/hdf5")
         np.testing.assert_allclose(x.data["foo"], self.foo)
 
+    def test_duplicated_data_type(self):
+        dt = DataType("foo", np.ndarray, (Axis.NFRAMES, 2, 4), required=False)
+        n_dtypes_old = len(dpdata.LabeledSystem.DTYPES)
+        with self.assertWarns(UserWarning):
+            dpdata.LabeledSystem.register_data_type(dt)
+        n_dtypes_new = len(dpdata.LabeledSystem.DTYPES)
+        self.assertEqual(n_dtypes_old, n_dtypes_new)
 
 class TestDeepmdLoadDumpCompAny(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
When a data type is unexpectedly registered twice, the behavior of some methods will be strange (for example, `append`).

For this reason, the old one is replaced, and a warning is thrown.