### PR TITLE
Adjust pp_file as an unnessary parameter in save to abacus/stru

### DIFF
--- a/dpdata/abacus/scf.py
+++ b/dpdata/abacus/scf.py
@@ -635,7 +635,7 @@ def get_frame_from_stru(fname):
 def make_unlabeled_stru(
     data,
     frame_idx,
-    pp_file,
+    pp_file=None,
     numerical_orbital=None,
     numerical_descriptor=None,
     mass=None,
@@ -759,7 +759,11 @@ def make_unlabeled_stru(
 
     # ATOMIC_SPECIES block
     out = "ATOMIC_SPECIES\n"
-    ppfiles = process_file_input(ndarray2list(pp_file), data["atom_names"], "pp_file")
+    if pp_file is not None:
+        ppfiles = process_file_input(ndarray2list(pp_file), data["atom_names"], "pp_file")
+    else:
+        warnings.warn("pp_file is not provided, will use empty string for pseudo potential file.")
+        ppfiles = [""] * len(data["atom_names"])
 
     for iele in range(len(data["atom_names"])):
         if data["atom_numbs"][iele] == 0:
@@ -771,12 +775,13 @@ def make_unlabeled_stru(
             out += "1 "
 
         ipp_file = ppfiles[iele]
-        if not link_file:
-            out += ipp_file
-        else:
-            out += os.path.basename(ipp_file.rstrip("/"))
-            if dest_dir is not None:
-                _link_file(dest_dir, ipp_file)
+        if ipp_file != "":
+            if not link_file:
+                out += ipp_file
+            else:
+                out += os.path.basename(ipp_file.rstrip("/"))
+                if dest_dir is not None:
+                    _link_file(dest_dir, ipp_file)
         out += "\n"
     out += "\n"
 

--- a/tests/test_abacus_stru_dump.py
+++ b/tests/test_abacus_stru_dump.py
@@ -29,6 +29,10 @@ class TestStruDump(unittest.TestCase):
         )
         myfilecmp(self, "abacus.scf/stru_test", "STRU_tmp")
 
+    def test_dump_stru_without_pporb(self):
+        self.system_ch4.to("stru", "STRU_tmp", mass=[12, 1])
+        self.assertTrue(os.path.isfile("STRU_tmp"))
+    
     def test_dumpStruLinkFile(self):
         os.makedirs("abacus.scf/tmp", exist_ok=True)
         self.system_ch4.to(

--- a/tests/test_abacus_stru_dump.py
+++ b/tests/test_abacus_stru_dump.py
@@ -32,7 +32,7 @@ class TestStruDump(unittest.TestCase):
     def test_dump_stru_without_pporb(self):
         self.system_ch4.to("stru", "STRU_tmp", mass=[12, 1])
         self.assertTrue(os.path.isfile("STRU_tmp"))
-    
+
     def test_dumpStruLinkFile(self):
         os.makedirs("abacus.scf/tmp", exist_ok=True)
         self.system_ch4.to(


### PR DESCRIPTION
In case, some one may just save only as a stru file and has no pseudopotential information.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling and messaging for cases where the pseudo potential file is not provided.
	- Added checks to ensure parameter lengths match the total number of atoms, enhancing robustness.

- **New Features**
	- Introduced a default value for the pseudo potential file parameter, allowing for more flexible function usage.

- **Tests**
	- Added a new test to verify functionality when the pseudo potential file is not specified, ensuring reliable output with minimal parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->