### PR TITLE
raise error instead of sys.exit

### DIFF
--- a/dpdata/qe/scf.py
+++ b/dpdata/qe/scf.py
@@ -55,7 +55,7 @@ def get_cell(lines):
             raise RuntimeError("parameter 'a' or 'celldm(1)' cannot be found.")
         ret = np.array([[a, 0.0, 0.0], [0.0, a, 0.0], [0.0, 0.0, a]])
     else:
-        sys.exit("ibrav > 1 not supported yet.")
+        raise RuntimeError("ibrav > 1 not supported yet.")
     return ret
 
 

--- a/dpdata/qe/scf.py
+++ b/dpdata/qe/scf.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import os
-import sys
 
 import numpy as np
 


### PR DESCRIPTION
`sys.exit` is a lousy implementation when one wants to catch the error.