### PR TITLE
Enable loading of virials for 'qe/cp/traj' if prefix.str file is present

### DIFF
--- a/dpdata/plugins/qe.py
+++ b/dpdata/plugins/qe.py
@@ -1,8 +1,9 @@
+import numpy as np
+
 import dpdata.md.pbc
 import dpdata.qe.scf
 import dpdata.qe.traj
 from dpdata.format import Format
-import numpy as np
 
 
 @Format.register("qe/cp/traj")

--- a/dpdata/plugins/qe.py
+++ b/dpdata/plugins/qe.py
@@ -2,6 +2,7 @@ import dpdata.md.pbc
 import dpdata.qe.scf
 import dpdata.qe.traj
 from dpdata.format import Format
+import numpy as np
 
 
 @Format.register("qe/cp/traj")
@@ -26,9 +27,13 @@ class QECPTrajFormat(Format):
             data["coords"],
             data["cells"],
         )
-        data["energies"], data["forces"], es = dpdata.qe.traj.to_system_label(
+        data["energies"], data["forces"], stress, es = dpdata.qe.traj.to_system_label(
             file_name + ".in", file_name, begin=begin, step=step
         )
+        if stress is not None:
+            # Compute virials of all frames by: virial = stress * volume
+            virial = stress * np.linalg.det(data["cells"])[:, np.newaxis, np.newaxis]
+            data["virials"] = virial
         assert cs == es, "the step key between files are not consistent"
         return data
 

--- a/dpdata/qe/traj.py
+++ b/dpdata/qe/traj.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 import warnings
+import os
 
 import numpy as np
 
@@ -16,6 +17,7 @@ kbar2evperang3 = PressureConversion("kbar", "eV/angstrom^3").value()
 length_convert = LengthConversion("bohr", "angstrom").value()
 energy_convert = EnergyConversion("hartree", "eV").value()
 force_convert = ForceConversion("hartree/bohr", "eV/angstrom").value()
+stress_convert = PressureConversion("GPa", "eV/angstrom^3").value()
 
 
 def load_key(lines, key):
@@ -233,8 +235,15 @@ def to_system_label(input_name, prefix, begin=0, step=1):
         step=step,
         convert=force_convert,
     )
-    assert esteps == fsteps, "the step key between files are not consistent "
-    return energy, force, esteps
+    # Load stress from .str file if it exists
+    if os.path.isfile(prefix + ".str"):
+        stress, vsteps = load_data(
+            prefix + ".str", 3, begin=begin, step=step, convert=stress_convert
+        )
+    else:
+        stress, vsteps = None, esteps
+    assert esteps == fsteps == vsteps, "the step key between files are not consistent "
+    return energy, force, stress, esteps
 
 
 if __name__ == "__main__":

--- a/dpdata/qe/traj.py
+++ b/dpdata/qe/traj.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
-import warnings
 import os
+import warnings
 
 import numpy as np
 


### PR DESCRIPTION
Currently the virials are not read when reading a QE cp.x MD. But the stresses are printed in the `prefix.str` by default. This PR adds support to load virials if this file is present.