### PR TITLE
Update ase.py: To avoid errors in writing to the .extxyz format from an Atom object coverted from .npy with dpdata.

### DIFF
--- a/dpdata/plugins/ase.py
+++ b/dpdata/plugins/ase.py
@@ -181,7 +181,8 @@ class ASEStructureFormat(Format):
                 # v_pref = 1 * 1e4 / 1.602176621e6
                 vol = structure.get_volume()
                 # results['stress'] = data["virials"][ii] / (v_pref * vol)
-                results["stress"] = -data["virials"][ii] / vol
+                stress33 = -data["virials"][ii] / vol
+                results["stress"] = np.array([stress33[0][0],stress33[1][1],stress33[2][2],stress33[1][2],stress33[2][0],stress33[0][1]])
 
             structure.calc = SinglePointCalculator(structure, **results)
             structures.append(structure)

--- a/dpdata/plugins/ase.py
+++ b/dpdata/plugins/ase.py
@@ -188,7 +188,7 @@ class ASEStructureFormat(Format):
                         stress33[1][1],
                         stress33[2][2],
                         stress33[1][2],
-                        stress33[2][0],
+                        stress33[0][2],
                         stress33[0][1],
                     ]
                 )

--- a/dpdata/plugins/ase.py
+++ b/dpdata/plugins/ase.py
@@ -182,7 +182,16 @@ class ASEStructureFormat(Format):
                 vol = structure.get_volume()
                 # results['stress'] = data["virials"][ii] / (v_pref * vol)
                 stress33 = -data["virials"][ii] / vol
-                results["stress"] = np.array([stress33[0][0],stress33[1][1],stress33[2][2],stress33[1][2],stress33[2][0],stress33[0][1]])
+                results["stress"] = np.array(
+                    [
+                        stress33[0][0],
+                        stress33[1][1],
+                        stress33[2][2],
+                        stress33[1][2],
+                        stress33[2][0],
+                        stress33[0][1],
+                    ]
+                )
 
             structure.calc = SinglePointCalculator(structure, **results)
             structures.append(structure)


### PR DESCRIPTION
Stress store in an ASE SinglePointCalculator should be an 1×6 array, not be a 3×3 matrix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced stress value calculations to provide a more structured representation of the stress tensor components in results.
	- Improved handling of stress tensor components for better accuracy in subsequent calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->