### PR TITLE
fix: change `project.entry-points.console_scripts` to `project.scripts` in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ Homepage = "https://github.com/deepmodeling/dpdata"
 documentation = "https://docs.deepmodeling.com/projects/dpdata"
 repository = "https://github.com/deepmodeling/dpdata"
 
-[project.entry-points.console_scripts]
+[project.scripts]
 dpdata = "dpdata.cli:dpdata_cli"
 
 [project.optional-dependencies]


### PR DESCRIPTION
`project.entry-points.console_scripts` is not allowed per [PEP 621](https://peps.python.org/pep-0621/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the command entry point for the `dpdata` tool for improved accessibility.
  
- **Chores**
	- Organized optional dependencies for better clarity and management.
	- Maintained existing configurations for tools and package data without functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->