### PR TITLE
abacus: add checks on pp and orb in construction of STRU

### DIFF
--- a/dpdata/abacus/scf.py
+++ b/dpdata/abacus/scf.py
@@ -687,7 +687,8 @@ def make_unlabeled_stru(
         pp_file = ndarray2list(pp_file)
         ppfiles = None
         if isinstance(pp_file,(list, tuple)):
-            assert len(pp_file) == len(data["atom_names"]), "ERROR: make_unlabeled_stru: pp_file length is not equal to the number of atom types"
+            if len(pp_file) != len(data["atom_names"]):
+                raise RuntimeError("ERROR: make_unlabeled_stru: pp_file length is not equal to the number of atom types")
             ppfiles = pp_file
         elif isinstance(pp_file, dict):
             for iele in data["atom_names"]:
@@ -724,7 +725,8 @@ def make_unlabeled_stru(
         numerical_orbital = ndarray2list(numerical_orbital)
         orbfiles = []
         if isinstance(numerical_orbital, (list, tuple)):
-            assert len(numerical_orbital) == len(data["atom_names"]), "ERROR: make_unlabeled_stru: numerical_orbital length is not equal to the number of atom types"
+            if len(numerical_orbital) != len(data["atom_names"]):
+                raise RuntimeError("ERROR: make_unlabeled_stru: numerical_orbital length is not equal to the number of atom types")
             orbfiles = [numerical_orbital[i] for i in range(len(data["atom_names"])) if data["atom_numbs"][i] != 0]
         elif isinstance(numerical_orbital, dict):
             for iele in data["atom_names"]:

--- a/dpdata/abacus/scf.py
+++ b/dpdata/abacus/scf.py
@@ -656,7 +656,7 @@ def make_unlabeled_stru(
             return i.tolist()
         else:
             return i
-        
+
     def process_file_input(file_input, atom_names, input_name):
         # For pp_file and numerical_orbital, process the file input, and return a list of file names
         # file_input can be a list of file names, or a dictionary of file names for each atom names
@@ -673,7 +673,6 @@ def make_unlabeled_stru(
             return [file_input[element] for element in atom_names]
         else:
             raise ValueError(f"Invalid {input_name}: {file_input}")
-    
 
     if link_file and dest_dir is None:
         print(
@@ -700,7 +699,7 @@ def make_unlabeled_stru(
 
     # ATOMIC_SPECIES block
     out = "ATOMIC_SPECIES\n"
-    ppfiles = process_file_input(ndarray2list(pp_file), data["atom_names"], "pp_file") 
+    ppfiles = process_file_input(ndarray2list(pp_file), data["atom_names"], "pp_file")
 
     for iele in range(len(data["atom_names"])):
         if data["atom_numbs"][iele] == 0:
@@ -724,7 +723,9 @@ def make_unlabeled_stru(
     # NUMERICAL_ORBITAL block
     if numerical_orbital is not None:
         numerical_orbital = ndarray2list(numerical_orbital)
-        orbfiles = process_file_input(numerical_orbital, data["atom_names"], "numerical_orbital")
+        orbfiles = process_file_input(
+            numerical_orbital, data["atom_names"], "numerical_orbital"
+        )
         orbfiles = [
             orbfiles[i]
             for i in range(len(data["atom_names"]))

--- a/tests/test_abacus_stru_dump.py
+++ b/tests/test_abacus_stru_dump.py
@@ -60,8 +60,10 @@ class TestStruDump(unittest.TestCase):
                 pp_file={"C": "C.upf", "O": "O.upf"},
                 numerical_orbital={"C": "C.orb", "H": "H.orb"},
             )
-            
-        with self.assertRaises(ValueError, msg="pp_file is a list and lack of pp for H"):
+
+        with self.assertRaises(
+            ValueError, msg="pp_file is a list and lack of pp for H"
+        ):
             self.system_ch4.to(
                 "stru",
                 "STRU_tmp",
@@ -69,8 +71,10 @@ class TestStruDump(unittest.TestCase):
                 pp_file=["C.upf"],
                 numerical_orbital={"C": "C.orb", "H": "H.orb"},
             )
-    
-        with self.assertRaises(KeyError, msg="numerical_orbital is a dict and lack of orbital for H"):
+
+        with self.assertRaises(
+            KeyError, msg="numerical_orbital is a dict and lack of orbital for H"
+        ):
             self.system_ch4.to(
                 "stru",
                 "STRU_tmp",
@@ -78,8 +82,10 @@ class TestStruDump(unittest.TestCase):
                 pp_file={"C": "C.upf", "H": "H.upf"},
                 numerical_orbital={"C": "C.orb", "O": "O.orb"},
             )
-            
-        with self.assertRaises(ValueError, msg="numerical_orbital is a list and lack of orbital for H"):
+
+        with self.assertRaises(
+            ValueError, msg="numerical_orbital is a list and lack of orbital for H"
+        ):
             self.system_ch4.to(
                 "stru",
                 "STRU_tmp",

--- a/tests/test_abacus_stru_dump.py
+++ b/tests/test_abacus_stru_dump.py
@@ -50,6 +50,28 @@ class TestStruDump(unittest.TestCase):
 
         if os.path.isdir("abacus.scf/tmp"):
             shutil.rmtree("abacus.scf/tmp")
+    
+    def test_dump_stru_pporb_mismatch(self):
+        self.assertRaises(RuntimeError,
+            self.system_ch4.to,"stru","STRU_tmp",mass=[12, 1],
+            pp_file={"C": "C.upf", "O": "O.upf"},
+            numerical_orbital={"C": "C.orb", "H": "H.orb"}), "pp_file is a dict and lack of pp for H"
+        
+        self.assertRaises(RuntimeError,
+            self.system_ch4.to,"stru","STRU_tmp",mass=[12, 1],
+            pp_file=["C.upf"],
+            numerical_orbital={"C": "C.orb", "H": "H.orb"}), "pp_file is a list and lack of pp for H"
+        
+        self.assertRaises(RuntimeError,
+            self.system_ch4.to,"stru","STRU_tmp",mass=[12, 1],
+            pp_file={"C": "C.upf", "H": "H.upf"},
+            numerical_orbital={"C": "C.orb", "O": "O.orb"}), "numerical_orbital is a dict and lack of orbital for H"
+        
+        self.assertRaises(RuntimeError,
+            self.system_ch4.to,"stru","STRU_tmp",mass=[12, 1],
+            pp_file=["C.upf", "H.upf"],
+            numerical_orbital=["C.orb"]), "numerical_orbital is a list and lack of orbital for H"
+    
 
     def test_dump_spinconstrain(self):
         self.system_ch4.to(

--- a/tests/test_abacus_stru_dump.py
+++ b/tests/test_abacus_stru_dump.py
@@ -52,26 +52,41 @@ class TestStruDump(unittest.TestCase):
             shutil.rmtree("abacus.scf/tmp")
     
     def test_dump_stru_pporb_mismatch(self):
-        self.assertRaises(RuntimeError,
-            self.system_ch4.to,"stru","STRU_tmp",mass=[12, 1],
-            pp_file={"C": "C.upf", "O": "O.upf"},
-            numerical_orbital={"C": "C.orb", "H": "H.orb"}), "pp_file is a dict and lack of pp for H"
-        
-        self.assertRaises(RuntimeError,
-            self.system_ch4.to,"stru","STRU_tmp",mass=[12, 1],
-            pp_file=["C.upf"],
-            numerical_orbital={"C": "C.orb", "H": "H.orb"}), "pp_file is a list and lack of pp for H"
-        
-        self.assertRaises(RuntimeError,
-            self.system_ch4.to,"stru","STRU_tmp",mass=[12, 1],
-            pp_file={"C": "C.upf", "H": "H.upf"},
-            numerical_orbital={"C": "C.orb", "O": "O.orb"}), "numerical_orbital is a dict and lack of orbital for H"
-        
-        self.assertRaises(RuntimeError,
-            self.system_ch4.to,"stru","STRU_tmp",mass=[12, 1],
-            pp_file=["C.upf", "H.upf"],
-            numerical_orbital=["C.orb"]), "numerical_orbital is a list and lack of orbital for H"
+        with self.assertRaises(KeyError, msg="pp_file is a dict and lack of pp for H"):
+            self.system_ch4.to(
+                "stru",
+                "STRU_tmp",
+                mass=[12, 1],
+                pp_file={"C": "C.upf", "O": "O.upf"},
+                numerical_orbital={"C": "C.orb", "H": "H.orb"},
+            )
+            
+        with self.assertRaises(ValueError, msg="pp_file is a list and lack of pp for H"):
+            self.system_ch4.to(
+                "stru",
+                "STRU_tmp",
+                mass=[12, 1],
+                pp_file=["C.upf"],
+                numerical_orbital={"C": "C.orb", "H": "H.orb"},
+            )
     
+        with self.assertRaises(KeyError, msg="numerical_orbital is a dict and lack of orbital for H"):
+            self.system_ch4.to(
+                "stru",
+                "STRU_tmp",
+                mass=[12, 1],
+                pp_file={"C": "C.upf", "H": "H.upf"},
+                numerical_orbital={"C": "C.orb", "O": "O.orb"},
+            )
+            
+        with self.assertRaises(ValueError, msg="numerical_orbital is a list and lack of orbital for H"):
+            self.system_ch4.to(
+                "stru",
+                "STRU_tmp",
+                mass=[12, 1],
+                pp_file=["C.upf", "H.upf"],
+                numerical_orbital=["C.orb"],
+            )
 
     def test_dump_spinconstrain(self):
         self.system_ch4.to(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a mandatory parameter for pseudopotential files and an optional parameter to specify the destination directory for symbolic links.

- **Improvements**
	- Enhanced clarity and functionality in handling input parameters for pseudopotential and orbital files.
	- Streamlined output construction for `pp_file` and `numerical_orbital`.

- **Bug Fixes**
	- Added tests to validate error handling for mismatches between provided pseudopotential files and numerical orbitals, ensuring appropriate exceptions are raised.

- **Documentation**
	- Added comments for better understanding of code functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->