### PR TITLE
breaking: drop python 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.12"]
+        python-version: ["3.8", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Installation
 
-DP-GEN only supports Python 3.7 and above. You can [setup a conda/pip environment](https://docs.deepmodeling.com/faq/conda.html), and then use one of the following methods to install DP-GEN:
+dpdata only supports Python 3.7 and above. You can [setup a conda/pip environment](https://docs.deepmodeling.com/faq/conda.html), and then use one of the following methods to install dpdata:
 
 - Install via pip: `pip install dpdata`
 - Install via conda: `conda install -c conda-forge dpdata`

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-DP-GEN only supports Python 3.7 and above. You can [setup a conda/pip environment](https://docs.deepmodeling.com/faq/conda.html), and then use one of the following methods to install DP-GEN:
+dpdata only supports Python 3.8 and above. You can [setup a conda/pip environment](https://docs.deepmodeling.com/faq/conda.html), and then use one of the following methods to install dpdata:
 
 - Install via pip: `pip install dpdata`
 - Install via conda: `conda install -c conda-forge dpdata`

--- a/docs/make_format.py
+++ b/docs/make_format.py
@@ -2,14 +2,9 @@ from __future__ import annotations
 
 import csv
 import os
-import sys
 from collections import defaultdict
 from inspect import Parameter, Signature, cleandoc, signature
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
+from typing import Literal
 
 from numpydoc.docscrape import Parameter as numpydoc_Parameter
 from numpydoc.docscrape_sphinx import SphinxDocString

--- a/dpdata/system.py
+++ b/dpdata/system.py
@@ -5,20 +5,15 @@ import glob
 import hashlib
 import numbers
 import os
-import sys
 import warnings
 from copy import deepcopy
 from typing import (
     TYPE_CHECKING,
     Any,
     Iterable,
+    Literal,
     overload,
 )
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 import numpy as np
 

--- a/dpdata/utils.py
+++ b/dpdata/utils.py
@@ -2,14 +2,9 @@ from __future__ import annotations
 
 import io
 import os
-import sys
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Generator, overload
+from typing import TYPE_CHECKING, Generator, Literal, overload
 
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 import numpy as np
 
 from dpdata.periodic_table import Element

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ authors = [
 ]
 license = {file = "LICENSE"}
 classifiers = [
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -28,7 +27,7 @@ dependencies = [
     'importlib_metadata>=1.4; python_version < "3.8"',
     'typing_extensions; python_version < "3.8"',
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 readme = "README.md"
 keywords = ["lammps", "vasp", "deepmd-kit"]
 

--- a/tests/plugin/pyproject.toml
+++ b/tests/plugin/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     'dpdata',
 ]
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 
 [project.entry-points.'dpdata.plugins']
 random = "dpdata_plugin_test:ep"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **Python Version Support**
  - Dropped support for Python 3.7
  - Now requires Python 3.8 or higher

- **Documentation**
  - Updated installation instructions to reflect new Python version requirements

- **Code Maintenance**
  - Simplified type imports and version-specific code handling
  - Removed legacy version compatibility checks

- **Build Configuration**
  - Updated GitHub Actions workflow to test only Python 3.8 and 3.12

<!-- end of auto-generated comment: release notes by coderabbit.ai -->