### PR TITLE
fix: only apply comp_prec for floating dtypes

### DIFF
--- a/dpdata/deepmd/comp.py
+++ b/dpdata/deepmd/comp.py
@@ -203,7 +203,9 @@ def dump(folder, data, set_size=5000, comp_prec=np.float32, remove_sets=True):
                 f"Shape of {dtype.name} is not (nframes, ...), but {dtype.shape}. This type of data will not converted to deepmd/npy format."
             )
             continue
-        ddata = np.reshape(data[dtype.name], [nframes, -1]).astype(comp_prec)
+        ddata = np.reshape(data[dtype.name], [nframes, -1])
+        if np.issubdtype(ddata.dtype, np.floating):
+            ddata = ddata.astype(comp_prec)
         for ii in range(nsets):
             set_stt = ii * set_size
             set_end = (ii + 1) * set_size

--- a/dpdata/deepmd/hdf5.py
+++ b/dpdata/deepmd/hdf5.py
@@ -252,9 +252,10 @@ def dump(
     for dt, prop in data_types.items():
         if dt in data:
             if prop["dump"]:
-                reshaped_data[dt] = np.reshape(data[dt], prop["shape"]).astype(
-                    comp_prec
-                )
+                ddata = np.reshape(data[dt], prop["shape"])
+                if np.issubdtype(ddata.dtype, np.floating):
+                    ddata = ddata.astype(comp_prec)
+                reshaped_data[dt] = ddata
 
     # dump frame properties: cell, coord, energy, force and virial
     nsets = nframes // set_size


### PR DESCRIPTION
Fix #703.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved handling of data types during the reshaping process, ensuring type conversion only occurs for floating-point data.

- **Bug Fixes**
  - Enhanced robustness of data processing by preventing unnecessary type casting for non-floating-point data types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->