### PR TITLE
docs: fix directives

### DIFF
--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -1,7 +1,7 @@
 # Plugins
 
 One can follow a simple example under `plugin_example/` directory to add their own format by creating and installing plugins.
-It's critical to add the {class}`Format` class to `entry_points['dpdata.plugins']` in `pyproject.toml`:
+It's critical to add the {class}`Format <dpdata.format.Format>` class to `entry_points['dpdata.plugins']` in `pyproject.toml`:
 
 ```toml
 [project.entry-points.'dpdata.plugins']

--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -1,7 +1,7 @@
 # Plugins
 
 One can follow a simple example under `plugin_example/` directory to add their own format by creating and installing plugins.
-It's critical to add the :class:`Format` class to `entry_points['dpdata.plugins']` in `pyproject.toml`:
+It's critical to add the {class}`Format` class to `entry_points['dpdata.plugins']` in `pyproject.toml`:
 
 ```toml
 [project.entry-points.'dpdata.plugins']

--- a/docs/systems/bond_order_system.md
+++ b/docs/systems/bond_order_system.md
@@ -1,6 +1,6 @@
 
 ## BondOrderSystem
-A new class :class:`BondOrderSystem` which inherits from class :class:`System` is introduced in dpdata. This new class contains information of chemical bonds and formal charges (stored in `BondOrderSystem.data['bonds']`, `BondOrderSystem.data['formal_charges']`). Now BondOrderSystem can only read from .mol/.sdf formats, because of its dependency on rdkit (which means rdkit must be installed if you want to use this function). Other formats, such as pdb, must be converted to .mol/.sdf format (maybe with software like open babel).
+A new class {class}`BondOrderSystem` which inherits from class {class}`System` is introduced in dpdata. This new class contains information of chemical bonds and formal charges (stored in `BondOrderSystem.data['bonds']`, `BondOrderSystem.data['formal_charges']`). Now BondOrderSystem can only read from .mol/.sdf formats, because of its dependency on rdkit (which means rdkit must be installed if you want to use this function). Other formats, such as pdb, must be converted to .mol/.sdf format (maybe with software like open babel).
 ```python
 import dpdata
 
@@ -12,7 +12,7 @@ system_2 = dpdata.BondOrderSystem(
 )  # read from .sdf file
 ```
 In sdf file, all molecules must be of the same topology (i.e. conformers of the same molecular configuration).
-`BondOrderSystem` also supports initialize from a :class:`rdkit.Chem.rdchem.Mol` object directly.
+`BondOrderSystem` also supports initialize from a {class}`rdkit.Chem.rdchem.Mol` object directly.
 ```python
 from rdkit import Chem
 from rdkit.Chem import AllChem
@@ -25,7 +25,7 @@ system = dpdata.BondOrderSystem(rdkit_mol=mol)
 ```
 
 ### Bond Order Assignment
-The :class:`BondOrderSystem` implements a more robust sanitize procedure for rdkit Mol, as defined in :class:`dpdata.rdkit.santizie.Sanitizer`. This class defines 3 level of sanitization process by: low, medium and high. (default is medium).
+The {class}`BondOrderSystem` implements a more robust sanitize procedure for rdkit Mol, as defined in {class}`dpdata.rdkit.santizie.Sanitizer`. This class defines 3 level of sanitization process by: low, medium and high. (default is medium).
 + low: use `rdkit.Chem.SanitizeMol()` function to sanitize molecule.
 + medium: before using rdkit, the programm will first assign formal charge of each atom to avoid inappropriate valence exceptions. However, this mode requires the rightness of the bond order information in the given molecule.
 + high: the program will try to fix inappropriate bond orders in aromatic hetreocycles, phosphate, sulfate, carboxyl, nitro, nitrine, guanidine groups. If this procedure fails to sanitize the given molecule, the program will then try to call `obabel` to pre-process the mol and repeat the sanitization procedure. **That is to say, if you wan't to use this level of sanitization, please ensure `obabel` is installed in the environment.**

--- a/docs/systems/bond_order_system.md
+++ b/docs/systems/bond_order_system.md
@@ -1,6 +1,6 @@
 
 ## BondOrderSystem
-A new class {class}`BondOrderSystem` which inherits from class {class}`System` is introduced in dpdata. This new class contains information of chemical bonds and formal charges (stored in `BondOrderSystem.data['bonds']`, `BondOrderSystem.data['formal_charges']`). Now BondOrderSystem can only read from .mol/.sdf formats, because of its dependency on rdkit (which means rdkit must be installed if you want to use this function). Other formats, such as pdb, must be converted to .mol/.sdf format (maybe with software like open babel).
+A new class {class}`BondOrderSystem <dpdata.BondOrderSystem>` which inherits from class {class}`System <dpdata.System>` is introduced in dpdata. This new class contains information of chemical bonds and formal charges (stored in `BondOrderSystem.data['bonds']`, `BondOrderSystem.data['formal_charges']`). Now BondOrderSystem can only read from .mol/.sdf formats, because of its dependency on rdkit (which means rdkit must be installed if you want to use this function). Other formats, such as pdb, must be converted to .mol/.sdf format (maybe with software like open babel).
 ```python
 import dpdata
 
@@ -12,7 +12,7 @@ system_2 = dpdata.BondOrderSystem(
 )  # read from .sdf file
 ```
 In sdf file, all molecules must be of the same topology (i.e. conformers of the same molecular configuration).
-`BondOrderSystem` also supports initialize from a {class}`rdkit.Chem.rdchem.Mol` object directly.
+`BondOrderSystem <dpdata.BondOrderSystem>` also supports initialize from a {class}`rdkit.Chem.rdchem.Mol` object directly.
 ```python
 from rdkit import Chem
 from rdkit.Chem import AllChem
@@ -25,7 +25,7 @@ system = dpdata.BondOrderSystem(rdkit_mol=mol)
 ```
 
 ### Bond Order Assignment
-The {class}`BondOrderSystem` implements a more robust sanitize procedure for rdkit Mol, as defined in {class}`dpdata.rdkit.santizie.Sanitizer`. This class defines 3 level of sanitization process by: low, medium and high. (default is medium).
+The {class}`BondOrderSystem <dpdata.BondOrderSystem>` implements a more robust sanitize procedure for rdkit Mol, as defined in {class}`dpdata.rdkit.santizie.Sanitizer`. This class defines 3 level of sanitization process by: low, medium and high. (default is medium).
 + low: use `rdkit.Chem.SanitizeMol()` function to sanitize molecule.
 + medium: before using rdkit, the programm will first assign formal charge of each atom to avoid inappropriate valence exceptions. However, this mode requires the rightness of the bond order information in the given molecule.
 + high: the program will try to fix inappropriate bond orders in aromatic hetreocycles, phosphate, sulfate, carboxyl, nitro, nitrine, guanidine groups. If this procedure fails to sanitize the given molecule, the program will then try to call `obabel` to pre-process the mol and repeat the sanitization procedure. **That is to say, if you wan't to use this level of sanitization, please ensure `obabel` is installed in the environment.**

--- a/docs/systems/mixed.md
+++ b/docs/systems/mixed.md
@@ -1,6 +1,6 @@
 # Mixed Type Format
 
-The format `deepmd/npy/mixed` is the mixed type numpy format for DeePMD-kit, and can be loaded or dumped through class :class:`dpdata.MultiSystems`.
+The format `deepmd/npy/mixed` is the mixed type numpy format for DeePMD-kit, and can be loaded or dumped through class {class}`dpdata.MultiSystems`.
 
 Under this format, systems with the same number of atoms but different formula can be put together
 for a larger system, especially when the frame numbers in systems are sparse.

--- a/docs/systems/multi.md
+++ b/docs/systems/multi.md
@@ -1,15 +1,15 @@
 # `MultiSystems`
 
-The Class :class:`dpdata.MultiSystems`  can read data  from a dir which may contains many files of different systems, or from single xyz file which contains different systems.
+The Class {class}`dpdata.MultiSystems`  can read data  from a dir which may contains many files of different systems, or from single xyz file which contains different systems.
 
-Use :meth:`dpdata.MultiSystems.from_dir` to read from a  directory, :class:`dpdata.MultiSystems` will walk in the directory
-Recursively  and  find all file with specific file_name. Supports all the file formats that :class:`dpdata.LabeledSystem` supports.
+Use {meth}`dpdata.MultiSystems.from_dir` to read from a  directory, {class}`dpdata.MultiSystems` will walk in the directory
+Recursively  and  find all file with specific file_name. Supports all the file formats that {class}`dpdata.LabeledSystem` supports.
 
-Use :meth:`dpdata.MultiSystems.from_file` to read from single file. Single-file support is available for the `quip/gap/xyz` and `ase/structure` formats.
+Use {meth}`dpdata.MultiSystems.from_file` to read from single file. Single-file support is available for the `quip/gap/xyz` and `ase/structure` formats.
 
 For example, for `quip/gap xyz` files, single .xyz file may contain many different configurations with different atom numbers and atom type.
 
-The following commands relating to :class:`dpdata.MultiSystems` may be useful.
+The following commands relating to {class}`dpdata.MultiSystems` may be useful.
 ```python
 # load data
 

--- a/docs/systems/system.md
+++ b/docs/systems/system.md
@@ -19,7 +19,7 @@ or let dpdata infer the format (`vasp/poscar`) of the file from the file name ex
 ```python
 d_poscar = dpdata.System("my.POSCAR")
 ```
-The number of atoms, atom types, coordinates are loaded from the `POSCAR` and stored to a data {class}`System` called `d_poscar`.
+The number of atoms, atom types, coordinates are loaded from the `POSCAR` and stored to a data {class}`System <dpdata.System>` called `d_poscar`.
 A data {class}`System <dpdata.System>` (a concept used by [deepmd-kit](https://github.com/deepmodeling/deepmd-kit)) contains frames that has the same number of atoms of the same type. The order of the atoms should be consistent among the frames in one {class}`System <dpdata.System>`.
 It is noted that `POSCAR` only contains one frame.
 If the multiple frames stored in, for example, a `OUTCAR` is wanted,

--- a/docs/systems/system.md
+++ b/docs/systems/system.md
@@ -20,20 +20,20 @@ or let dpdata infer the format (`vasp/poscar`) of the file from the file name ex
 d_poscar = dpdata.System("my.POSCAR")
 ```
 The number of atoms, atom types, coordinates are loaded from the `POSCAR` and stored to a data {class}`System` called `d_poscar`.
-A data {class}`System` (a concept used by [deepmd-kit](https://github.com/deepmodeling/deepmd-kit)) contains frames that has the same number of atoms of the same type. The order of the atoms should be consistent among the frames in one {class}`System`.
+A data {class}`System <dpdata.System>` (a concept used by [deepmd-kit](https://github.com/deepmodeling/deepmd-kit)) contains frames that has the same number of atoms of the same type. The order of the atoms should be consistent among the frames in one {class}`System <dpdata.System>`.
 It is noted that `POSCAR` only contains one frame.
 If the multiple frames stored in, for example, a `OUTCAR` is wanted,
 ```python
 d_outcar = dpdata.LabeledSystem("OUTCAR")
 ```
-The labels provided in the `OUTCAR`, i.e. energies, forces and virials (if any), are loaded by {class}`LabeledSystem`. It is noted that the forces of atoms are always assumed to exist. {class}`LabeledSystem` is a derived class of {class}`System`.
+The labels provided in the `OUTCAR`, i.e. energies, forces and virials (if any), are loaded by {class}`LabeledSystem <dpdata.LabeledSystem>`. It is noted that the forces of atoms are always assumed to exist. {class}`LabeledSystem <dpdata.LabeledSystem>` is a derived class of {class}`System <dpdata.System>`.
 
-The {class}`System` or {class}`LabeledSystem` can be constructed from the following file formats with the `format key` in the table passed to argument `fmt`:
+The {class}`System <dpdata.System>` or {class}`LabeledSystem <dpdata.LabeledSystem>` can be constructed from the following file formats with the `format key` in the table passed to argument `fmt`:
 
 
 
 ### Access data
-These properties stored in {class}`System` and {class}`LabeledSystem` can be accessed by operator `[]` with the key of the property supplied, for example
+These properties stored in {class}`System <dpdata.System>` and {class}`LabeledSystem <dpdata.LabeledSystem>` can be accessed by operator `[]` with the key of the property supplied, for example
 ```python
 coords = d_outcar["coords"]
 ```
@@ -52,7 +52,7 @@ Available properties are (nframe: number of frames in the system, natoms: total 
 
 
 ### Dump data
-The data stored in {class}`System` or {class}`LabeledSystem` can be dumped in 'lammps/lmp' or 'vasp/poscar' format, for example:
+The data stored in {class}`System <dpdata.System>` or {class}`LabeledSystem <dpdata.LabeledSystem>` can be dumped in 'lammps/lmp' or 'vasp/poscar' format, for example:
 ```python
 d_outcar.to("lammps/lmp", "conf.lmp", frame_idx=0)
 ```

--- a/docs/systems/system.md
+++ b/docs/systems/system.md
@@ -19,21 +19,21 @@ or let dpdata infer the format (`vasp/poscar`) of the file from the file name ex
 ```python
 d_poscar = dpdata.System("my.POSCAR")
 ```
-The number of atoms, atom types, coordinates are loaded from the `POSCAR` and stored to a data :class:`System` called `d_poscar`.
-A data :class:`System` (a concept used by [deepmd-kit](https://github.com/deepmodeling/deepmd-kit)) contains frames that has the same number of atoms of the same type. The order of the atoms should be consistent among the frames in one :class:`System`.
+The number of atoms, atom types, coordinates are loaded from the `POSCAR` and stored to a data {class}`System` called `d_poscar`.
+A data {class}`System` (a concept used by [deepmd-kit](https://github.com/deepmodeling/deepmd-kit)) contains frames that has the same number of atoms of the same type. The order of the atoms should be consistent among the frames in one {class}`System`.
 It is noted that `POSCAR` only contains one frame.
 If the multiple frames stored in, for example, a `OUTCAR` is wanted,
 ```python
 d_outcar = dpdata.LabeledSystem("OUTCAR")
 ```
-The labels provided in the `OUTCAR`, i.e. energies, forces and virials (if any), are loaded by :class:`LabeledSystem`. It is noted that the forces of atoms are always assumed to exist. :class:`LabeledSystem` is a derived class of :class:`System`.
+The labels provided in the `OUTCAR`, i.e. energies, forces and virials (if any), are loaded by {class}`LabeledSystem`. It is noted that the forces of atoms are always assumed to exist. {class}`LabeledSystem` is a derived class of {class}`System`.
 
-The :class:`System` or :class:`LabeledSystem` can be constructed from the following file formats with the `format key` in the table passed to argument `fmt`:
+The {class}`System` or {class}`LabeledSystem` can be constructed from the following file formats with the `format key` in the table passed to argument `fmt`:
 
 
 
 ### Access data
-These properties stored in :class:`System` and :class:`LabeledSystem` can be accessed by operator `[]` with the key of the property supplied, for example
+These properties stored in {class}`System` and {class}`LabeledSystem` can be accessed by operator `[]` with the key of the property supplied, for example
 ```python
 coords = d_outcar["coords"]
 ```
@@ -52,7 +52,7 @@ Available properties are (nframe: number of frames in the system, natoms: total 
 
 
 ### Dump data
-The data stored in :class:`System` or :class:`LabeledSystem` can be dumped in 'lammps/lmp' or 'vasp/poscar' format, for example:
+The data stored in {class}`System` or {class}`LabeledSystem` can be dumped in 'lammps/lmp' or 'vasp/poscar' format, for example:
 ```python
 d_outcar.to("lammps/lmp", "conf.lmp", frame_idx=0)
 ```

--- a/docs/systems/system.md
+++ b/docs/systems/system.md
@@ -28,7 +28,7 @@ d_outcar = dpdata.LabeledSystem("OUTCAR")
 ```
 The labels provided in the `OUTCAR`, i.e. energies, forces and virials (if any), are loaded by {class}`LabeledSystem <dpdata.LabeledSystem>`. It is noted that the forces of atoms are always assumed to exist. {class}`LabeledSystem <dpdata.LabeledSystem>` is a derived class of {class}`System <dpdata.System>`.
 
-The {class}`System <dpdata.System>` or {class}`LabeledSystem <dpdata.LabeledSystem>` can be constructed from the following file formats with the `format key` in the table passed to argument `fmt`:
+The {class}`System <dpdata.System>` or {class}`LabeledSystem <dpdata.LabeledSystem>` can be constructed from the [supported file formats](../formats.rst) with the `format key` in the table passed to argument `fmt`.
 
 
 


### PR DESCRIPTION
The previous syntax is for RST files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced the `BondOrderSystem` class for managing chemical bond information with enhanced sanitization capabilities.

- **Documentation**
	- Updated class reference formatting across multiple documentation files for clarity and consistency, changing from colon to curly brace syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->