### PR TITLE
fix(rtd): pin python to `<3.13` and mamba to `<2`

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "mambaforge-22.9"
+    python: "mambaforge-23.11"
 conda:
   environment: docs/rtd_environment.yml
 sphinx:

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,4 +1,4 @@
-name: dpdata
+name: dpdata-emscripten
 channels:
   - https://repo.mamba.pm/emscripten-forge
   - conda-forge

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,4 +1,4 @@
-name: dpdata-emscripten
+name: dpdata
 channels:
   - https://repo.mamba.pm/emscripten-forge
   - conda-forge

--- a/docs/rtd_environment.yml
+++ b/docs/rtd_environment.yml
@@ -3,5 +3,6 @@ channels:
   - conda-forge
 dependencies:
   - python <3.13
+  - conda
   - pip:
     - ..[docs]

--- a/docs/rtd_environment.yml
+++ b/docs/rtd_environment.yml
@@ -2,5 +2,6 @@ name: dpdata
 channels:
   - conda-forge
 dependencies:
+  - python <3.13
   - pip:
     - ..[docs]

--- a/docs/rtd_environment.yml
+++ b/docs/rtd_environment.yml
@@ -1,4 +1,4 @@
-name: dpdata-rtd
+name: dpdata
 channels:
   - conda-forge
 dependencies:

--- a/docs/rtd_environment.yml
+++ b/docs/rtd_environment.yml
@@ -3,6 +3,6 @@ channels:
   - conda-forge
 dependencies:
   - python <3.13
-  - mamba
+  - mamba <2
   - pip:
     - ..[docs]

--- a/docs/rtd_environment.yml
+++ b/docs/rtd_environment.yml
@@ -1,4 +1,4 @@
-name: dpdata
+name: dpdata-rtd
 channels:
   - conda-forge
 dependencies:

--- a/docs/rtd_environment.yml
+++ b/docs/rtd_environment.yml
@@ -3,6 +3,6 @@ channels:
   - conda-forge
 dependencies:
   - python <3.13
-  - conda
+  - mamba
   - pip:
     - ..[docs]

--- a/docs/rtd_environment.yml
+++ b/docs/rtd_environment.yml
@@ -2,6 +2,5 @@ name: dpdata
 channels:
   - conda-forge
 dependencies:
-  - mamba
   - pip:
     - ..[docs]


### PR DESCRIPTION
Fix the RTD build error. Pinning mamba to `<2` is a workaround for https://github.com/jupyterlite/xeus/issues/122.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Added a constraint specifying that the `python` dependency must be less than version 3.13.
	- Updated the Python version in the Read the Docs configuration to `mambaforge-23.11`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->