### PR TITLE
fix: use deepcopy when dumping mixed types

### DIFF
--- a/dpdata/deepmd/mixed.py
+++ b/dpdata/deepmd/mixed.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import glob
 import os
 import shutil
+import copy
 
 import numpy as np
 
@@ -159,6 +160,8 @@ def dump(folder, data, set_size=2000, comp_prec=np.float32, remove_sets=True):
     # if not converted to mixed
     if "real_atom_types" not in data:
         from dpdata import LabeledSystem, System
+        # not change the original content
+        data = copy.deepcopy(data)
 
         if "energies" in data:
             temp_sys = LabeledSystem(data=data)

--- a/dpdata/deepmd/mixed.py
+++ b/dpdata/deepmd/mixed.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
+import copy
 import glob
 import os
 import shutil
-import copy
 
 import numpy as np
 
@@ -160,6 +160,7 @@ def dump(folder, data, set_size=2000, comp_prec=np.float32, remove_sets=True):
     # if not converted to mixed
     if "real_atom_types" not in data:
         from dpdata import LabeledSystem, System
+
         # not change the original content
         data = copy.deepcopy(data)
 

--- a/tests/test_deepmd_mixed.py
+++ b/tests/test_deepmd_mixed.py
@@ -314,9 +314,7 @@ class TestMixedMultiSystemsTypeChange(
         )
 
 
-class TestMixedSingleSystemsDump(
-    unittest.TestCase, CompLabeledSys, IsNoPBC
-):
+class TestMixedSingleSystemsDump(unittest.TestCase, CompLabeledSys, IsNoPBC):
     def setUp(self):
         self.places = 6
         self.e_places = 6
@@ -331,7 +329,7 @@ class TestMixedSingleSystemsDump(
             "gaussian/methane.gaussianlog", fmt="gaussian/log"
         )
         # test dump
-        self.system_1.to('deepmd/npy/mixed', "tmp.deepmd.mixed.single")
+        self.system_1.to("deepmd/npy/mixed", "tmp.deepmd.mixed.single")
 
     def tearDown(self):
         if os.path.exists("tmp.deepmd.mixed.single"):

--- a/tests/test_deepmd_mixed.py
+++ b/tests/test_deepmd_mixed.py
@@ -314,5 +314,29 @@ class TestMixedMultiSystemsTypeChange(
         )
 
 
+class TestMixedSingleSystemsDump(
+    unittest.TestCase, CompLabeledSys, IsNoPBC
+):
+    def setUp(self):
+        self.places = 6
+        self.e_places = 6
+        self.f_places = 6
+        self.v_places = 6
+
+        # C1H4
+        self.system_1 = dpdata.LabeledSystem(
+            "gaussian/methane.gaussianlog", fmt="gaussian/log"
+        )
+        self.system_2 = dpdata.LabeledSystem(
+            "gaussian/methane.gaussianlog", fmt="gaussian/log"
+        )
+        # test dump
+        self.system_1.to('deepmd/npy/mixed', "tmp.deepmd.mixed.single")
+
+    def tearDown(self):
+        if os.path.exists("tmp.deepmd.mixed.single"):
+            shutil.rmtree("tmp.deepmd.mixed.single")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Use deepcopy when dumping mixed types in system level. Fix #670 .

Typically, users use the following command to dump list of systems to mixed_type:
```
dpdata.MultiSystems(*systems).to_deepmd_npy_mixed("mixed_dir")
```
This command will rebuild a new system with a new data dict, thus it **does not change the original `system.data`**.

In #670 , when users use 
```
system.to('deepmd/npy/mixed', 'dir') 
```
on a system in standard format, it would directly convert the original `system.data` into mixed types, thus the original `system.data` would be changed.

Use deepcopy to prevent this.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced data integrity by preserving the original content before processing.

- **Tests**
  - Added new tests to ensure proper functionality of the data dumping process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->