### PR TITLE
breaking: drop support of py3.7. fix: pin scipy constants to version 2018

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.12"]
+        python-version: ["3.8", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Installation
 
-DP-GEN only supports Python 3.7 and above. You can [setup a conda/pip environment](https://docs.deepmodeling.com/faq/conda.html), and then use one of the following methods to install DP-GEN:
+dpdata only supports Python 3.8 and above. You can [setup a conda/pip environment](https://docs.deepmodeling.com/faq/conda.html), and then use one of the following methods to install dpdata:
 
 - Install via pip: `pip install dpdata`
 - Install via conda: `conda install -c conda-forge dpdata`

--- a/docs/make_format.py
+++ b/docs/make_format.py
@@ -4,10 +4,10 @@ import csv
 import os
 from collections import defaultdict
 from inspect import Parameter, Signature, cleandoc, signature
+from typing import Literal
 
 from numpydoc.docscrape import Parameter as numpydoc_Parameter
 from numpydoc.docscrape_sphinx import SphinxDocString
-from typing_extensions import Literal
 
 from dpdata.bond_order_system import BondOrderSystem
 

--- a/docs/make_format.py
+++ b/docs/make_format.py
@@ -2,17 +2,12 @@ from __future__ import annotations
 
 import csv
 import os
-import sys
 from collections import defaultdict
 from inspect import Parameter, Signature, cleandoc, signature
 
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
-
 from numpydoc.docscrape import Parameter as numpydoc_Parameter
 from numpydoc.docscrape_sphinx import SphinxDocString
+from typing_extensions import Literal
 
 from dpdata.bond_order_system import BondOrderSystem
 

--- a/dpdata/stat.py
+++ b/dpdata/stat.py
@@ -116,7 +116,7 @@ class Errors(ErrorsBase):
     SYSTEM_TYPE = LabeledSystem
 
     @property
-    @lru_cache()
+    @lru_cache
     def e_errors(self) -> np.ndarray:
         """Energy errors."""
         assert isinstance(self.system_1, self.SYSTEM_TYPE)
@@ -124,7 +124,7 @@ class Errors(ErrorsBase):
         return self.system_1["energies"] - self.system_2["energies"]
 
     @property
-    @lru_cache()
+    @lru_cache
     def f_errors(self) -> np.ndarray:
         """Force errors."""
         assert isinstance(self.system_1, self.SYSTEM_TYPE)
@@ -153,7 +153,7 @@ class MultiErrors(ErrorsBase):
     SYSTEM_TYPE = MultiSystems
 
     @property
-    @lru_cache()
+    @lru_cache
     def e_errors(self) -> np.ndarray:
         """Energy errors."""
         assert isinstance(self.system_1, self.SYSTEM_TYPE)
@@ -166,7 +166,7 @@ class MultiErrors(ErrorsBase):
         return np.concatenate(errors)
 
     @property
-    @lru_cache()
+    @lru_cache
     def f_errors(self) -> np.ndarray:
         """Force errors."""
         assert isinstance(self.system_1, self.SYSTEM_TYPE)

--- a/dpdata/system.py
+++ b/dpdata/system.py
@@ -5,7 +5,6 @@ import glob
 import hashlib
 import numbers
 import os
-import sys
 import warnings
 from copy import deepcopy
 from typing import (
@@ -15,12 +14,8 @@ from typing import (
     overload,
 )
 
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
-
 import numpy as np
+from typing_extensions import Literal
 
 import dpdata
 import dpdata.md.pbc

--- a/dpdata/system.py
+++ b/dpdata/system.py
@@ -11,11 +11,11 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Iterable,
+    Literal,
     overload,
 )
 
 import numpy as np
-from typing_extensions import Literal
 
 import dpdata
 import dpdata.md.pbc

--- a/dpdata/unit.py
+++ b/dpdata/unit.py
@@ -4,11 +4,49 @@ from abc import ABC
 
 from scipy import constants  # noqa: TID253
 
-AVOGADRO = constants.Avogadro  # Avagadro constant
-ELE_CHG = constants.elementary_charge  # Elementary Charge, in C
-BOHR = constants.value("atomic unit of length")  # Bohr, in m
-HARTREE = constants.value("atomic unit of energy")  # Hartree, in Jole
-RYDBERG = constants.Rydberg * constants.h * constants.c  # Rydberg, in Jole
+physical_constants = {}
+# use constants up to 2018
+physical_constants.update(constants._codata._physical_constants_2002)
+physical_constants.update(constants._codata._physical_constants_2006)
+physical_constants.update(constants._codata._physical_constants_2010)
+physical_constants.update(constants._codata._physical_constants_2014)
+physical_constants.update(constants._codata._physical_constants_2018)
+
+
+# copied from scipy
+def scipy_constant_value(key: str) -> float:
+    """Value in physical_constants indexed by key.
+
+    Parameters
+    ----------
+    key : Python string
+        Key in dictionary `physical_constants`
+
+    Returns
+    -------
+    value : float
+        Value in `physical_constants` corresponding to `key`
+
+    Examples
+    --------
+    >>> from scipy import constants
+    >>> constants.value('elementary charge')
+    1.602176634e-19
+
+    """
+    constants._codata._check_obsolete(key)
+    return physical_constants[key][0]
+
+
+AVOGADRO = scipy_constant_value("Avogadro constant")  # Avagadro constant
+ELE_CHG = scipy_constant_value("elementary charge")  # Elementary Charge, in C
+BOHR = scipy_constant_value("atomic unit of length")  # Bohr, in m
+HARTREE = scipy_constant_value("atomic unit of energy")  # Hartree, in Jole
+RYDBERG = (
+    scipy_constant_value("Rydberg constant")
+    * scipy_constant_value("Planck constant")
+    * scipy_constant_value("speed of light in vacuum")
+)  # Rydberg, in Jole
 
 # energy conversions
 econvs = {

--- a/dpdata/utils.py
+++ b/dpdata/utils.py
@@ -3,10 +3,9 @@ from __future__ import annotations
 import io
 import os
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Generator, overload
+from typing import TYPE_CHECKING, Generator, Literal, overload
 
 import numpy as np
-from typing_extensions import Literal
 
 from dpdata.periodic_table import Element
 

--- a/dpdata/utils.py
+++ b/dpdata/utils.py
@@ -2,15 +2,11 @@ from __future__ import annotations
 
 import io
 import os
-import sys
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Generator, overload
 
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 import numpy as np
+from typing_extensions import Literal
 
 from dpdata.periodic_table import Element
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ authors = [
 ]
 license = {file = "LICENSE"}
 classifiers = [
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -28,7 +27,7 @@ dependencies = [
     'importlib_metadata>=1.4; python_version < "3.8"',
     'typing_extensions; python_version < "3.8"',
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 readme = "README.md"
 keywords = ["lammps", "vasp", "deepmd-kit"]
 
@@ -46,7 +45,6 @@ test = [
 ase = ['ase']
 amber = [
     'parmed; python_version >= "3.8"',
-    'parmed<4; python_version < "3.8"',
 ]
 pymatgen = ['pymatgen']
 docs = [


### PR DESCRIPTION
drop support of py3.7
fix issue #773 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced management of physical constants with a centralized dictionary approach.
	- Added a new function to dynamically retrieve physical constants from multiple CODATA releases.

- **Bug Fixes**
	- Updated Python version compatibility to require Python 3.8 or above.

- **Refactor**
	- Improved constant management structure for better maintainability.
	- Replaced direct constant assignments with a more flexible retrieval method.
	- Adjusted caching behavior in error handling classes.
	- Simplified import statements for type handling by utilizing native Python features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->