### PR TITLE
update coords after shift_orig_zero

### DIFF
--- a/dpdata/system.py
+++ b/dpdata/system.py
@@ -710,9 +710,7 @@ class System:
 
     @post_funcs.register("shift_orig_zero")
     def _shift_orig_zero(self):
-        for ff in self.data["coords"]:
-            for ii in ff:
-                ii = ii - self.data["orig"]
+        self.data["coords"] = self.data["coords"] - self.data["orig"]
         self.data["orig"] = self.data["orig"] - self.data["orig"]
         assert (np.zeros([3]) == self.data["orig"]).all()
 


### PR DESCRIPTION
Hi,

I think this part of the code was attempting to modify local variables (`ii`) rather than the actual array elements in `self.data["coords"]`. 

Before:
```
@post_funcs.register("shift_orig_zero")
    def _shift_orig_zero(self):
        for ff in self.data["coords"]:
             for ii in ff:
                 ii = ii - self.data["orig"]
                 ...
```
After:
```
...
self.data["coords"] = self.data["coords"] - self.data["orig"]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced the efficiency of coordinate adjustments for improved performance on larger datasets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->