### PR TITLE
fix: issue 822 and 836

### DIFF
--- a/dpdata/vasp/outcar.py
+++ b/dpdata/vasp/outcar.py
@@ -60,7 +60,6 @@ def system_info(
     nelm = None
     nwrite = None
     for ii in lines:
-        ii_word_list = ii.split()
         if "TITEL" in ii:
             # get atom names from POTCAR info, tested only for PAW_PBE ...
             # for case like : TITEL  = PAW_PBE Sn_d 06Sep2000

--- a/dpdata/vasp/outcar.py
+++ b/dpdata/vasp/outcar.py
@@ -6,31 +6,94 @@ import warnings
 import numpy as np
 
 
-def system_info(lines, type_idx_zero=False):
+def atom_name_from_potcar_string(instr: str) -> str:
+    """Get atom name from a potcar element name.
+
+    e.g. Sn_d -> Sn
+
+    Parameters
+    ----------
+    instr : str
+        input potcar elemenet name
+
+    Returns
+    -------
+    name: str
+        name of atoms
+    """
+    if "_" in instr:
+        # for case like : TITEL  = PAW_PBE Sn_d 06Sep2000
+        return instr.split("_")[0]
+    else:
+        return instr
+
+
+def system_info(
+    lines: list[str],
+    type_idx_zero: bool = False,
+) -> tuple[list[str], list[int], np.ndarray, int | None, int | None]:
+    """Get system information from lines of an OUTCAR file.
+
+    Parameters
+    ----------
+    lines : list[str]
+        the lines of the OUTCAR file
+    type_idx_zero : bool
+        if true atom types starts from 0 otherwise from 1.
+
+    Returns
+    -------
+    atom_names: list[str]
+        name of atoms
+    atom_numbs: list[int]
+        number of atoms that have a certain name. same length as atom_names
+    atom_types: np.ndarray
+        type of each atom, the array has same lenght as number of atoms
+    nelm: optional[int]
+        the value of NELM parameter
+    nwrite: optional[int]
+        the value of NWRITE parameter
+    """
     atom_names = []
+    atom_names_potcar = []
     atom_numbs = None
     nelm = None
+    nwrite = None
     for ii in lines:
         ii_word_list = ii.split()
         if "TITEL" in ii:
             # get atom names from POTCAR info, tested only for PAW_PBE ...
+            # for case like : TITEL  = PAW_PBE Sn_d 06Sep2000
             _ii = ii.split()[3]
-            if "_" in _ii:
-                # for case like : TITEL  = PAW_PBE Sn_d 06Sep2000
-                atom_names.append(_ii.split("_")[0])
-            else:
-                atom_names.append(_ii)
+            atom_names.append(atom_name_from_potcar_string(_ii))
+        elif "POTCAR:" in ii:
+            # get atom names from POTCAR info, tested only for PAW_PBE ...
+            # for case like : POTCAR:  PAW_PBE Ti 08Apr2002
+            _ii = ii.split()[2]
+            atom_names_potcar.append(atom_name_from_potcar_string(_ii))
         # a stricker check for "NELM"; compatible with distingct formats in different versions(6 and older, newers_expect-to-work) of vasp
         elif nelm is None:
             m = re.search(r"NELM\s*=\s*(\d+)", ii)
             if m:
                 nelm = int(m.group(1))
+        elif nwrite is None:
+            m = re.search(r"NWRITE\s*=\s*(\d+)", ii)
+            if m:
+                nwrite = int(m.group(1))
         if "ions per type" in ii:
             atom_numbs_ = [int(s) for s in ii.split()[4:]]
             if atom_numbs is None:
                 atom_numbs = atom_numbs_
             else:
                 assert atom_numbs == atom_numbs_, "in consistent numb atoms in OUTCAR"
+    if len(atom_names) == 0:
+        # try to use atom_names_potcar
+        if len(atom_names_potcar) == 0:
+            raise ValueError("cannot get atom names from potcar")
+        nnames = len(atom_names_potcar)
+        # the names are repeated. check if it is the case
+        assert atom_names_potcar[: nnames // 2] == atom_names_potcar[nnames // 2 :]
+        atom_names = atom_names_potcar[: nnames // 2]
     assert nelm is not None, "cannot find maximum steps for each SC iteration"
     assert atom_numbs is not None, "cannot find ion type info in OUTCAR"
     atom_names = atom_names[: len(atom_numbs)]
@@ -41,7 +104,7 @@ def system_info(lines, type_idx_zero=False):
                 atom_types.append(idx)
             else:
                 atom_types.append(idx + 1)
-    return atom_names, atom_numbs, np.array(atom_types, dtype=int), nelm
+    return atom_names, atom_numbs, np.array(atom_types, dtype=int), nelm, nwrite
 
 
 def get_outcar_block(fp, ml=False):
@@ -57,12 +120,24 @@ def get_outcar_block(fp, ml=False):
     return blk
 
 
+def check_outputs(coord, cell, force):
+    if len(force) == 0:
+        raise ValueError("cannot find forces in OUTCAR block")
+    if len(coord) == 0:
+        raise ValueError("cannot find coordinates in OUTCAR block")
+    if len(cell) == 0:
+        raise ValueError("cannot find cell in OUTCAR block")
+    return True
+
+
 # we assume that the force is printed ...
 def get_frames(fname, begin=0, step=1, ml=False, convergence_check=True):
     fp = open(fname)
     blk = get_outcar_block(fp)
 
-    atom_names, atom_numbs, atom_types, nelm = system_info(blk, type_idx_zero=True)
+    atom_names, atom_numbs, atom_types, nelm, nwrite = system_info(
+        blk, type_idx_zero=True
+    )
     ntot = sum(atom_numbs)
 
     all_coords = []
@@ -78,9 +153,15 @@ def get_frames(fname, begin=0, step=1, ml=False, convergence_check=True):
             coord, cell, energy, force, virial, is_converge = analyze_block(
                 blk, ntot, nelm, ml
             )
-            if len(coord) == 0:
+            if energy is None:
                 break
-            if is_converge or not convergence_check:
+            if nwrite == 0:
+                has_label = len(force) > 0 and len(coord) > 0 and len(cell) > 0
+                if not has_label:
+                    warnings.warn("cannot find labels in the frame, ingore")
+            else:
+                has_label = check_outputs(coord, cell, force)
+            if (is_converge or not convergence_check) and has_label:
                 all_coords.append(coord)
                 all_cells.append(cell)
                 all_energies.append(energy)
@@ -144,12 +225,6 @@ def analyze_block(lines, ntot, nelm, ml=False):
                 is_converge = False
         elif energy_token[ml_index] in ii:
             energy = float(ii.split()[energy_index[ml_index]])
-            if len(force) == 0:
-                raise ValueError("cannot find forces in OUTCAR block")
-            if len(coord) == 0:
-                raise ValueError("cannot find coordinates in OUTCAR block")
-            if len(cell) == 0:
-                raise ValueError("cannot find cell in OUTCAR block")
             return coord, cell, energy, force, virial, is_converge
         elif cell_token[ml_index] in ii:
             for dd in range(3):

--- a/tests/poscars/Ti-O-Ti-v6/OUTCAR
+++ b/tests/poscars/Ti-O-Ti-v6/OUTCAR
@@ -1,0 +1,1856 @@
+ vasp.6.3.0 20Jan22 (build Apr 09 2022 18:33:31) complex                        
+  
+ executed on             LinuxIFC date 2025.07.07  11:18:24
+ running on  128 total cores
+ distrk:  each k-point on  128 cores,    1 groups
+ distr:  one band on NCORE=   1 cores,  128 groups
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+ INCAR:
+   SYSTEM = dpgen
+   PREC = Accurate
+   ISTART = 0
+   ICHARG = 2
+   ENCUT = 350
+   NELM = 100
+   NELMIN = 6
+   NELMDL = -5
+   EDIFF = 1e-06
+   LREAL = A
+   ALGO = Normal
+   IBRION = -1
+   POTIM = 2
+   NWRITE = 0
+   ISIF = 2
+   ISYM = 0
+   NSW = 0
+   ISYM = 0
+   NSW = 1
+   ISMEAR = 1
+   SIGMA = 0.20
+   LWAVE = False
+   LCHARG = False
+   KPAR = 1
+   KSPACING = 10.0
+   KGAMMA = False
+   PSTRESS = 0
+
+ POTCAR:    PAW_PBE Ti 08Apr2002                  
+ POTCAR:    PAW_PBE O 08Apr2002                   
+ POTCAR:  PAW_PBE Ti 08Apr2002                    
+ -----------------------------------------------------------------------------
+|                                                                             |
+|           W    W    AA    RRRRR   N    N  II  N    N   GGGG   !!!           |
+|           W    W   A  A   R    R  NN   N  II  NN   N  G    G  !!!           |
+|           W    W  A    A  R    R  N N  N  II  N N  N  G       !!!           |
+|           W WW W  AAAAAA  RRRRR   N  N N  II  N  N N  G  GGG   !            |
+|           WW  WW  A    A  R   R   N   NN  II  N   NN  G    G                |
+|           W    W  A    A  R    R  N    N  II  N    N   GGGG   !!!           |
+|                                                                             |
+|     For optimal performance we recommend to set                             |
+|       NCORE = 2 up to number-of-cores-per-socket                            |
+|     NCORE specifies how many cores store one orbital (NPAR=cpu/NCORE).      |
+|     This setting can greatly improve the performance of VASP for DFT.       |
+|     The default, NCORE=1 might be grossly inefficient on modern             |
+|     multi-core architectures or massively parallel machines. Do your        |
+|     own testing! More info at https://www.vasp.at/wiki/index.php/NCORE      |
+|     Unfortunately you need to use the default for GW and RPA                |
+|     calculations (for HF NCORE is supported but not extensively tested      |
+|     yet).                                                                   |
+|                                                                             |
+ -----------------------------------------------------------------------------
+
+ POTCAR:    PAW_PBE Ti 08Apr2002                  
+  local pseudopotential read in
+  partial core-charges read in
+  partial kinetic energy density read in
+  atomic valenz-charges read in
+  non local Contribution for L=           2  read in
+    real space projection operators read in
+  non local Contribution for L=           2  read in
+    real space projection operators read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+    PAW grid and wavefunctions read in
+ 
+   number of l-projection  operators is LMAX  =           5
+   number of lm-projection operators is LMMAX =          15
+ 
+ POTCAR:    PAW_PBE O 08Apr2002                   
+  local pseudopotential read in
+  partial core-charges read in
+  partial kinetic energy density read in
+  kinetic energy density of atom read in
+  atomic valenz-charges read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+    PAW grid and wavefunctions read in
+ 
+   number of l-projection  operators is LMAX  =           4
+   number of lm-projection operators is LMMAX =           8
+ 
+ POTCAR:  PAW_PBE Ti 08Apr2002                    
+  local pseudopotential read in
+  partial core-charges read in
+  partial kinetic energy density read in
+  atomic valenz-charges read in
+  non local Contribution for L=           2  read in
+    real space projection operators read in
+  non local Contribution for L=           2  read in
+    real space projection operators read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+    PAW grid and wavefunctions read in
+ 
+   number of l-projection  operators is LMAX  =           5
+   number of lm-projection operators is LMMAX =          15
+ 
+ -----------------------------------------------------------------------------
+|                                                                             |
+|               ----> ADVICE to this user running VASP <----                  |
+|                                                                             |
+|     You have a (more or less) 'small supercell' and for smaller cells       |
+|     it is recommended to use the reciprocal-space projection scheme!        |
+|     The real-space optimization is not efficient for small cells and it     |
+|     is also less accurate ...                                               |
+|     Therefore, set LREAL=.FALSE. in the INCAR file.                         |
+|                                                                             |
+ -----------------------------------------------------------------------------
+
+ Optimization of the real space projectors (new method)
+
+ maximal supplied QI-value         = 13.42
+ optimisation between [QCUT,QGAM] = [  9.53, 19.05] = [ 25.41,101.65] Ry 
+ Optimized for a Real-space Cutoff    1.71 Angstroem
+
+   l    n(q)    QCUT    max X(q) W(low)/X(q) W(high)/X(q)  e(spline) 
+   2      9     9.526    49.363    0.22E-03    0.19E-03    0.16E-06
+   2      9     9.526    47.669    0.21E-03    0.18E-03    0.15E-06
+   0     10     9.526    26.374    0.66E-04    0.97E-04    0.20E-06
+   0     10     9.526    11.549    0.52E-04    0.76E-04    0.15E-06
+   1      9     9.526     9.492    0.58E-04    0.43E-04    0.22E-07
+ Optimization of the real space projectors (new method)
+
+ maximal supplied QI-value         = 24.76
+ optimisation between [QCUT,QGAM] = [  9.41, 19.06] = [ 24.78,101.75] Ry 
+ Optimized for a Real-space Cutoff    1.52 Angstroem
+
+   l    n(q)    QCUT    max X(q) W(low)/X(q) W(high)/X(q)  e(spline) 
+   0      9     9.407    20.381    0.18E-03    0.80E-04    0.45E-06
+   0      9     9.407    15.268    0.20E-03    0.93E-04    0.47E-06
+   1      8     9.407     5.946    0.21E-03    0.21E-03    0.43E-06
+   1      8     9.407     5.382    0.18E-03    0.18E-03    0.39E-06
+ Optimization of the real space projectors (new method)
+
+ maximal supplied QI-value         = 13.42
+ optimisation between [QCUT,QGAM] = [  9.53, 19.05] = [ 25.41,101.65] Ry 
+ Optimized for a Real-space Cutoff    1.71 Angstroem
+
+   l    n(q)    QCUT    max X(q) W(low)/X(q) W(high)/X(q)  e(spline) 
+   2      9     9.526    49.363    0.22E-03    0.19E-03    0.16E-06
+   2      9     9.526    47.669    0.21E-03    0.18E-03    0.15E-06
+   0     10     9.526    26.374    0.66E-04    0.97E-04    0.20E-06
+   0     10     9.526    11.549    0.52E-04    0.76E-04    0.15E-06
+   1      9     9.526     9.492    0.58E-04    0.43E-04    0.22E-07
+  PAW_PBE Ti 08Apr2002                  :
+ energy of atom  1       EATOM=  -94.7928
+ kinetic energy error for atom=    0.0008 (will be added to EATOM!!)
+  PAW_PBE O 08Apr2002                   :
+ energy of atom  2       EATOM= -432.3788
+ kinetic energy error for atom=    0.3782 (will be added to EATOM!!)
+PAW_PBE Ti 08Apr2002                    :
+ energy of atom  3       EATOM=  -94.7928
+ kinetic energy error for atom=    0.0008 (will be added to EATOM!!)
+ 
+ 
+ POSCAR: POSCAR file written by OVITO Basic 3.10.
+  positions in cartesian coordinates
+  No initial velocities read in
+ exchange correlation table for  LEXCH =        8
+   RHO(1)=    0.500       N(1)  =     2000
+   RHO(2)=  100.500       N(2)  =     4000
+ 
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+ ion  position               nearest neighbor table
+   1  0.042  0.103  0.248-   7 2.88   7 2.88   3 2.88   3 2.88   2 2.88   2 2.88   8 2.93   8 2.93
+
+   2  0.042  0.769  0.748-   8 2.88   8 2.88   1 2.88   1 2.88   3 2.93   3 2.93   7 2.93   7 2.93
+                             6 2.94   6 2.94
+   3  0.292  0.269  0.748-   1 2.88   1 2.88   2 2.93   2 2.93   6 2.93   6 2.93   7 2.94   7 2.94
+
+   4  0.292  0.603  0.248-
+   5  0.542  0.103  0.248-
+   6  0.542  0.769  0.748-   8 2.88   8 2.88   7 2.93   7 2.93   3 2.93   3 2.93   2 2.94   2 2.94
+
+   7  0.792  0.269  0.748-   1 2.88   1 2.88   8 2.88   8 2.88   6 2.93   6 2.93   2 2.93   2 2.93
+                             3 2.94   3 2.94
+   8  0.792  0.603  0.248-   6 2.88   6 2.88   2 2.88   2 2.88   7 2.88   7 2.88   1 2.93   1 2.93
+
+ 
+
+IMPORTANT INFORMATION: All symmetrisations will be switched off!
+NOSYMM: (Re-)initialisation of all symmetry stuff for point group C_1.
+
+
+----------------------------------------------------------------------------------------
+
+                                     Primitive cell                                     
+
+  volume of cell :     138.7156
+
+  direct lattice vectors                    reciprocal lattice vectors
+     5.871982203  0.000000000  0.000000000     0.170300244  0.000000000  0.000000000
+     0.000000000  5.082805747  0.000000000     0.000000000  0.196741731  0.000000000
+     0.000000000  0.000000000  4.647690000     0.000000000  0.000000000  0.215160650
+
+  length of vectors
+     5.871982203  5.082805747  4.647690000     0.170300244  0.196741731  0.215160650
+
+  position of ions in fractional coordinates (direct lattice)
+     0.042324146  0.102503026  0.248036420
+     0.042337684  0.769068244  0.748031130
+     0.292332070  0.269066398  0.748032034
+     0.292330835  0.602503302  0.248035096
+     0.542324146  0.102503026  0.248036420
+     0.542337684  0.769068244  0.748031130
+     0.792332070  0.269066398  0.748032034
+     0.792330835  0.602503302  0.248035096
+
+  ion indices of the primitive-cell ions
+   primitive index   ion index
+                 1           1
+                 2           2
+                 3           3
+                 4           4
+                 5           5
+                 6           6
+                 7           7
+                 8           8
+
+----------------------------------------------------------------------------------------
+
+ 
+ -----------------------------------------------------------------------------
+|                                                                             |
+|           W    W    AA    RRRRR   N    N  II  N    N   GGGG   !!!           |
+|           W    W   A  A   R    R  NN   N  II  NN   N  G    G  !!!           |
+|           W    W  A    A  R    R  N N  N  II  N N  N  G       !!!           |
+|           W WW W  AAAAAA  RRRRR   N  N N  II  N  N N  G  GGG   !            |
+|           WW  WW  A    A  R   R   N   NN  II  N   NN  G    G                |
+|           W    W  A    A  R    R  N    N  II  N    N   GGGG   !!!           |
+|                                                                             |
+|     The requested file  could not be found or opened for reading            |
+|     k-point information. Automatic k-point generation is used as a          |
+|     fallback, which may lead to unwanted results.                           |
+|                                                                             |
+ -----------------------------------------------------------------------------
+
+ 
+
+Automatic generation of k-mesh.
+ Grid dimensions derived from KSPACING:
+ generate k-points for:    1    1    1
+
+ Generating k-lattice:
+
+  Cartesian coordinates                     Fractional coordinates (reciprocal lattice)
+     0.170300244  0.000000000  0.000000000     1.000000000  0.000000000  0.000000000
+     0.000000000  0.196741731  0.000000000     0.000000000  1.000000000  0.000000000
+     0.000000000  0.000000000  0.215160650     0.000000000  0.000000000  1.000000000
+
+  Length of vectors
+     0.170300244  0.196741731  0.215160650
+
+  Shift w.r.t. Gamma in fractional coordinates (k-lattice)
+     0.000000000  0.000000000  0.000000000
+
+ 
+ Subroutine IBZKPT returns following result:
+ ===========================================
+ 
+ Found      1 irreducible k-points:
+ 
+ Following reciprocal coordinates:
+            Coordinates               Weight
+  0.000000  0.000000  0.000000      1.000000
+ 
+ Following cartesian coordinates:
+            Coordinates               Weight
+  0.000000  0.000000  0.000000      1.000000
+ 
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+ Dimension of arrays:
+   k-points           NKPTS =      1   k-points in BZ     NKDIM =      1   number of bands    NBANDS=    128
+   number of dos      NEDOS =    301   number of ions     NIONS =      8
+   non local maximal  LDIM  =      5   non local SUM 2l+1 LMDIM =     15
+   total plane-waves  NPLWV =  32256
+   max r-space proj   IRMAX =   4928   max aug-charges    IRDMAX=  16257
+   dimension x,y,z NGX =    36 NGY =   32 NGZ =   28
+   dimension x,y,z NGXF=    72 NGYF=   64 NGZF=   56
+   support grid    NGXF=    72 NGYF=   64 NGZF=   56
+   ions per type =               3   2   3
+   NGX,Y,Z   is equivalent  to a cutoff of  10.19, 10.47, 10.02 a.u.
+   NGXF,Y,Z  is equivalent  to a cutoff of  20.38, 20.93, 20.03 a.u.
+
+ SYSTEM =  dpgen                                   
+ POSCAR =  POSCAR file written by OVITO Basic 3.10.
+
+ Startparameter for this run:
+   NWRITE =      0    write-flag & timer
+   PREC   = accura    normal or accurate (medium, high low for compatibility)
+   ISTART =      0    job   : 0-new  1-cont  2-samecut
+   ICHARG =      2    charge: 1-file 2-atom 10-const
+   ISPIN  =      1    spin polarized calculation?
+   LNONCOLLINEAR =      F non collinear calculations
+   LSORBIT =      F    spin-orbit coupling
+   INIWAV =      1    electr: 0-lowe 1-rand  2-diag
+   LASPH  =      F    aspherical Exc in radial PAW
+ Electronic Relaxation 1
+   ENCUT  =  350.0 eV  25.72 Ry    5.07 a.u.   8.96  7.75  7.09*2*pi/ulx,y,z
+   ENINI  =  350.0     initial cutoff
+   ENAUG  =  605.4 eV  augmentation charge cutoff
+   NELM   =    100;   NELMIN=  6; NELMDL= -5     # of ELM steps 
+   EDIFF  = 0.1E-05   stopping-criterion for ELM
+   LREAL  =      T    real-space projection
+   NLSPLINE    = F    spline interpolate recip. space projectors
+   LCOMPAT=      F    compatible to vasp.4.4
+   GGA_COMPAT  = T    GGA compatible to vasp.4.4-vasp.4.6
+   LMAXPAW     = -100 max onsite density
+   LMAXMIX     =    2 max onsite mixed and CHGCAR
+   VOSKOWN=      0    Vosko Wilk Nusair interpolation
+   ROPT   =   -0.00025  -0.00025  -0.00025
+ Ionic relaxation
+   EDIFFG = 0.1E-04   stopping-criterion for IOM
+   NSW    =      0    number of steps for IOM
+   NBLOCK =      1;   KBLOCK =      1    inner block; outer block 
+   IBRION =     -1    ionic relax: 0-MD 1-quasi-New 2-CG
+   NFREE  =      0    steps in history (QN), initial steepest desc. (CG)
+   ISIF   =      2    stress and relaxation
+   IWAVPR =     10    prediction:  0-non 1-charg 2-wave 3-comb
+   ISYM   =      0    0-nonsym 1-usesym 2-fastsym
+   LCORR  =      T    Harris-Foulkes like correction to forces
+
+   POTIM  = 2.0000    time-step for ionic-motion
+   TEIN   =    0.0    initial temperature
+   TEBEG  =    0.0;   TEEND  =   0.0 temperature during run
+   SMASS  =  -3.00    Nose mass-parameter (am)
+   estimated Nose-frequenzy (Omega)   =  0.10E-29 period in steps = 0.31E+46 mass=  -0.788E-27a.u.
+   SCALEE = 1.0000    scale energy and forces
+   NPACO  =    256;   APACO  = 10.0  distance and # of slots for P.C.
+   PSTRESS=    0.0 pullay stress
+
+  Mass of Ions in am
+   POMASS =  47.88 16.00 47.88
+  Ionic Valenz
+   ZVAL   =   4.00  6.00  4.00
+  Atomic Wigner-Seitz radii
+   RWIGS  =  -1.00 -1.00 -1.00
+  virtual crystal weights 
+   VCA    =   1.00  1.00  1.00
+   NELECT =      36.0000    total number of electrons
+   NUPDOWN=      -1.0000    fix difference up-down
+
+ DOS related values:
+   EMIN   =  10.00;   EMAX   =-10.00  energy-range for DOS
+   EFERMI =   0.00
+   ISMEAR =     1;   SIGMA  =   0.20  broadening in eV -4-tet -1-fermi 0-gaus
+
+ Electronic relaxation 2 (details)
+   IALGO  =     38    algorithm
+   LDIAG  =      T    sub-space diagonalisation (order eigenvalues)
+   LSUBROT=      F    optimize rotation matrix (better conditioning)
+   TURBO    =      0    0=normal 1=particle mesh
+   IRESTART =      0    0=no restart 2=restart with 2 vectors
+   NREBOOT  =      0    no. of reboots
+   NMIN     =      0    reboot dimension
+   EREF     =   0.00    reference energy to select bands
+   IMIX   =      4    mixing-type and parameters
+     AMIX     =   0.40;   BMIX     =  1.00
+     AMIX_MAG =   1.60;   BMIX_MAG =  1.00
+     AMIN     =   0.10
+     WC   =   100.;   INIMIX=   1;  MIXPRE=   1;  MAXMIX= -45
+
+ Intra band minimization:
+   WEIMIN = 0.0000     energy-eigenvalue tresh-hold
+   EBREAK =  0.20E-08  absolut break condition
+   DEPER  =   0.30     relativ break condition  
+
+   TIME   =   0.40     timestep for ELM
+
+  volume/ion in A,a.u.               =      17.34       117.01
+  Fermi-wavevector in a.u.,A,eV,Ry     =   1.044240  1.973328 14.836313  1.090438
+  Thomas-Fermi vector in A             =   2.178985
+ 
+ Write flags
+   LWAVE        =      F    write WAVECAR
+   LDOWNSAMPLE  =      F    k-point downsampling of WAVECAR
+   LCHARG       =      F    write CHGCAR
+   LVTOT        =      F    write LOCPOT, total local potential
+   LVHAR        =      F    write LOCPOT, Hartree potential only
+   LELF         =      F    write electronic localiz. function (ELF)
+   LORBIT       =      0    0 simple, 1 ext, 2 COOP (PROOUT), +10 PAW based schemes
+
+
+ Dipole corrections
+   LMONO  =      F    monopole corrections only (constant potential shift)
+   LDIPOL =      F    correct potential (dipole corrections)
+   IDIPOL =      0    1-x, 2-y, 3-z, 4-all directions 
+   EPSILON=  1.0000000 bulk dielectric constant
+
+ Exchange correlation treatment:
+   GGA     =    --    GGA type
+   LEXCH   =     8    internal setting for exchange type
+   LIBXC   =     F    Libxc                    
+   VOSKOWN =     0    Vosko Wilk Nusair interpolation
+   LHFCALC =     F    Hartree Fock is set to
+   LHFONE  =     F    Hartree Fock one center treatment
+   AEXX    =    0.0000 exact exchange contribution
+
+ Linear response parameters
+   LEPSILON=     F    determine dielectric tensor
+   LRPA    =     F    only Hartree local field effects (RPA)
+   LNABLA  =     F    use nabla operator in PAW spheres
+   LVEL    =     F    velocity operator in full k-point grid
+   CSHIFT  =0.1000    complex shift for real part using Kramers Kronig
+   OMEGAMAX=  -1.0    maximum frequency
+   DEG_THRESHOLD= 0.2000000E-02 threshold for treating states as degnerate
+   RTIME   =   -0.100 relaxation time in fs
+  (WPLASMAI=    0.000 imaginary part of plasma frequency in eV, 0.658/RTIME)
+   DFIELD  = 0.0000000 0.0000000 0.0000000 field for delta impulse in time
+ 
+  Optional k-point grid parameters
+   LKPOINTS_OPT  =     F    use optional k-point grid
+   KPOINTS_OPT_MODE=     1    mode for optional k-point grid
+ 
+ Orbital magnetization related:
+   ORBITALMAG=     F  switch on orbital magnetization
+   LCHIMAG   =     F  perturbation theory with respect to B field
+   DQ        =  0.001000  dq finite difference perturbation B field
+   LLRAUG    =     F  two centre corrections for induced B field
+
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+ Static calculation
+ charge density and potential will be updated during run
+ non-spin polarized calculation
+ Variant of blocked Davidson
+ Davidson routine will perform the subspace rotation
+ perform sub-space diagonalisation
+    after iterative eigenvector-optimisation
+ modified Broyden-mixing scheme, WC =      100.0
+ initial mixing is a Kerker type mixing with AMIX =  0.4000 and BMIX =      1.0000
+ Hartree-type preconditioning will be used
+ using additional bands          110
+ real space projection scheme for non local part
+ use partial core corrections
+ calculate Harris-corrections to forces 
+   (improved forces if not selfconsistent)
+ use gradient corrections 
+ use of overlap-Matrix (Vanderbilt PP)
+ Methfessel and Paxton  Order N= 1 SIGMA  =   0.20
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+  energy-cutoff  :      350.00
+  volume of cell :      138.72
+      direct lattice vectors                 reciprocal lattice vectors
+     5.871982203  0.000000000  0.000000000     0.170300244  0.000000000  0.000000000
+     0.000000000  5.082805747  0.000000000     0.000000000  0.196741731  0.000000000
+     0.000000000  0.000000000  4.647690000     0.000000000  0.000000000  0.215160650
+
+  length of vectors
+     5.871982203  5.082805747  4.647690000     0.170300244  0.196741731  0.215160650
+
+
+ 
+ k-points in units of 2pi/SCALE and weight: read from INCAR                         
+   0.00000000  0.00000000  0.00000000       1.000
+ 
+ k-points in reciprocal lattice and weights: read from INCAR                         
+   0.00000000  0.00000000  0.00000000       1.000
+ 
+ position of ions in fractional coordinates (direct lattice) 
+   0.04232415  0.10250303  0.24803642
+   0.04233768  0.76906824  0.74803113
+   0.29233207  0.26906640  0.74803203
+   0.29233083  0.60250330  0.24803510
+   0.54232415  0.10250303  0.24803642
+   0.54233768  0.76906824  0.74803113
+   0.79233207  0.26906640  0.74803203
+   0.79233083  0.60250330  0.24803510
+ 
+ position of ions in cartesian coordinates  (Angst):
+   0.24852663  0.52100297  1.15279639
+   0.24860612  3.90902449  3.47661680
+   1.71656871  1.36761223  3.47662101
+   1.71656146  3.06240725  1.15279023
+   3.18451774  0.52100297  1.15279639
+   3.18459723  3.90902449  3.47661680
+   4.65255982  1.36761223  3.47662101
+   4.65255256  3.06240725  1.15279023
+ 
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+ k-point   1 :   0.0000 0.0000 0.0000  plane waves:    2061
+
+ maximum and minimum number of plane-waves per node :      2061     2061
+
+ maximum number of plane-waves:      2061
+ maximum index in each direction: 
+   IXMAX=    8   IYMAX=    7   IZMAX=    7
+   IXMIN=   -8   IYMIN=   -7   IZMIN=   -7
+
+
+ serial   3D FFT for wavefunctions
+ parallel 3D FFT for charge:
+    minimum data exchange during FFTs selected (reduces bandwidth)
+
+
+ total amount of memory used by VASP MPI-rank0    36808. kBytes
+=======================================================================
+
+   base      :      30000. kBytes
+   nonlr-proj:       4860. kBytes
+   fftplans  :        282. kBytes
+   grid      :       1544. kBytes
+   one-center:         86. kBytes
+   wavefun   :         36. kBytes
+ 
+     INWAV:  cpu time      0.0001: real time      0.0001
+ Broyden mixing: mesh for mixing (old mesh)
+   NGX = 17   NGY = 15   NGZ = 15
+  (NGX  = 72   NGY  = 64   NGZ  = 56)
+  gives a total of   3825 points
+
+ initial charge density was supplied:
+ charge density of overlapping atoms calculated
+ number of electron      36.0000000 magnetization 
+ keeping initial charge density in first step
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+ Maximum index for non-local projection operator         4715
+ Maximum index for augmentation-charges          724 (set IRDMAX)
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+ First call to EWALD:  gamma=   0.342
+ Maximum number of real-space cells 2x 3x 3
+ Maximum number of reciprocal cells 3x 3x 3
+
+    FEWALD:  cpu time      0.0027: real time      0.0027
+
+
+--------------------------------------- Iteration      1(   1)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.1425: real time      0.1597
+    SETDIJ:  cpu time      0.0101: real time      0.0116
+     EDDAV:  cpu time      0.5043: real time      0.5621
+       DOS:  cpu time      0.0072: real time      0.0092
+    --------------------------------------------
+      LOOP:  cpu time      0.6641: real time      0.7426
+
+ eigenvalue-minimisations  :   256
+ total energy-change (2. order) :-0.4509380E+02  (-0.1244155E+04)
+ number of electron      36.0000000 magnetization 
+ augmentation part       36.0000000 magnetization 
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =       149.21459756
+  Ewald energy   TEWEN  =     -1320.89694581
+  -Hartree energ DENC   =      -340.66686448
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      -169.19906533
+  PAW double counting   =      1446.19366583    -1207.00626252
+  entropy T*S    EENTRO =        -0.01391075
+  eigenvalues    EBANDS =       -35.47240814
+  atomic energy  EATOM  =      1432.75339491
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =       -45.09379873 eV
+
+  energy without entropy =      -45.07988798  energy(sigma->0) =      -45.08916181
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(   2)  ---------------------------------------
+
+
+     EDDAV:  cpu time      0.8396: real time      0.8484
+       DOS:  cpu time      0.0043: real time      0.0043
+    --------------------------------------------
+      LOOP:  cpu time      0.8439: real time      0.8527
+
+ eigenvalue-minimisations  :   384
+ total energy-change (2. order) :-0.2362669E+02  (-0.2361664E+02)
+ number of electron      36.0000000 magnetization 
+ augmentation part       36.0000000 magnetization 
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =       149.21459756
+  Ewald energy   TEWEN  =     -1320.89694581
+  -Hartree energ DENC   =      -340.66686448
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      -169.19906533
+  PAW double counting   =      1446.19366583    -1207.00626252
+  entropy T*S    EENTRO =        -0.04771430
+  eigenvalues    EBANDS =       -59.06529221
+  atomic energy  EATOM  =      1432.75339491
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =       -68.72048634 eV
+
+  energy without entropy =      -68.67277204  energy(sigma->0) =      -68.70458158
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(   3)  ---------------------------------------
+
+
+     EDDAV:  cpu time      0.4514: real time      0.4625
+       DOS:  cpu time      0.0038: real time      0.0038
+    --------------------------------------------
+      LOOP:  cpu time      0.4552: real time      0.4663
+
+ eigenvalue-minimisations  :   256
+ total energy-change (2. order) :-0.2069685E-01  (-0.2069680E-01)
+ number of electron      36.0000000 magnetization 
+ augmentation part       36.0000000 magnetization 
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =       149.21459756
+  Ewald energy   TEWEN  =     -1320.89694581
+  -Hartree energ DENC   =      -340.66686448
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      -169.19906533
+  PAW double counting   =      1446.19366583    -1207.00626252
+  entropy T*S    EENTRO =        -0.04781065
+  eigenvalues    EBANDS =       -59.08589270
+  atomic energy  EATOM  =      1432.75339491
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =       -68.74118319 eV
+
+  energy without entropy =      -68.69337254  energy(sigma->0) =      -68.72524631
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(   4)  ---------------------------------------
+
+
+     EDDAV:  cpu time      1.4111: real time      1.4201
+       DOS:  cpu time      0.0039: real time      0.0039
+    --------------------------------------------
+      LOOP:  cpu time      1.4150: real time      1.4240
+
+ eigenvalue-minimisations  :   512
+ total energy-change (2. order) :-0.4637535E-05  (-0.4637293E-05)
+ number of electron      36.0000000 magnetization 
+ augmentation part       36.0000000 magnetization 
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =       149.21459756
+  Ewald energy   TEWEN  =     -1320.89694581
+  -Hartree energ DENC   =      -340.66686448
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      -169.19906533
+  PAW double counting   =      1446.19366583    -1207.00626252
+  entropy T*S    EENTRO =        -0.04781065
+  eigenvalues    EBANDS =       -59.08589734
+  atomic energy  EATOM  =      1432.75339491
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =       -68.74118783 eV
+
+  energy without entropy =      -68.69337718  energy(sigma->0) =      -68.72525094
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(   5)  ---------------------------------------
+
+
+     EDDAV:  cpu time      0.4493: real time      0.4571
+       DOS:  cpu time      0.0031: real time      0.0044
+    CHARGE:  cpu time      0.0161: real time      0.0191
+    MIXING:  cpu time      0.0150: real time      0.0175
+    --------------------------------------------
+      LOOP:  cpu time      0.4835: real time      0.4982
+
+ eigenvalue-minimisations  :   256
+ total energy-change (2. order) : 0.4774847E-11  (-0.1577866E-11)
+ number of electron      35.9999971 magnetization 
+ augmentation part        6.0422716 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.25649E+01    rms(broyden)= 0.25647E+01
+  rms(prec ) = 0.42061E+01
+  weight for this iteration     100.00
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =       149.21459756
+  Ewald energy   TEWEN  =     -1320.89694581
+  -Hartree energ DENC   =      -340.66686448
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      -169.19906533
+  PAW double counting   =      1446.19366583    -1207.00626252
+  entropy T*S    EENTRO =        -0.04781065
+  eigenvalues    EBANDS =       -59.08589734
+  atomic energy  EATOM  =      1432.75339491
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =       -68.74118783 eV
+
+  energy without entropy =      -68.69337718  energy(sigma->0) =      -68.72525094
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(   6)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.1424: real time      0.1533
+    SETDIJ:  cpu time      0.0179: real time      0.0179
+     EDDAV:  cpu time      1.4002: real time      1.4051
+       DOS:  cpu time      0.0041: real time      0.0041
+    CHARGE:  cpu time      0.0107: real time      0.0107
+    MIXING:  cpu time      0.0138: real time      0.0191
+    --------------------------------------------
+      LOOP:  cpu time      1.5890: real time      1.6102
+
+ eigenvalue-minimisations  :   512
+ total energy-change (2. order) : 0.2913973E+01  (-0.1872709E+02)
+ number of electron      36.0000000 magnetization 
+ augmentation part        8.6973312 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.25821E+01    rms(broyden)= 0.25800E+01
+  rms(prec ) = 0.55196E+01
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.5113
+  0.5113
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =       149.21459756
+  Ewald energy   TEWEN  =     -1320.89694581
+  -Hartree energ DENC   =      -372.14983427
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      -165.24511882
+  PAW double counting   =      1830.00792687    -1589.05074054
+  entropy T*S    EENTRO =        -0.02836379
+  eigenvalues    EBANDS =       -30.43213053
+  atomic energy  EATOM  =      1432.75339491
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =       -65.82721442 eV
+
+  energy without entropy =      -65.79885062  energy(sigma->0) =      -65.81775982
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(   7)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.1525: real time      0.1627
+    SETDIJ:  cpu time      0.0030: real time      0.0030
+     EDDAV:  cpu time      1.3984: real time      1.4453
+       DOS:  cpu time      0.0038: real time      0.0038
+    CHARGE:  cpu time      0.0097: real time      0.0097
+    MIXING:  cpu time      0.0128: real time      0.0145
+    --------------------------------------------
+      LOOP:  cpu time      1.5802: real time      1.6391
+
+ eigenvalue-minimisations  :   512
+ total energy-change (2. order) : 0.4915665E+01  (-0.1877841E+02)
+ number of electron      35.9999977 magnetization 
+ augmentation part        7.5474334 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.12562E+01    rms(broyden)= 0.12541E+01
+  rms(prec ) = 0.30279E+01
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.6911
+  1.0874  0.2949
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =       149.21459756
+  Ewald energy   TEWEN  =     -1320.89694581
+  -Hartree energ DENC   =      -336.80870568
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      -167.46836675
+  PAW double counting   =      1824.50465822    -1584.15991532
+  entropy T*S    EENTRO =         0.05706525
+  eigenvalues    EBANDS =       -58.10733132
+  atomic energy  EATOM  =      1432.75339491
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =       -60.91154893 eV
+
+  energy without entropy =      -60.96861418  energy(sigma->0) =      -60.93057068
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(   8)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.1330: real time      0.1430
+    SETDIJ:  cpu time      0.0030: real time      0.0030
+     EDDAV:  cpu time      0.4527: real time      0.4527
+       DOS:  cpu time      0.0040: real time      0.0040
+    CHARGE:  cpu time      0.0099: real time      0.0099
+    MIXING:  cpu time      0.0117: real time      0.0117
+    --------------------------------------------
+      LOOP:  cpu time      0.6143: real time      0.6243
+
+ eigenvalue-minimisations  :   256
+ total energy-change (2. order) : 0.1907934E+01  (-0.3532018E+01)
+ number of electron      35.9999979 magnetization 
+ augmentation part        7.6573809 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.82367E+00    rms(broyden)= 0.82347E+00
+  rms(prec ) = 0.19777E+01
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.6570
+  1.3531  0.3759  0.2422
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =       149.21459756
+  Ewald energy   TEWEN  =     -1320.89694581
+  -Hartree energ DENC   =      -333.69782623
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      -167.33247735
+  PAW double counting   =      1913.44897205    -1673.21016230
+  entropy T*S    EENTRO =        -0.09486516
+  eigenvalues    EBANDS =       -59.18830251
+  atomic energy  EATOM  =      1432.75339491
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =       -59.00361482 eV
+
+  energy without entropy =      -58.90874967  energy(sigma->0) =      -58.97199310
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(   9)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.1277: real time      0.1405
+    SETDIJ:  cpu time      0.0177: real time      0.0177
+     EDDAV:  cpu time      1.3956: real time      1.3959
+       DOS:  cpu time      0.0043: real time      0.0043
+    CHARGE:  cpu time      0.0093: real time      0.0093
+    MIXING:  cpu time      0.0125: real time      0.0125
+    --------------------------------------------
+      LOOP:  cpu time      1.5671: real time      1.5802
+
+ eigenvalue-minimisations  :   512
+ total energy-change (2. order) : 0.1312128E+01  (-0.9127418E+00)
+ number of electron      35.9999983 magnetization 
+ augmentation part        7.8226646 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.32324E+00    rms(broyden)= 0.32257E+00
+  rms(prec ) = 0.76765E+00
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.5429
+  1.3728  0.3898  0.2530  0.1559
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =       149.21459756
+  Ewald energy   TEWEN  =     -1320.89694581
+  -Hartree energ DENC   =      -340.34205961
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      -166.60208707
+  PAW double counting   =      2008.92943630    -1768.70255759
+  entropy T*S    EENTRO =         0.02579601
+  eigenvalues    EBANDS =       -52.07106201
+  atomic energy  EATOM  =      1432.75339491
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =       -57.69148731 eV
+
+  energy without entropy =      -57.71728332  energy(sigma->0) =      -57.70008598
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  10)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.1410: real time      0.1497
+    SETDIJ:  cpu time      0.0027: real time      0.0027
+     EDDAV:  cpu time      0.4419: real time      0.4419
+       DOS:  cpu time      0.0040: real time      0.0040
+    CHARGE:  cpu time      0.0099: real time      0.0099
+    MIXING:  cpu time      0.0118: real time      0.0118
+    --------------------------------------------
+      LOOP:  cpu time      0.6112: real time      0.6199
+
+ eigenvalue-minimisations  :   256
+ total energy-change (2. order) : 0.5165199E-01  (-0.4621710E-02)
+ number of electron      35.9999983 magnetization 
+ augmentation part        7.8226010 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.27695E+00    rms(broyden)= 0.27692E+00
+  rms(prec ) = 0.63316E+00
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.7157
+  1.7471  1.0184  0.3602  0.2480  0.2048
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =       149.21459756
+  Ewald energy   TEWEN  =     -1320.89694581
+  -Hartree energ DENC   =      -340.37794476
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      -166.59044365
+  PAW double counting   =      2011.54595350    -1771.31963635
+  entropy T*S    EENTRO =         0.01133417
+  eigenvalues    EBANDS =       -51.98014490
+  atomic energy  EATOM  =      1432.75339491
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =       -57.63983531 eV
+
+  energy without entropy =      -57.65116949  energy(sigma->0) =      -57.64361337
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  11)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.1385: real time      0.1430
+    SETDIJ:  cpu time      0.0169: real time      0.0169
+     EDDAV:  cpu time      0.8105: real time      0.8108
+       DOS:  cpu time      0.0042: real time      0.0042
+    CHARGE:  cpu time      0.0101: real time      0.0104
+    MIXING:  cpu time      0.0125: real time      0.0129
+    --------------------------------------------
+      LOOP:  cpu time      0.9928: real time      0.9983
+
+ eigenvalue-minimisations  :   384
+ total energy-change (2. order) : 0.1486595E+00  (-0.9280671E-01)
+ number of electron      35.9999984 magnetization 
+ augmentation part        8.0190870 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.11242E+00    rms(broyden)= 0.11228E+00
+  rms(prec ) = 0.17370E+00
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.8661
+  1.7915  1.7915  0.7978  0.3815  0.2419  0.1921
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =       149.21459756
+  Ewald energy   TEWEN  =     -1320.89694581
+  -Hartree energ DENC   =      -340.42184557
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      -166.35075620
+  PAW double counting   =      2071.50791165    -1831.33971226
+  entropy T*S    EENTRO =        -0.03198149
+  eigenvalues    EBANDS =       -51.92583862
+  atomic energy  EATOM  =      1432.75339491
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =       -57.49117582 eV
+
+  energy without entropy =      -57.45919433  energy(sigma->0) =      -57.48051533
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  12)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.1510: real time      0.1562
+    SETDIJ:  cpu time      0.0128: real time      0.0128
+     EDDAV:  cpu time      0.8083: real time      0.8086
+       DOS:  cpu time      0.0036: real time      0.0036
+    CHARGE:  cpu time      0.0094: real time      0.0094
+    MIXING:  cpu time      0.0101: real time      0.0101
+    --------------------------------------------
+      LOOP:  cpu time      0.9954: real time      1.0008
+
+ eigenvalue-minimisations  :   384
+ total energy-change (2. order) : 0.4633969E-02  (-0.1408698E-01)
+ number of electron      35.9999984 magnetization 
+ augmentation part        7.9801458 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.54973E-01    rms(broyden)= 0.54933E-01
+  rms(prec ) = 0.12592E+00
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.9656
+  2.2199  1.6503  1.3090  0.7632  0.3830  0.2415  0.1923
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =       149.21459756
+  Ewald energy   TEWEN  =     -1320.89694581
+  -Hartree energ DENC   =      -339.78507728
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      -166.39787576
+  PAW double counting   =      2078.25224234    -1838.32625423
+  entropy T*S    EENTRO =        -0.01972211
+  eigenvalues    EBANDS =       -52.28090148
+  atomic energy  EATOM  =      1432.75339491
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =       -57.48654186 eV
+
+  energy without entropy =      -57.46681975  energy(sigma->0) =      -57.47996782
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  13)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.1431: real time      0.1538
+    SETDIJ:  cpu time      0.0034: real time      0.0034
+     EDDAV:  cpu time      1.4095: real time      1.4099
+       DOS:  cpu time      0.0043: real time      0.0043
+    CHARGE:  cpu time      0.0098: real time      0.0098
+    MIXING:  cpu time      0.0125: real time      0.0143
+    --------------------------------------------
+      LOOP:  cpu time      1.5826: real time      1.5956
+
+ eigenvalue-minimisations  :   512
+ total energy-change (2. order) : 0.2010473E-03  (-0.8083608E-02)
+ number of electron      35.9999984 magnetization 
+ augmentation part        8.0066949 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.52789E-01    rms(broyden)= 0.52768E-01
+  rms(prec ) = 0.14476E+00
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.8943
+  2.4066  1.4831  1.4831  0.7708  0.3828  0.2418  0.1931  0.1931
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =       149.21459756
+  Ewald energy   TEWEN  =     -1320.89694581
+  -Hartree energ DENC   =      -340.17189112
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      -166.34563020
+  PAW double counting   =      2086.18272507    -1846.31440123
+  entropy T*S    EENTRO =        -0.03046851
+  eigenvalues    EBANDS =       -51.87772149
+  atomic energy  EATOM  =      1432.75339491
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =       -57.48634081 eV
+
+  energy without entropy =      -57.45587229  energy(sigma->0) =      -57.47618464
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  14)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.1432: real time      0.1542
+    SETDIJ:  cpu time      0.0025: real time      0.0025
+     EDDAV:  cpu time      0.4433: real time      0.4437
+       DOS:  cpu time      0.0043: real time      0.0043
+    CHARGE:  cpu time      0.0099: real time      0.0099
+    MIXING:  cpu time      0.0120: real time      0.0121
+    --------------------------------------------
+      LOOP:  cpu time      0.6153: real time      0.6266
+
+ eigenvalue-minimisations  :   256
+ total energy-change (2. order) : 0.1732079E-02  (-0.3580945E-02)
+ number of electron      35.9999984 magnetization 
+ augmentation part        8.0128845 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.30804E-01    rms(broyden)= 0.30794E-01
+  rms(prec ) = 0.73595E-01
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.9250
+  2.6275  1.5747  1.5747  0.8866  0.7001  0.3833  0.2414  0.1923  0.1447
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =       149.21459756
+  Ewald energy   TEWEN  =     -1320.89694581
+  -Hartree energ DENC   =      -340.27940868
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      -166.33045955
+  PAW double counting   =      2088.64100204    -1848.79074008
+  entropy T*S    EENTRO =        -0.03257842
+  eigenvalues    EBANDS =       -51.76347071
+  atomic energy  EATOM  =      1432.75339491
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =       -57.48460873 eV
+
+  energy without entropy =      -57.45203031  energy(sigma->0) =      -57.47374926
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  15)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.1530: real time      0.1643
+    SETDIJ:  cpu time      0.0030: real time      0.0030
+     EDDAV:  cpu time      0.8068: real time      0.8069
+       DOS:  cpu time      0.0041: real time      0.0041
+    CHARGE:  cpu time      0.0103: real time      0.0103
+    MIXING:  cpu time      0.0123: real time      0.0123
+    --------------------------------------------
+      LOOP:  cpu time      0.9896: real time      1.0011
+
+ eigenvalue-minimisations  :   384
+ total energy-change (2. order) : 0.1003813E-02  (-0.6492154E-03)
+ number of electron      35.9999984 magnetization 
+ augmentation part        8.0064500 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.10331E-01    rms(broyden)= 0.10325E-01
+  rms(prec ) = 0.22958E-01
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.8899
+  2.6101  1.6279  1.6279  0.8808  0.6896  0.5022  0.3826  0.2414  0.1923  0.1441
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =       149.21459756
+  Ewald energy   TEWEN  =     -1320.89694581
+  -Hartree energ DENC   =      -340.25126586
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      -166.33105444
+  PAW double counting   =      2089.62746255    -1849.78626063
+  entropy T*S    EENTRO =        -0.02699240
+  eigenvalues    EBANDS =       -51.78654080
+  atomic energy  EATOM  =      1432.75339491
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =       -57.48360492 eV
+
+  energy without entropy =      -57.45661252  energy(sigma->0) =      -57.47460745
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  16)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.1463: real time      0.1560
+    SETDIJ:  cpu time      0.0077: real time      0.0077
+     EDDAV:  cpu time      0.8086: real time      0.8104
+       DOS:  cpu time      0.0046: real time      0.0046
+    CHARGE:  cpu time      0.0099: real time      0.0101
+    MIXING:  cpu time      0.0128: real time      0.0128
+    --------------------------------------------
+      LOOP:  cpu time      0.9897: real time      1.0015
+
+ eigenvalue-minimisations  :   384
+ total energy-change (2. order) : 0.8937704E-04  (-0.8260131E-04)
+ number of electron      35.9999984 magnetization 
+ augmentation part        8.0043950 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.73265E-02    rms(broyden)= 0.73230E-02
+  rms(prec ) = 0.16204E-01
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.9019
+  2.5094  1.8015  1.8015  0.9731  0.9731  0.7140  0.3831  0.2414  0.1923  0.1438
+  0.1882
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =       149.21459756
+  Ewald energy   TEWEN  =     -1320.89694581
+  -Hartree energ DENC   =      -340.22995345
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      -166.33380657
+  PAW double counting   =      2089.32803941    -1849.48655463
+  entropy T*S    EENTRO =        -0.02652456
+  eigenvalues    EBANDS =       -51.80576241
+  atomic energy  EATOM  =      1432.75339491
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =       -57.48351554 eV
+
+  energy without entropy =      -57.45699098  energy(sigma->0) =      -57.47467402
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  17)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.1415: real time      0.1515
+    SETDIJ:  cpu time      0.0032: real time      0.0032
+     EDDAV:  cpu time      1.3969: real time      1.3972
+       DOS:  cpu time      0.0044: real time      0.0044
+    CHARGE:  cpu time      0.0094: real time      0.0094
+    MIXING:  cpu time      0.0142: real time      0.0142
+    --------------------------------------------
+      LOOP:  cpu time      1.5696: real time      1.5799
+
+ eigenvalue-minimisations  :   512
+ total energy-change (2. order) : 0.7295949E-04  (-0.8783187E-04)
+ number of electron      35.9999984 magnetization 
+ augmentation part        7.9990647 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.27339E-02    rms(broyden)= 0.27193E-02
+  rms(prec ) = 0.49627E-02
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.9280
+  2.6211  1.8502  1.8502  1.0515  1.0515  0.7833  0.7833  0.3830  0.2414  0.1923
+  0.1438  0.1846
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =       149.21459756
+  Ewald energy   TEWEN  =     -1320.89694581
+  -Hartree energ DENC   =      -340.17471846
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      -166.34121492
+  PAW double counting   =      2088.40941689    -1848.56600775
+  entropy T*S    EENTRO =        -0.02518900
+  eigenvalues    EBANDS =       -51.85677601
+  atomic energy  EATOM  =      1432.75339491
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =       -57.48344258 eV
+
+  energy without entropy =      -57.45825358  energy(sigma->0) =      -57.47504625
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  18)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.1364: real time      0.1448
+    SETDIJ:  cpu time      0.0028: real time      0.0028
+     EDDAV:  cpu time      0.8190: real time      0.8192
+       DOS:  cpu time      0.0031: real time      0.0046
+    CHARGE:  cpu time      0.0098: real time      0.0098
+    MIXING:  cpu time      0.0339: real time      0.0339
+    --------------------------------------------
+      LOOP:  cpu time      1.0050: real time      1.0151
+
+ eigenvalue-minimisations  :   384
+ total energy-change (2. order) :-0.3837288E-05  (-0.1016701E-04)
+ number of electron      35.9999984 magnetization 
+ augmentation part        7.9992424 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.26668E-02    rms(broyden)= 0.26661E-02
+  rms(prec ) = 0.60258E-02
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.9235
+  2.8037  2.0106  1.7292  1.2193  1.2193  0.8729  0.7570  0.3830  0.2414  0.2495
+  0.1923  0.1438  0.1837
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =       149.21459756
+  Ewald energy   TEWEN  =     -1320.89694581
+  -Hartree energ DENC   =      -340.18030791
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      -166.34043983
+  PAW double counting   =      2088.44404602    -1848.59894885
+  entropy T*S    EENTRO =        -0.02513904
+  eigenvalues    EBANDS =       -51.85370347
+  atomic energy  EATOM  =      1432.75339491
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =       -57.48344642 eV
+
+  energy without entropy =      -57.45830738  energy(sigma->0) =      -57.47506674
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  19)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.1348: real time      0.1450
+    SETDIJ:  cpu time      0.0033: real time      0.0033
+     EDDAV:  cpu time      0.8072: real time      0.8109
+       DOS:  cpu time      0.0043: real time      0.0043
+    CHARGE:  cpu time      0.0096: real time      0.0096
+    MIXING:  cpu time      0.0129: real time      0.0129
+    --------------------------------------------
+      LOOP:  cpu time      0.9720: real time      0.9860
+
+ eigenvalue-minimisations  :   384
+ total energy-change (2. order) : 0.5994765E-05  (-0.7218330E-05)
+ number of electron      35.9999984 magnetization 
+ augmentation part        8.0000380 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.14093E-02    rms(broyden)= 0.14086E-02
+  rms(prec ) = 0.35865E-02
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.9203
+  2.8259  2.1243  1.5395  1.5395  1.1339  0.8200  0.8200  0.6964  0.3830  0.2414
+  0.2408  0.1923  0.1438  0.1834
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =       149.21459756
+  Ewald energy   TEWEN  =     -1320.89694581
+  -Hartree energ DENC   =      -340.19210337
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      -166.33867253
+  PAW double counting   =      2088.57222872    -1848.72469109
+  entropy T*S    EENTRO =        -0.02522472
+  eigenvalues    EBANDS =       -51.84602411
+  atomic energy  EATOM  =      1432.75339491
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =       -57.48344042 eV
+
+  energy without entropy =      -57.45821571  energy(sigma->0) =      -57.47503218
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  20)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.1741: real time      0.1842
+    SETDIJ:  cpu time      0.0027: real time      0.0027
+     EDDAV:  cpu time      0.8664: real time      0.8715
+       DOS:  cpu time      0.0044: real time      0.0044
+    CHARGE:  cpu time      0.0102: real time      0.0102
+    MIXING:  cpu time      0.0132: real time      0.0132
+    --------------------------------------------
+      LOOP:  cpu time      1.0708: real time      1.0861
+
+ eigenvalue-minimisations  :   384
+ total energy-change (2. order) : 0.2663354E-05  (-0.1232949E-05)
+ number of electron      35.9999984 magnetization 
+ augmentation part        8.0001657 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.51580E-03    rms(broyden)= 0.51515E-03
+  rms(prec ) = 0.12335E-02
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.9054
+  2.8286  2.1644  1.5693  1.5693  1.1237  0.8821  0.8821  0.7333  0.3830  0.4454
+  0.1438  0.1923  0.2414  0.2391  0.1833
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =       149.21459756
+  Ewald energy   TEWEN  =     -1320.89694581
+  -Hartree energ DENC   =      -340.18863565
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      -166.33880885
+  PAW double counting   =      2088.53158050    -1848.68305863
+  entropy T*S    EENTRO =        -0.02540127
+  eigenvalues    EBANDS =       -51.85016054
+  atomic energy  EATOM  =      1432.75339491
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =       -57.48343776 eV
+
+  energy without entropy =      -57.45803649  energy(sigma->0) =      -57.47497067
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  21)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.1496: real time      0.1587
+    SETDIJ:  cpu time      0.0145: real time      0.0145
+     EDDAV:  cpu time      0.2362: real time      0.2433
+       DOS:  cpu time      0.0042: real time      0.0042
+    --------------------------------------------
+      LOOP:  cpu time      0.4046: real time      0.4208
+
+ eigenvalue-minimisations  :   128
+ total energy-change (2. order) : 0.4734277E-06  (-0.1766329E-06)
+ number of electron      35.9999984 magnetization 
+ augmentation part        8.0001657 magnetization 
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =       149.21459756
+  Ewald energy   TEWEN  =     -1320.89694581
+  -Hartree energ DENC   =      -340.18729532
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      -166.33888735
+  PAW double counting   =      2088.50860028    -1848.65967198
+  entropy T*S    EENTRO =        -0.02544838
+  eigenvalues    EBANDS =       -51.85178121
+  atomic energy  EATOM  =      1432.75339491
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =       -57.48343729 eV
+
+  energy without entropy =      -57.45798891  energy(sigma->0) =      -57.47495449
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+ average (electrostatic) potential at core
+  the test charge radii are     1.2598  0.7215  1.2598
+  (the norm of the test charge is              1.0000)
+       1 -28.0011       2 -27.6603       3 -27.9857       4 -73.3905       5 -73.3907
+       6 -27.9857       7 -27.6602       8 -28.0011
+ 
+ 
+ 
+ E-fermi :   2.1341     XC(G=0): -10.4124     alpha+bet : -9.2977
+
+ Fermi energy:         2.1341126282
+
+ k-point     1 :       0.0000    0.0000    0.0000
+  band No.  band energies     occupation 
+      1     -14.8338      2.00000
+      2     -14.4401      2.00000
+      3      -2.6050      2.00000
+      4      -1.3412      2.00000
+      5      -1.0744      2.00000
+      6      -1.0332      2.00000
+      7      -1.0043      2.00000
+      8      -0.8333      2.00000
+      9       0.1483      2.00000
+     10       0.2015      2.00000
+     11       1.0105      2.00000
+     12       1.0177      2.00000
+     13       1.1660      2.00000
+     14       1.2742      2.00000
+     15       1.4083      2.00000
+     16       1.4490      2.00001
+     17       1.5042      2.00008
+     18       2.0379      1.71878
+     19       2.2253      0.31011
+     20       2.3000      0.00566
+     21       2.4870     -0.03169
+     22       2.6231     -0.00295
+     23       2.9206     -0.00000
+     24       2.9297     -0.00000
+     25       2.9701     -0.00000
+     26       3.0920     -0.00000
+     27       3.6168     -0.00000
+     28       3.6257     -0.00000
+     29       3.8840     -0.00000
+     30       3.9191     -0.00000
+     31       4.0241     -0.00000
+     32       4.0446     -0.00000
+     33       4.3509     -0.00000
+     34       4.4768     -0.00000
+     35       4.5413     -0.00000
+     36       4.5541     -0.00000
+     37       4.7307     -0.00000
+     38       5.2836     -0.00000
+     39       5.3149     -0.00000
+     40       5.6955     -0.00000
+     41       6.2666     -0.00000
+     42       6.2818     -0.00000
+     43       6.2836     -0.00000
+     44       8.0487      0.00000
+     45       9.8849      0.00000
+     46      10.2583      0.00000
+     47      10.4112      0.00000
+     48      10.6540      0.00000
+     49      10.8337      0.00000
+     50      11.3241      0.00000
+     51      11.7073      0.00000
+     52      12.1050      0.00000
+     53      13.0823      0.00000
+     54      13.4307      0.00000
+     55      13.7056      0.00000
+     56      13.8640      0.00000
+     57      15.2230      0.00000
+     58      15.7464      0.00000
+     59      15.7866      0.00000
+     60      15.8964      0.00000
+     61      16.9974      0.00000
+     62      17.0548      0.00000
+     63      17.3805      0.00000
+     64      18.1921      0.00000
+     65      18.5666      0.00000
+     66      18.7118      0.00000
+     67      19.5674      0.00000
+     68      19.9026      0.00000
+     69      19.9534      0.00000
+     70      20.7588      0.00000
+     71      21.7603      0.00000
+     72      21.8212      0.00000
+     73      22.5272      0.00000
+     74      22.6121      0.00000
+     75      23.2475      0.00000
+     76      23.6013      0.00000
+     77      23.7268      0.00000
+     78      24.5881      0.00000
+     79      24.6734      0.00000
+     80      24.8087      0.00000
+     81      24.8521      0.00000
+     82      24.9440      0.00000
+     83      25.2723      0.00000
+     84      25.9306      0.00000
+     85      26.0470      0.00000
+     86      26.3701      0.00000
+     87      26.3837      0.00000
+     88      26.8439      0.00000
+     89      27.4781      0.00000
+     90      27.5912      0.00000
+     91      27.8200      0.00000
+     92      27.8659      0.00000
+     93      28.2819      0.00000
+     94      28.6623      0.00000
+     95      28.6726      0.00000
+     96      28.7351      0.00000
+     97      29.1619      0.00000
+     98      29.8769      0.00000
+     99      29.9126      0.00000
+    100      30.0647      0.00000
+    101      30.1068      0.00000
+    102      30.6352      0.00000
+    103      30.6523      0.00000
+    104      30.7936      0.00000
+    105      31.5254      0.00000
+    106      31.8083      0.00000
+    107      32.0340      0.00000
+    108      32.5288      0.00000
+    109      32.9961      0.00000
+    110      33.0020      0.00000
+    111      33.3344      0.00000
+    112      33.4052      0.00000
+    113      33.5275      0.00000
+    114      34.8649      0.00000
+    115      34.9384      0.00000
+    116      35.1531      0.00000
+    117      35.2974      0.00000
+    118      36.0745      0.00000
+    119      36.2444      0.00000
+    120      36.8973      0.00000
+    121      37.4623      0.00000
+    122      38.2356      0.00000
+    123      38.2926      0.00000
+    124      38.7569      0.00000
+    125      39.0149      0.00000
+    126      39.4083      0.00000
+    127      39.4995      0.00000
+    128      39.6990      0.00000
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+ soft charge-density along one line, spin component           1
+         0         1         2         3         4         5         6         7         8         9
+ total charge-density along one line
+ 
+ pseudopotential strength for first ion, spin component:           1
+ -4.429  -0.000   0.025  -0.000  -0.003  -4.569  -0.000   0.030
+ -0.000  -4.287  -0.000  -0.023   0.000  -0.000  -4.402  -0.000
+  0.025  -0.000  -4.284  -0.000   0.047   0.030  -0.000  -4.398
+ -0.000  -0.023  -0.000  -4.374   0.000  -0.000  -0.027  -0.000
+ -0.003   0.000   0.047   0.000  -4.430  -0.003   0.000   0.056
+ -4.569  -0.000   0.030  -0.000  -0.003  -4.612  -0.000   0.035
+ -0.000  -4.402  -0.000  -0.027   0.000  -0.000  -4.415  -0.000
+  0.030  -0.000  -4.398  -0.000   0.056   0.035  -0.000  -4.410
+ -0.000  -0.027  -0.000  -4.505   0.000  -0.000  -0.031  -0.000
+ -0.003   0.000   0.056   0.000  -4.571  -0.004   0.000   0.066
+  0.008   0.000  -0.025   0.000   0.015   0.010   0.000  -0.030
+ -0.016  -0.000   0.052  -0.000  -0.030  -0.018  -0.000   0.062
+ -0.021   0.000   0.002   0.000   0.006  -0.025   0.000   0.003
+  0.000  -0.003   0.000  -0.015  -0.000   0.000  -0.004   0.000
+ -0.001   0.000   0.012   0.000  -0.016  -0.001   0.000   0.015
+ total augmentation occupancy for first ion, spin component:           1
+  1.815  -0.000   0.062  -0.000  -0.185  -0.764   0.000  -0.017   0.000   0.030  -0.040  -0.001  -0.187  -0.000   0.041
+ -0.000   2.233  -0.000  -0.024   0.000   0.000  -0.958   0.000  -0.007  -0.000  -0.000  -0.000   0.000   0.010  -0.000
+  0.062  -0.000   3.190  -0.000   0.471  -0.022   0.000  -1.575   0.000  -0.224   0.637   0.022   0.006   0.000   0.119
+ -0.000  -0.024  -0.000   1.634   0.000   0.000  -0.006   0.000  -0.608  -0.000   0.000   0.000  -0.000  -0.045   0.000
+ -0.185   0.000   0.471   0.000   1.096   0.029  -0.000  -0.216  -0.000  -0.540  -0.300  -0.014   0.110   0.000   0.002
+ -0.764   0.000  -0.022   0.000   0.029   0.339  -0.000   0.008  -0.000   0.002   0.004   0.001   0.026   0.000  -0.029
+  0.000  -0.958   0.000  -0.006  -0.000  -0.000   0.417  -0.000   0.013   0.000   0.000   0.000  -0.000  -0.001  -0.000
+ -0.017   0.000  -1.575   0.000  -0.216   0.008  -0.000   0.818  -0.000   0.099  -0.416  -0.013  -0.011  -0.000  -0.065
+  0.000  -0.007   0.000  -0.608  -0.000  -0.000   0.013  -0.000   0.232   0.000  -0.000  -0.000  -0.000   0.025  -0.000
+  0.030  -0.000  -0.224  -0.000  -0.540   0.002   0.000   0.099   0.000   0.300   0.216   0.008  -0.036  -0.000  -0.002
+ -0.040  -0.000   0.637   0.000  -0.300   0.004   0.000  -0.416  -0.000   0.216   1.676   0.033   0.015   0.000  -0.090
+ -0.001  -0.000   0.022   0.000  -0.014   0.001   0.000  -0.013  -0.000   0.008   0.033   0.002   0.000  -0.000  -0.002
+ -0.187   0.000   0.006  -0.000   0.110   0.026  -0.000  -0.011  -0.000  -0.036   0.015   0.000   0.253   0.000  -0.004
+ -0.000   0.010   0.000  -0.045   0.000   0.000  -0.001  -0.000   0.025  -0.000   0.000  -0.000   0.000   0.220   0.000
+  0.041  -0.000   0.119   0.000   0.002  -0.029  -0.000  -0.065  -0.000  -0.002  -0.090  -0.002  -0.004   0.000   0.178
+
+
+------------------------ aborting loop because EDIFF is reached ----------------------------------------
+
+
+    CHARGE:  cpu time      0.0102: real time      0.0105
+    FORLOC:  cpu time      0.0080: real time      0.0117
+    FORNL :  cpu time      0.0286: real time      0.0299
+    STRESS:  cpu time      0.0789: real time      0.0817
+    FORCOR:  cpu time      0.0720: real time      0.1158
+    FORHAR:  cpu time      0.0509: real time      0.0544
+    MIXING:  cpu time      0.0025: real time      0.0025
+    OFIELD:  cpu time      0.0013: real time      0.0014
+
+  FORCE on cell =-STRESS in cart. coord.  units (eV):
+  Direction    XX          YY          ZZ          XY          YZ          ZX
+  --------------------------------------------------------------------------------------
+  Alpha Z   149.21460   149.21460   149.21460
+  Ewald    -452.07920  -434.53522  -434.28322    -0.00234    -0.00000     0.00002
+  Hartree   100.21437   137.12035   102.85476    -0.00067     0.00001     0.00003
+  E(xc)    -144.84874  -146.23460  -145.28353    -0.00004    -0.00003     0.00000
+  Local     -45.59152  -104.89569   -67.51611     0.00259    -0.00001    -0.00004
+  n-local   -72.87378   -74.66983   -88.22238    -0.00046     0.00024    -0.00012
+  augment    47.06780    48.97621    49.81845     0.00019    -0.00018     0.00003
+  Kinetic   401.66714   409.27925   401.02013     0.00045     0.00025    -0.00005
+  Fock        0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+  -------------------------------------------------------------------------------------
+  Total     -17.22932   -15.74493   -32.39732    -0.00027     0.00028    -0.00013
+  in kB    -199.00014  -181.85530  -374.19175    -0.00312     0.00325    -0.00151
+  external pressure =     -251.68 kB  Pullay stress =        0.00 kB
+
+
+ VOLUME and BASIS-vectors are now :
+ -----------------------------------------------------------------------------
+  energy-cutoff  :      350.00
+  volume of cell :      138.72
+      direct lattice vectors                 reciprocal lattice vectors
+     5.871982203  0.000000000  0.000000000     0.170300244  0.000000000  0.000000000
+     0.000000000  5.082805747  0.000000000     0.000000000  0.196741731  0.000000000
+     0.000000000  0.000000000  4.647690000     0.000000000  0.000000000  0.215160650
+
+  length of vectors
+     5.871982203  5.082805747  4.647690000     0.170300244  0.196741731  0.215160650
+
+
+ FORCES acting on ions
+    electron-ion (+dipol)            ewald-force                    non-local-force                 convergence-correction
+ -----------------------------------------------------------------------------------------------
+   0.814E+01 -.395E+00 0.142E-02   -.866E+01 0.321E-02 -.150E-02   0.186E+01 0.190E+00 0.331E-04   -.183E-02 -.209E-03 -.620E-07
+   0.883E+01 -.179E+01 -.170E-02   -.939E+01 0.256E+01 0.175E-02   0.524E+00 -.179E+01 -.796E-04   -.157E-02 -.308E-03 -.183E-07
+   0.995E+01 0.241E+01 -.186E-02   -.939E+01 -.257E+01 0.183E-02   0.153E+01 0.136E+01 -.472E-04   -.114E-02 0.259E-03 0.271E-07
+   0.110E+02 0.173E+01 0.176E-02   -.130E+02 0.414E-02 -.209E-02   0.136E+01 -.172E+01 0.117E-03   -.271E-02 0.771E-03 -.209E-07
+   -.110E+02 0.173E+01 0.182E-02   0.130E+02 0.482E-02 -.225E-02   -.136E+01 -.172E+01 0.199E-03   0.359E-02 0.642E-03 -.259E-07
+   -.995E+01 0.241E+01 -.204E-02   0.939E+01 -.257E+01 0.198E-02   -.153E+01 0.136E+01 -.506E-04   0.184E-02 -.401E-03 -.715E-08
+   -.883E+01 -.179E+01 -.166E-02   0.939E+01 0.256E+01 0.169E-02   -.524E+00 -.179E+01 0.154E-04   0.874E-03 0.410E-03 0.200E-07
+   -.814E+01 -.394E+00 0.133E-02   0.866E+01 0.276E-02 -.140E-02   -.186E+01 0.190E+00 -.207E-04   0.120E-02 -.273E-03 -.248E-07
+ -----------------------------------------------------------------------------------------------
+   0.640E-03 0.391E+01 -.939E-03   0.711E-14 0.266E-14 -.693E-15   -.348E-03 -.391E+01 0.167E-03   0.246E-03 0.892E-03 -.112E-06
+ 
+ 
+ POSITION                                       TOTAL-FORCE (eV/Angst)
+ -----------------------------------------------------------------------------------
+      0.24853      0.52100      1.15280         1.344461     -0.201954      0.000044
+      0.24861      3.90902      3.47662        -0.036895     -1.019247      0.000065
+      1.71657      1.36761      3.47662         2.080383      1.200874      0.000010
+      1.71656      3.06241      1.15279        -0.626845      0.020242     -0.000117
+      3.18452      0.52100      1.15280         0.627302      0.020241     -0.000139
+      3.18460      3.90902      3.47662        -2.080833      1.201120     -0.000010
+      4.65256      1.36761      3.47662         0.036608     -1.019125      0.000138
+      4.65255      3.06241      1.15279        -1.344181     -0.202151      0.000009
+ -----------------------------------------------------------------------------------
+    total drift:                                0.000539      0.001275     -0.000772
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+  FREE ENERGIE OF THE ION-ELECTRON SYSTEM (eV)
+  ---------------------------------------------------
+  free  energy   TOTEN  =       -57.48343729 eV
+
+  energy  without entropy=      -57.45798891  energy(sigma->0) =      -57.47495449
+ 
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+    POTLOK:  cpu time      0.1461: real time      0.1473
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+     LOOP+:  cpu time     21.4366: real time     21.8690
+    4ORBIT:  cpu time      0.0007: real time      0.0011
+
+ total amount of memory used by VASP MPI-rank0    36808. kBytes
+=======================================================================
+
+   base      :      30000. kBytes
+   nonlr-proj:       4860. kBytes
+   fftplans  :        282. kBytes
+   grid      :       1544. kBytes
+   one-center:         86. kBytes
+   wavefun   :         36. kBytes
+ 
+  
+  
+ General timing and accounting informations for this job:
+ ========================================================
+  
+                  Total CPU time used (sec):       27.244
+                            User time (sec):       25.022
+                          System time (sec):        2.222
+                         Elapsed time (sec):       31.413
+  
+                   Maximum memory used (kb):      354228.
+                   Average memory used (kb):          N/A
+  
+                          Minor page faults:        44897
+                          Major page faults:            0
+                 Voluntary context switches:         7025

--- a/tests/poscars/Ti-O-Ti-v6/vasprun.xml
+++ b/tests/poscars/Ti-O-Ti-v6/vasprun.xml
@@ -1,0 +1,1205 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<modeling>
+ <generator>
+  <i name="program" type="string">vasp </i>
+  <i name="version" type="string">6.3.0  </i>
+  <i name="subversion" type="string">20Jan22 (build Apr 09 2022 18:33:31) complex                          parallel </i>
+  <i name="platform" type="string">LinuxIFC </i>
+  <i name="date" type="string">2025 07 07 </i>
+  <i name="time" type="string">11:18:24 </i>
+ </generator>
+ <incar>
+  <i type="string" name="SYSTEM">dpgen</i>
+  <i type="int" name="ISTART">     0</i>
+  <i type="string" name="PREC">Accurate</i>
+  <i type="string" name="ALGO">Normal</i>
+  <i type="int" name="ICHARG">     2</i>
+  <i type="int" name="NELM">   100</i>
+  <i type="int" name="NELMDL">    -5</i>
+  <i type="int" name="NELMIN">     6</i>
+  <i type="int" name="IBRION">    -1</i>
+  <i name="EDIFF">      0.00000100</i>
+  <i type="int" name="NSW">     0</i>
+  <i type="int" name="ISIF">     2</i>
+  <i type="int" name="ISYM">     0</i>
+  <i name="ENCUT">    350.00000000</i>
+  <i name="POTIM">      2.00000000</i>
+  <i type="string" name="LREAL">A</i>
+  <i type="int" name="ISMEAR">     1</i>
+  <i name="SIGMA">      0.20000000</i>
+  <i name="KSPACING">     10.00000000</i>
+  <i type="logical" name="KGAMMA"> F  </i>
+  <i type="int" name="NWRITE">     0</i>
+  <i name="PSTRESS">      0.00000000</i>
+  <i type="logical" name="LWAVE"> F  </i>
+  <i type="logical" name="LCHARG"> F  </i>
+ </incar>
+ <primitive_cell>
+  <structure name="primitive_cell" >
+   <crystal>
+    <varray name="basis" >
+     <v>       5.87198220       0.00000000       0.00000000 </v>
+     <v>       0.00000000       5.08280575       0.00000000 </v>
+     <v>       0.00000000       0.00000000       4.64769000 </v>
+    </varray>
+    <i name="volume">    138.71562913 </i>
+    <varray name="rec_basis" >
+     <v>       0.17030024       0.00000000       0.00000000 </v>
+     <v>       0.00000000       0.19674173       0.00000000 </v>
+     <v>       0.00000000       0.00000000       0.21516065 </v>
+    </varray>
+   </crystal>
+   <varray name="positions" >
+    <v>       0.04232415       0.10250303       0.24803642 </v>
+    <v>       0.04233768       0.76906824       0.74803113 </v>
+    <v>       0.29233207       0.26906640       0.74803203 </v>
+    <v>       0.29233083       0.60250330       0.24803510 </v>
+    <v>       0.54232415       0.10250303       0.24803642 </v>
+    <v>       0.54233768       0.76906824       0.74803113 </v>
+    <v>       0.79233207       0.26906640       0.74803203 </v>
+    <v>       0.79233083       0.60250330       0.24803510 </v>
+   </varray>
+  </structure>
+  <varray name="primitive_index" >
+   <v type="int" >        1 </v>
+   <v type="int" >        2 </v>
+   <v type="int" >        3 </v>
+   <v type="int" >        4 </v>
+   <v type="int" >        5 </v>
+   <v type="int" >        6 </v>
+   <v type="int" >        7 </v>
+   <v type="int" >        8 </v>
+  </varray>
+ </primitive_cell>
+ <kpoints>
+  <generation param="Monkhorst-Pack">
+   <v type="int" name="divisions">       1        1        1 </v>
+   <v name="usershift">      0.00000000       0.00000000       0.00000000 </v>
+   <v name="genvec1">      1.00000000       0.00000000       0.00000000 </v>
+   <v name="genvec2">      0.00000000       1.00000000       0.00000000 </v>
+   <v name="genvec3">      0.00000000       0.00000000       1.00000000 </v>
+   <v name="shift">      0.00000000       0.00000000       0.00000000 </v>
+  </generation>
+  <varray name="kpointlist" >
+   <v>       0.00000000       0.00000000       0.00000000 </v>
+  </varray>
+  <varray name="weights" >
+   <v>       1.00000000 </v>
+  </varray>
+ </kpoints>
+ <parameters>
+  <separator name="general" >
+   <i type="string" name="SYSTEM">dpgen</i>
+   <i type="logical" name="LCOMPAT"> F  </i>
+  </separator>
+  <separator name="electronic" >
+   <i type="string" name="PREC">accura</i>
+   <i name="ENMAX">    350.00000000</i>
+   <i name="ENAUG">    605.39200000</i>
+   <i name="EDIFF">      0.00000100</i>
+   <i type="int" name="IALGO">    38</i>
+   <i type="int" name="IWAVPR">    10</i>
+   <i type="int" name="NBANDS">   128</i>
+   <i type="int" name="NBANDSLOW">    -1</i>
+   <i type="int" name="NBANDSHIGH">    -1</i>
+   <i name="NELECT">     36.00000000</i>
+   <i type="int" name="TURBO">     0</i>
+   <i type="int" name="IRESTART">     0</i>
+   <i type="int" name="NREBOOT">     0</i>
+   <i type="int" name="NMIN">     0</i>
+   <i name="EREF">      0.00000000</i>
+   <separator name="electronic smearing" >
+    <i type="int" name="ISMEAR">     1</i>
+    <i name="SIGMA">      0.20000000</i>
+    <i name="KSPACING">     10.00000000</i>
+    <i type="logical" name="KGAMMA"> F  </i>
+    <i type="logical" name="KBLOWUP"> T  </i>
+   </separator>
+   <separator name="electronic projectors" >
+    <i type="logical" name="LREAL"> T  </i>
+    <v name="ROPT">     -0.00025000     -0.00025000     -0.00025000</v>
+    <i type="int" name="LMAXPAW">  -100</i>
+    <i type="int" name="LMAXMIX">     2</i>
+    <i type="logical" name="NLSPLINE"> F  </i>
+   </separator>
+   <separator name="electronic startup" >
+    <i type="int" name="ISTART">     0</i>
+    <i type="int" name="ICHARG">     2</i>
+    <i type="int" name="INIWAV">     1</i>
+   </separator>
+   <separator name="electronic spin" >
+    <i type="int" name="ISPIN">     1</i>
+    <i type="logical" name="LNONCOLLINEAR"> F  </i>
+    <v name="MAGMOM">      1.00000000      1.00000000      1.00000000      1.00000000      1.00000000      1.00000000      1.00000000      1.00000000</v>
+    <i name="NUPDOWN">     -1.00000000</i>
+    <i type="logical" name="LSORBIT"> F  </i>
+    <v name="SAXIS">      0.00000000      0.00000000      1.00000000</v>
+    <i type="logical" name="LSPIRAL"> F  </i>
+    <v name="QSPIRAL">      0.00000000      0.00000000      0.00000000</v>
+    <i type="logical" name="LZEROZ"> F  </i>
+   </separator>
+   <separator name="electronic exchange-correlation" >
+    <i type="logical" name="LASPH"> F  </i>
+    <i type="logical" name="LMETAGGA"> F  </i>
+   </separator>
+   <separator name="electronic convergence" >
+    <i type="int" name="NELM">   100</i>
+    <i type="int" name="NELMDL">    -5</i>
+    <i type="int" name="NELMIN">     6</i>
+    <i name="ENINI">    350.00000000</i>
+    <separator name="electronic convergence detail" >
+     <i type="logical" name="LDIAG"> T  </i>
+     <i type="logical" name="LSUBROT"> F  </i>
+     <i name="WEIMIN">      0.00000000</i>
+     <i name="EBREAK">      0.00000000</i>
+     <i name="DEPER">      0.30000000</i>
+     <i type="int" name="NRMM">     4</i>
+     <i name="TIME">      0.40000000</i>
+    </separator>
+   </separator>
+   <separator name="electronic mixer" >
+    <i name="AMIX">      0.40000000</i>
+    <i name="BMIX">      1.00000000</i>
+    <i name="AMIN">      0.10000000</i>
+    <i name="AMIX_MAG">      1.60000000</i>
+    <i name="BMIX_MAG">      1.00000000</i>
+    <separator name="electronic mixer details" >
+     <i type="int" name="IMIX">     4</i>
+     <i type="logical" name="MIXFIRST"> F  </i>
+     <i type="int" name="MAXMIX">   -45</i>
+     <i name="WC">    100.00000000</i>
+     <i type="int" name="INIMIX">     1</i>
+     <i type="int" name="MIXPRE">     1</i>
+     <i type="int" name="MREMOVE">     5</i>
+    </separator>
+   </separator>
+   <separator name="electronic dipolcorrection" >
+    <i type="logical" name="LDIPOL"> F  </i>
+    <i type="logical" name="LMONO"> F  </i>
+    <i type="int" name="IDIPOL">     0</i>
+    <i name="EPSILON">      1.00000000</i>
+    <v name="DIPOL">   -100.00000000   -100.00000000   -100.00000000</v>
+    <i name="EFIELD">      0.00000000</i>
+   </separator>
+  </separator>
+  <separator name="grids" >
+   <i type="int" name="NGX">    36</i>
+   <i type="int" name="NGY">    32</i>
+   <i type="int" name="NGZ">    28</i>
+   <i type="int" name="NGXF">    72</i>
+   <i type="int" name="NGYF">    64</i>
+   <i type="int" name="NGZF">    56</i>
+   <i type="logical" name="ADDGRID"> F  </i>
+  </separator>
+  <separator name="ionic" >
+   <i type="int" name="NSW">     0</i>
+   <i type="int" name="IBRION">    -1</i>
+   <i type="int" name="MDALGO">     0</i>
+   <i type="int" name="ISIF">     2</i>
+   <i name="PSTRESS">      0.00000000</i>
+   <i name="EDIFFG">      0.00001000</i>
+   <i type="int" name="NFREE">     0</i>
+   <i name="POTIM">      2.00000000</i>
+   <i name="SMASS">     -3.00000000</i>
+   <i name="SCALEE">      1.00000000</i>
+  </separator>
+  <separator name="ionic md" >
+   <i name="TEBEG">      0.00010000</i>
+   <i name="TEEND">      0.00010000</i>
+   <i type="int" name="NBLOCK">     1</i>
+   <i type="int" name="KBLOCK">     1</i>
+   <i type="int" name="NPACO">   256</i>
+   <i name="APACO">     10.00000000</i>
+  </separator>
+  <separator name="symmetry" >
+   <i type="int" name="ISYM">     0</i>
+   <i name="SYMPREC">      0.00001000</i>
+  </separator>
+  <separator name="dos" >
+   <i type="int" name="LORBIT">     0</i>
+   <v name="RWIGS">     -1.00000000     -1.00000000     -1.00000000</v>
+   <i type="int" name="NEDOS">   301</i>
+   <i name="EMIN">     10.00000000</i>
+   <i name="EMAX">    -10.00000000</i>
+   <i name="EFERMI">      0.00000000</i>
+  </separator>
+  <separator name="writing" >
+   <i type="int" name="NWRITE">     0</i>
+   <i type="logical" name="LWAVE"> F  </i>
+   <i type="logical" name="LDOWNSAMPLE"> F  </i>
+   <i type="logical" name="LCHARG"> F  </i>
+   <i type="logical" name="LPARD"> F  </i>
+   <i type="logical" name="LVTOT"> F  </i>
+   <i type="logical" name="LVHAR"> F  </i>
+   <i type="logical" name="LELF"> F  </i>
+   <i type="logical" name="LOPTICS"> F  </i>
+   <v name="STM">      0.00000000      0.00000000      0.00000000      0.00000000      0.00000000      0.00000000      0.00000000</v>
+  </separator>
+  <separator name="performance" >
+   <i type="int" name="NPAR">   128</i>
+   <i type="int" name="NSIM">     4</i>
+   <i type="int" name="NBLK">    -1</i>
+   <i type="logical" name="LPLANE"> T  </i>
+   <i type="logical" name="LSCALAPACK"> T  </i>
+   <i type="logical" name="LSCAAWARE"> T  </i>
+   <i type="logical" name="LSCALU"> F  </i>
+   <i type="logical" name="LASYNC"> F  </i>
+   <i type="logical" name="LORBITALREAL"> F  </i>
+  </separator>
+  <separator name="miscellaneous" >
+   <i type="int" name="IDIOT">     3</i>
+   <i type="int" name="PHON_NSTRUCT">    -1</i>
+   <i type="logical" name="LMUSIC"> F  </i>
+   <v name="POMASS">     47.88000000     16.00000000     47.88000000</v>
+   <v name="DARWINR">      0.00000000      0.00000000      0.00000000</v>
+   <v name="DARWINV">      1.00000000      1.00000000      1.00000000</v>
+   <i type="logical" name="LCORR"> T  </i>
+  </separator>
+  <i type="logical" name="GGA_COMPAT"> T  </i>
+  <i type="logical" name="LBERRY"> F  </i>
+  <i type="int" name="ICORELEVEL">     0</i>
+  <i type="logical" name="LDAU"> F  </i>
+  <i type="int" name="I_CONSTRAINED_M">     0</i>
+  <separator name="electronic exchange-correlation" >
+   <i type="string" name="GGA">--</i>
+   <i type="int" name="VOSKOWN">     0</i>
+   <i type="logical" name="LHFCALC"> F  </i>
+   <i type="string" name="PRECFOCK"></i>
+   <i type="logical" name="LSYMGRAD"> F  </i>
+   <i type="logical" name="LHFONE"> F  </i>
+   <i type="logical" name="LRHFCALC"> F  </i>
+   <i type="logical" name="LTHOMAS"> F  </i>
+   <i type="logical" name="LMODELHF"> F  </i>
+   <i type="logical" name="LFOCKACE"> F  </i>
+   <i name="ENCUT4O">     -1.00000000</i>
+   <i type="int" name="EXXOEP">     0</i>
+   <i type="int" name="FOURORBIT">     0</i>
+   <i name="AEXX">      0.00000000</i>
+   <i name="HFALPHA">      0.00000000</i>
+   <i name="MCALPHA">      0.00000000</i>
+   <i name="ALDAX">      1.00000000</i>
+   <i name="AGGAX">      1.00000000</i>
+   <i name="ALDAC">      1.00000000</i>
+   <i name="AGGAC">      1.00000000</i>
+   <i type="int" name="NKREDX">     1</i>
+   <i type="int" name="NKREDY">     1</i>
+   <i type="int" name="NKREDZ">     1</i>
+   <i type="logical" name="SHIFTRED"> F  </i>
+   <i type="logical" name="ODDONLY"> F  </i>
+   <i type="logical" name="EVENONLY"> F  </i>
+   <i type="int" name="LMAXFOCK">     0</i>
+   <i type="int" name="NMAXFOCKAE">     0</i>
+   <i type="logical" name="LFOCKAEDFT"> F  </i>
+   <i name="HFSCREEN">      0.00000000</i>
+   <i name="HFSCREENC">      0.00000000</i>
+   <i type="int" name="NBANDSGWLOW">     0</i>
+  </separator>
+  <separator name="vdW DFT" >
+   <i type="logical" name="LUSE_VDW"> F  </i>
+   <i name="Zab_VDW">     -0.84910000</i>
+   <i name="PARAM1">      0.12340000</i>
+   <i name="PARAM2">      1.00000000</i>
+   <i name="PARAM3">      0.00000000</i>
+  </separator>
+  <separator name="model GW" >
+   <i type="int" name="MODEL_GW">     0</i>
+   <i name="MODEL_EPS0">     10.40367218</i>
+   <i name="MODEL_ALPHA">      1.00000000</i>
+  </separator>
+  <separator name="linear response parameters" >
+   <i type="logical" name="LEPSILON"> F  </i>
+   <i type="logical" name="LRPA"> F  </i>
+   <i type="logical" name="LNABLA"> F  </i>
+   <i type="logical" name="LVEL"> F  </i>
+   <i name="CSHIFT">      0.10000000</i>
+   <i name="OMEGAMAX">     -1.00000000</i>
+   <i name="DEG_THRESHOLD">      0.00200000</i>
+   <i name="RTIME">     -0.10000000</i>
+   <i name="WPLASMAI">      0.00000000</i>
+   <v name="DFIELD">      0.00000000      0.00000000      0.00000000</v>
+   <v name="WPLASMA">      0.00000000      0.00000000      0.00000000      0.00000000      0.00000000      0.00000000      0.00000000      0.00000000      0.00000000</v>
+  </separator>
+  <separator name="orbital magnetization" >
+   <i type="logical" name="NUCIND"> F  </i>
+   <v name="MAGPOS">      0.00000000      0.00000000      0.00000000</v>
+   <i type="logical" name="LNICSALL"> T  </i>
+   <i type="logical" name="ORBITALMAG"> F  </i>
+   <i type="logical" name="LMAGBLOCH"> F  </i>
+   <i type="logical" name="LCHIMAG"> F  </i>
+   <i type="logical" name="LGAUGE"> T  </i>
+   <i type="int" name="MAGATOM">     0</i>
+   <v name="MAGDIPOL">      0.00000000      0.00000000      0.00000000</v>
+   <v name="AVECCONST">      0.00000000      0.00000000      0.00000000</v>
+  </separator>
+  <separator name="response functions" >
+   <i type="logical" name="LFINITE_TEMPERATURE"> F  </i>
+   <i type="logical" name="LADDER"> F  </i>
+   <i type="logical" name="LRPAFORCE"> F  </i>
+   <i type="logical" name="LFXC"> F  </i>
+   <i type="logical" name="LHARTREE"> T  </i>
+   <i type="int" name="IBSE">     0</i>
+   <v type="int" name="KPOINT">    -1     0     0     0</v>
+   <i type="logical" name="LTCTC"> F  </i>
+   <i type="logical" name="LTCTE"> F  </i>
+   <i type="logical" name="LTETE"> F  </i>
+   <i type="logical" name="LTRIPLET"> F  </i>
+   <i type="logical" name="LFXCEPS"> F  </i>
+   <i type="logical" name="LFXHEG"> F  </i>
+   <i type="int" name="NATURALO">     2</i>
+   <i type="logical" name="LHOLEGF"> F  </i>
+   <i type="logical" name="L2ORDER"> F  </i>
+   <i type="logical" name="LDMP1"> F  </i>
+   <i type="logical" name="LMP2LT"> F  </i>
+   <i type="logical" name="LSMP2LT"> F  </i>
+   <i type="logical" name="LGWLF"> F  </i>
+   <i name="ENCUTGW">     -2.00000000</i>
+   <i name="ENCUTGWSOFT">     -2.00000000</i>
+   <i name="ENCUTLF">     -1.00000000</i>
+   <i type="logical" name="LESF_SPLINES"> F  </i>
+   <i type="int" name="LMAXMP2">    -1</i>
+   <i name="SCISSOR">      0.00000000</i>
+   <i type="int" name="NOMEGA">     0</i>
+   <i type="int" name="NOMEGAR">     0</i>
+   <i type="int" name="NBANDSGW">    -1</i>
+   <i type="int" name="NBANDSO">    -1</i>
+   <i type="int" name="NBANDSV">    -1</i>
+   <i type="int" name="NELMGW">     1</i>
+   <i type="int" name="NELMHF">     1</i>
+   <i type="int" name="DIM">     3</i>
+   <i type="int" name="IESPILON">     4</i>
+   <i type="int" name="ANTIRES">     0</i>
+   <i name="OMEGAMAX">    -30.00000000</i>
+   <i name="OMEGAMIN">    -30.00000000</i>
+   <i name="OMEGATL">   -200.00000000</i>
+   <i type="int" name="OMEGAGRID">     0</i>
+   <i name="CSHIFT">     -0.10000000</i>
+   <i type="logical" name="LSELFENERGY"> F  </i>
+   <i type="logical" name="LSPECTRAL"> F  </i>
+   <i type="logical" name="LSPECTRALGW"> F  </i>
+   <i type="logical" name="LSINGLES"> F  </i>
+   <i type="logical" name="LFERMIGW"> F  </i>
+   <i type="logical" name="ODDONLYGW"> F  </i>
+   <i type="logical" name="EVENONLYGW"> F  </i>
+   <i type="int" name="NKREDLFX">     1</i>
+   <i type="int" name="NKREDLFY">     1</i>
+   <i type="int" name="NKREDLFZ">     1</i>
+   <i type="int" name="MAXMEM">  2800</i>
+   <i type="int" name="TELESCOPE">     0</i>
+   <i type="int" name="NTAUPAR">    -1</i>
+   <i type="int" name="NOMEGAPAR">    -1</i>
+   <i name="DAMP_NEWTON">      0.80000001</i>
+   <i name="LAMBDA">      1.00000000</i>
+  </separator>
+  <separator name="External order field" >
+   <i name="OFIELD_KAPPA">      0.00000000</i>
+   <v name="OFIELD_K">      0.00000000      0.00000000      0.00000000</v>
+   <i name="OFIELD_Q6_NEAR">      0.00000000</i>
+   <i name="OFIELD_Q6_FAR">      0.00000000</i>
+   <i name="OFIELD_A">      0.00000000</i>
+  </separator>
+  <separator name="optional k-points parameters" >
+   <i type="int" name="KPOINTS_OPT_MODE">     1</i>
+   <i type="logical" name="LKPOINTS_OPT"> F  </i>
+  </separator>
+ </parameters>
+ <atominfo>
+  <atoms>       8 </atoms>
+  <types>       3 </types>
+  <array name="atoms" >
+   <dimension dim="1">ion</dimension>
+   <field type="string">element</field>
+   <field type="int">atomtype</field>
+   <set>
+    <rc><c>Ti</c><c>   1</c></rc>
+    <rc><c>Ti</c><c>   1</c></rc>
+    <rc><c>Ti</c><c>   1</c></rc>
+    <rc><c>O </c><c>   2</c></rc>
+    <rc><c>O </c><c>   2</c></rc>
+    <rc><c>Ti</c><c>   3</c></rc>
+    <rc><c>Ti</c><c>   3</c></rc>
+    <rc><c>Ti</c><c>   3</c></rc>
+   </set>
+  </array>
+  <array name="atomtypes" >
+   <dimension dim="1">type</dimension>
+   <field type="int">atomspertype</field>
+   <field type="string">element</field>
+   <field>mass</field>
+   <field>valence</field>
+   <field type="string">pseudopotential</field>
+   <set>
+    <rc><c>   3</c><c>Ti</c><c>     47.88000000</c><c>      4.00000000</c><c>  PAW_PBE Ti 08Apr2002                  </c></rc>
+    <rc><c>   2</c><c>O </c><c>     16.00000000</c><c>      6.00000000</c><c>  PAW_PBE O 08Apr2002                   </c></rc>
+    <rc><c>   3</c><c>Ti</c><c>     47.88000000</c><c>      4.00000000</c><c>PAW_PBE Ti 08Apr2002                    </c></rc>
+   </set>
+  </array>
+ </atominfo>
+ <structure name="initialpos" >
+  <crystal>
+   <varray name="basis" >
+    <v>       5.87198220       0.00000000       0.00000000 </v>
+    <v>       0.00000000       5.08280575       0.00000000 </v>
+    <v>       0.00000000       0.00000000       4.64769000 </v>
+   </varray>
+   <i name="volume">    138.71562913 </i>
+   <varray name="rec_basis" >
+    <v>       0.17030024       0.00000000       0.00000000 </v>
+    <v>       0.00000000       0.19674173       0.00000000 </v>
+    <v>       0.00000000       0.00000000       0.21516065 </v>
+   </varray>
+  </crystal>
+  <varray name="positions" >
+   <v>       0.04232415       0.10250303       0.24803642 </v>
+   <v>       0.04233768       0.76906824       0.74803113 </v>
+   <v>       0.29233207       0.26906640       0.74803203 </v>
+   <v>       0.29233083       0.60250330       0.24803510 </v>
+   <v>       0.54232415       0.10250303       0.24803642 </v>
+   <v>       0.54233768       0.76906824       0.74803113 </v>
+   <v>       0.79233207       0.26906640       0.74803203 </v>
+   <v>       0.79233083       0.60250330       0.24803510 </v>
+  </varray>
+ </structure>
+ <calculation>
+  <scstep>
+   <time name="dav">    0.50    0.56</time>
+   <time name="total">    0.66    0.74</time>
+   <energy>
+    <i name="alphaZ">    149.21459756 </i>
+    <i name="ewald">  -1320.89694581 </i>
+    <i name="hartreedc">   -340.66686448 </i>
+    <i name="XCdc">   -169.19906533 </i>
+    <i name="pawpsdc">   1446.19366583 </i>
+    <i name="pawaedc">  -1207.00626252 </i>
+    <i name="eentropy">     -0.01391075 </i>
+    <i name="bandstr">    -35.47240814 </i>
+    <i name="atom">   1432.75339491 </i>
+    <i name="e_fr_energy">    -45.09379873 </i>
+    <i name="e_wo_entrp">    -45.07988798 </i>
+    <i name="e_0_energy">    -45.08916181 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.84    0.85</time>
+   <time name="total">    0.84    0.85</time>
+   <energy>
+    <i name="e_fr_energy">    -68.72048634 </i>
+    <i name="e_wo_entrp">    -68.67277204 </i>
+    <i name="e_0_energy">    -68.70458158 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.45    0.46</time>
+   <time name="total">    0.46    0.47</time>
+   <energy>
+    <i name="e_fr_energy">    -68.74118319 </i>
+    <i name="e_wo_entrp">    -68.69337254 </i>
+    <i name="e_0_energy">    -68.72524631 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    1.41    1.42</time>
+   <time name="total">    1.41    1.42</time>
+   <energy>
+    <i name="e_fr_energy">    -68.74118783 </i>
+    <i name="e_wo_entrp">    -68.69337718 </i>
+    <i name="e_0_energy">    -68.72525094 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.45    0.46</time>
+   <time name="total">    0.48    0.50</time>
+   <energy>
+    <i name="e_fr_energy">    -68.74118783 </i>
+    <i name="e_wo_entrp">    -68.69337718 </i>
+    <i name="e_0_energy">    -68.72525094 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    1.40    1.41</time>
+   <time name="total">    1.59    1.61</time>
+   <energy>
+    <i name="e_fr_energy">    -65.82721442 </i>
+    <i name="e_wo_entrp">    -65.79885062 </i>
+    <i name="e_0_energy">    -65.81775982 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    1.40    1.45</time>
+   <time name="total">    1.58    1.64</time>
+   <energy>
+    <i name="e_fr_energy">    -60.91154893 </i>
+    <i name="e_wo_entrp">    -60.96861418 </i>
+    <i name="e_0_energy">    -60.93057068 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.45    0.45</time>
+   <time name="total">    0.61    0.62</time>
+   <energy>
+    <i name="e_fr_energy">    -59.00361482 </i>
+    <i name="e_wo_entrp">    -58.90874967 </i>
+    <i name="e_0_energy">    -58.97199310 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    1.40    1.40</time>
+   <time name="total">    1.57    1.58</time>
+   <energy>
+    <i name="e_fr_energy">    -57.69148731 </i>
+    <i name="e_wo_entrp">    -57.71728332 </i>
+    <i name="e_0_energy">    -57.70008598 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.44    0.44</time>
+   <time name="total">    0.61    0.62</time>
+   <energy>
+    <i name="e_fr_energy">    -57.63983531 </i>
+    <i name="e_wo_entrp">    -57.65116949 </i>
+    <i name="e_0_energy">    -57.64361337 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.81    0.81</time>
+   <time name="total">    0.99    1.00</time>
+   <energy>
+    <i name="e_fr_energy">    -57.49117582 </i>
+    <i name="e_wo_entrp">    -57.45919433 </i>
+    <i name="e_0_energy">    -57.48051533 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.81    0.81</time>
+   <time name="total">    1.00    1.00</time>
+   <energy>
+    <i name="e_fr_energy">    -57.48654186 </i>
+    <i name="e_wo_entrp">    -57.46681975 </i>
+    <i name="e_0_energy">    -57.47996782 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    1.41    1.41</time>
+   <time name="total">    1.58    1.60</time>
+   <energy>
+    <i name="e_fr_energy">    -57.48634081 </i>
+    <i name="e_wo_entrp">    -57.45587229 </i>
+    <i name="e_0_energy">    -57.47618464 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.44    0.44</time>
+   <time name="total">    0.62    0.63</time>
+   <energy>
+    <i name="e_fr_energy">    -57.48460873 </i>
+    <i name="e_wo_entrp">    -57.45203031 </i>
+    <i name="e_0_energy">    -57.47374926 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.81    0.81</time>
+   <time name="total">    0.99    1.00</time>
+   <energy>
+    <i name="e_fr_energy">    -57.48360492 </i>
+    <i name="e_wo_entrp">    -57.45661252 </i>
+    <i name="e_0_energy">    -57.47460745 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.81    0.81</time>
+   <time name="total">    0.99    1.00</time>
+   <energy>
+    <i name="e_fr_energy">    -57.48351554 </i>
+    <i name="e_wo_entrp">    -57.45699098 </i>
+    <i name="e_0_energy">    -57.47467402 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    1.40    1.40</time>
+   <time name="total">    1.57    1.58</time>
+   <energy>
+    <i name="e_fr_energy">    -57.48344258 </i>
+    <i name="e_wo_entrp">    -57.45825358 </i>
+    <i name="e_0_energy">    -57.47504625 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.82    0.82</time>
+   <time name="total">    1.00    1.02</time>
+   <energy>
+    <i name="e_fr_energy">    -57.48344642 </i>
+    <i name="e_wo_entrp">    -57.45830738 </i>
+    <i name="e_0_energy">    -57.47506674 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.81    0.81</time>
+   <time name="total">    0.97    0.99</time>
+   <energy>
+    <i name="e_fr_energy">    -57.48344042 </i>
+    <i name="e_wo_entrp">    -57.45821571 </i>
+    <i name="e_0_energy">    -57.47503218 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.87    0.87</time>
+   <time name="total">    1.07    1.09</time>
+   <energy>
+    <i name="e_fr_energy">    -57.48343776 </i>
+    <i name="e_wo_entrp">    -57.45803649 </i>
+    <i name="e_0_energy">    -57.47497067 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.24    0.24</time>
+   <time name="total">    0.40    0.42</time>
+   <energy>
+    <i name="alphaZ">    149.21459756 </i>
+    <i name="ewald">  -1320.89694581 </i>
+    <i name="hartreedc">   -340.18729532 </i>
+    <i name="XCdc">   -166.33888735 </i>
+    <i name="pawpsdc">   2088.50860028 </i>
+    <i name="pawaedc">  -1848.65967198 </i>
+    <i name="eentropy">     -0.02544838 </i>
+    <i name="bandstr">    -51.85178121 </i>
+    <i name="atom">   1432.75339491 </i>
+    <i name="e_fr_energy">    -57.48343729 </i>
+    <i name="e_wo_entrp">    -57.45798891 </i>
+    <i name="e_0_energy">    -57.47495449 </i>
+   </energy>
+  </scstep>
+  <structure>
+   <crystal>
+    <varray name="basis" >
+     <v>       5.87198220       0.00000000       0.00000000 </v>
+     <v>       0.00000000       5.08280575       0.00000000 </v>
+     <v>       0.00000000       0.00000000       4.64769000 </v>
+    </varray>
+    <i name="volume">    138.71562913 </i>
+    <varray name="rec_basis" >
+     <v>       0.17030024       0.00000000       0.00000000 </v>
+     <v>       0.00000000       0.19674173       0.00000000 </v>
+     <v>       0.00000000       0.00000000       0.21516065 </v>
+    </varray>
+   </crystal>
+   <varray name="positions" >
+    <v>       0.04232415       0.10250303       0.24803642 </v>
+    <v>       0.04233768       0.76906824       0.74803113 </v>
+    <v>       0.29233207       0.26906640       0.74803203 </v>
+    <v>       0.29233083       0.60250330       0.24803510 </v>
+    <v>       0.54232415       0.10250303       0.24803642 </v>
+    <v>       0.54233768       0.76906824       0.74803113 </v>
+    <v>       0.79233207       0.26906640       0.74803203 </v>
+    <v>       0.79233083       0.60250330       0.24803510 </v>
+   </varray>
+  </structure>
+  <varray name="forces" >
+   <v>       1.34446109      -0.20195361       0.00004360 </v>
+   <v>      -0.03689496      -1.01924705       0.00006538 </v>
+   <v>       2.08038319       1.20087402       0.00001036 </v>
+   <v>      -0.62684471       0.02024177      -0.00011696 </v>
+   <v>       0.62730193       0.02024077      -0.00013931 </v>
+   <v>      -2.08083319       1.20111991      -0.00001006 </v>
+   <v>       0.03660766      -1.01912501       0.00013760 </v>
+   <v>      -1.34418100      -0.20215079       0.00000940 </v>
+  </varray>
+  <varray name="stress" >
+   <v>    -199.00013635      -0.00312264      -0.00150999 </v>
+   <v>      -0.00312261    -181.85529569       0.00324726 </v>
+   <v>      -0.00151004       0.00324729    -374.19175083 </v>
+  </varray>
+  <energy>
+   <i name="e_fr_energy">    -57.48343729 </i>
+   <i name="e_wo_entrp">    -57.45798891 </i>
+   <i name="e_0_energy">    -57.47495449 </i>
+  </energy>
+  <time name="totalsc">   21.44   21.87</time>
+  <eigenvalues>
+   <array>
+    <dimension dim="1">band</dimension>
+    <dimension dim="2">kpoint</dimension>
+    <dimension dim="3">spin</dimension>
+    <field>eigene</field>
+    <field>occ</field>
+    <set>
+     <set comment="spin 1">
+      <set comment="kpoint 1">
+       <r>  -14.8338    1.0000 </r>
+       <r>  -14.4401    1.0000 </r>
+       <r>   -2.6050    1.0000 </r>
+       <r>   -1.3412    1.0000 </r>
+       <r>   -1.0744    1.0000 </r>
+       <r>   -1.0332    1.0000 </r>
+       <r>   -1.0043    1.0000 </r>
+       <r>   -0.8333    1.0000 </r>
+       <r>    0.1483    1.0000 </r>
+       <r>    0.2015    1.0000 </r>
+       <r>    1.0105    1.0000 </r>
+       <r>    1.0177    1.0000 </r>
+       <r>    1.1660    1.0000 </r>
+       <r>    1.2742    1.0000 </r>
+       <r>    1.4083    1.0000 </r>
+       <r>    1.4490    1.0000 </r>
+       <r>    1.5042    1.0000 </r>
+       <r>    2.0379    0.8594 </r>
+       <r>    2.2253    0.1551 </r>
+       <r>    2.3000    0.0028 </r>
+       <r>    2.4870   -0.0158 </r>
+       <r>    2.6231   -0.0015 </r>
+       <r>    2.9206   -0.0000 </r>
+       <r>    2.9297   -0.0000 </r>
+       <r>    2.9701   -0.0000 </r>
+       <r>    3.0920   -0.0000 </r>
+       <r>    3.6168   -0.0000 </r>
+       <r>    3.6257   -0.0000 </r>
+       <r>    3.8840   -0.0000 </r>
+       <r>    3.9191   -0.0000 </r>
+       <r>    4.0241   -0.0000 </r>
+       <r>    4.0446   -0.0000 </r>
+       <r>    4.3509   -0.0000 </r>
+       <r>    4.4768   -0.0000 </r>
+       <r>    4.5413   -0.0000 </r>
+       <r>    4.5541   -0.0000 </r>
+       <r>    4.7307   -0.0000 </r>
+       <r>    5.2836   -0.0000 </r>
+       <r>    5.3149   -0.0000 </r>
+       <r>    5.6955   -0.0000 </r>
+       <r>    6.2666   -0.0000 </r>
+       <r>    6.2818   -0.0000 </r>
+       <r>    6.2836   -0.0000 </r>
+       <r>    8.0487    0.0000 </r>
+       <r>    9.8849    0.0000 </r>
+       <r>   10.2583    0.0000 </r>
+       <r>   10.4112    0.0000 </r>
+       <r>   10.6540    0.0000 </r>
+       <r>   10.8337    0.0000 </r>
+       <r>   11.3241    0.0000 </r>
+       <r>   11.7073    0.0000 </r>
+       <r>   12.1050    0.0000 </r>
+       <r>   13.0823    0.0000 </r>
+       <r>   13.4307    0.0000 </r>
+       <r>   13.7056    0.0000 </r>
+       <r>   13.8640    0.0000 </r>
+       <r>   15.2230    0.0000 </r>
+       <r>   15.7464    0.0000 </r>
+       <r>   15.7866    0.0000 </r>
+       <r>   15.8964    0.0000 </r>
+       <r>   16.9974    0.0000 </r>
+       <r>   17.0548    0.0000 </r>
+       <r>   17.3805    0.0000 </r>
+       <r>   18.1921    0.0000 </r>
+       <r>   18.5666    0.0000 </r>
+       <r>   18.7118    0.0000 </r>
+       <r>   19.5674    0.0000 </r>
+       <r>   19.9026    0.0000 </r>
+       <r>   19.9534    0.0000 </r>
+       <r>   20.7588    0.0000 </r>
+       <r>   21.7603    0.0000 </r>
+       <r>   21.8212    0.0000 </r>
+       <r>   22.5272    0.0000 </r>
+       <r>   22.6121    0.0000 </r>
+       <r>   23.2475    0.0000 </r>
+       <r>   23.6013    0.0000 </r>
+       <r>   23.7268    0.0000 </r>
+       <r>   24.5881    0.0000 </r>
+       <r>   24.6734    0.0000 </r>
+       <r>   24.8087    0.0000 </r>
+       <r>   24.8521    0.0000 </r>
+       <r>   24.9440    0.0000 </r>
+       <r>   25.2723    0.0000 </r>
+       <r>   25.9306    0.0000 </r>
+       <r>   26.0470    0.0000 </r>
+       <r>   26.3701    0.0000 </r>
+       <r>   26.3837    0.0000 </r>
+       <r>   26.8439    0.0000 </r>
+       <r>   27.4781    0.0000 </r>
+       <r>   27.5912    0.0000 </r>
+       <r>   27.8200    0.0000 </r>
+       <r>   27.8659    0.0000 </r>
+       <r>   28.2819    0.0000 </r>
+       <r>   28.6623    0.0000 </r>
+       <r>   28.6726    0.0000 </r>
+       <r>   28.7351    0.0000 </r>
+       <r>   29.1619    0.0000 </r>
+       <r>   29.8769    0.0000 </r>
+       <r>   29.9126    0.0000 </r>
+       <r>   30.0647    0.0000 </r>
+       <r>   30.1068    0.0000 </r>
+       <r>   30.6352    0.0000 </r>
+       <r>   30.6523    0.0000 </r>
+       <r>   30.7936    0.0000 </r>
+       <r>   31.5254    0.0000 </r>
+       <r>   31.8083    0.0000 </r>
+       <r>   32.0340    0.0000 </r>
+       <r>   32.5288    0.0000 </r>
+       <r>   32.9961    0.0000 </r>
+       <r>   33.0020    0.0000 </r>
+       <r>   33.3344    0.0000 </r>
+       <r>   33.4052    0.0000 </r>
+       <r>   33.5275    0.0000 </r>
+       <r>   34.8649    0.0000 </r>
+       <r>   34.9384    0.0000 </r>
+       <r>   35.1531    0.0000 </r>
+       <r>   35.2974    0.0000 </r>
+       <r>   36.0745    0.0000 </r>
+       <r>   36.2444    0.0000 </r>
+       <r>   36.8973    0.0000 </r>
+       <r>   37.4623    0.0000 </r>
+       <r>   38.2356    0.0000 </r>
+       <r>   38.2926    0.0000 </r>
+       <r>   38.7569    0.0000 </r>
+       <r>   39.0149    0.0000 </r>
+       <r>   39.4083    0.0000 </r>
+       <r>   39.4995    0.0000 </r>
+       <r>   39.6990    0.0000 </r>
+      </set>
+     </set>
+    </set>
+   </array>
+  </eigenvalues>
+  <separator name="orbital magnetization" >
+   <v name="MAGDIPOLOUT">      0.00000000      0.00000000      0.00000000</v>
+  </separator>
+  <dos>
+   <i name="efermi">      2.13411263 </i>
+   <total>
+    <array>
+     <dimension dim="1">gridpoints</dimension>
+     <dimension dim="2">spin</dimension>
+     <field>energy</field>
+     <field>total</field>
+     <field>integrated</field>
+     <set>
+      <set comment="spin 1">
+       <r>   -17.5604     0.0000     0.0000 </r>
+       <r>   -17.3605     0.0000     0.0000 </r>
+       <r>   -17.1605     0.0000     0.0000 </r>
+       <r>   -16.9606     0.0000     0.0000 </r>
+       <r>   -16.7606     0.0000     0.0000 </r>
+       <r>   -16.5606    -0.0000    -0.0000 </r>
+       <r>   -16.3607    -0.0000    -0.0000 </r>
+       <r>   -16.1607    -0.0000    -0.0000 </r>
+       <r>   -15.9608    -0.0000    -0.0000 </r>
+       <r>   -15.7608    -0.0000    -0.0000 </r>
+       <r>   -15.5609    -0.0000    -0.0000 </r>
+       <r>   -15.3609    -0.0062    -0.0012 </r>
+       <r>   -15.1610    -0.2080    -0.0428 </r>
+       <r>   -14.9610     0.8511     0.1274 </r>
+       <r>   -14.7611     6.9993     1.5269 </r>
+       <r>   -14.5611     3.4730     2.2213 </r>
+       <r>   -14.3612     6.9839     3.6178 </r>
+       <r>   -14.1612     2.2315     4.0640 </r>
+       <r>   -13.9612    -0.3016     4.0037 </r>
+       <r>   -13.7613    -0.0183     4.0000 </r>
+       <r>   -13.5613    -0.0001     4.0000 </r>
+       <r>   -13.3614    -0.0000     4.0000 </r>
+       <r>   -13.1614    -0.0000     4.0000 </r>
+       <r>   -12.9615     0.0000     4.0000 </r>
+       <r>   -12.7615     0.0000     4.0000 </r>
+       <r>   -12.5616     0.0000     4.0000 </r>
+       <r>   -12.3616     0.0000     4.0000 </r>
+       <r>   -12.1617     0.0000     4.0000 </r>
+       <r>   -11.9617     0.0000     4.0000 </r>
+       <r>   -11.7618     0.0000     4.0000 </r>
+       <r>   -11.5618     0.0000     4.0000 </r>
+       <r>   -11.3619     0.0000     4.0000 </r>
+       <r>   -11.1619     0.0000     4.0000 </r>
+       <r>   -10.9619     0.0000     4.0000 </r>
+       <r>   -10.7620     0.0000     4.0000 </r>
+       <r>   -10.5620     0.0000     4.0000 </r>
+       <r>   -10.3621     0.0000     4.0000 </r>
+       <r>   -10.1621     0.0000     4.0000 </r>
+       <r>    -9.9622     0.0000     4.0000 </r>
+       <r>    -9.7622     0.0000     4.0000 </r>
+       <r>    -9.5623     0.0000     4.0000 </r>
+       <r>    -9.3623     0.0000     4.0000 </r>
+       <r>    -9.1624     0.0000     4.0000 </r>
+       <r>    -8.9624     0.0000     4.0000 </r>
+       <r>    -8.7625     0.0000     4.0000 </r>
+       <r>    -8.5625     0.0000     4.0000 </r>
+       <r>    -8.3626     0.0000     4.0000 </r>
+       <r>    -8.1626     0.0000     4.0000 </r>
+       <r>    -7.9626     0.0000     4.0000 </r>
+       <r>    -7.7627     0.0000     4.0000 </r>
+       <r>    -7.5627     0.0000     4.0000 </r>
+       <r>    -7.3628     0.0000     4.0000 </r>
+       <r>    -7.1628     0.0000     4.0000 </r>
+       <r>    -6.9629     0.0000     4.0000 </r>
+       <r>    -6.7629     0.0000     4.0000 </r>
+       <r>    -6.5630     0.0000     4.0000 </r>
+       <r>    -6.3630     0.0000     4.0000 </r>
+       <r>    -6.1631     0.0000     4.0000 </r>
+       <r>    -5.9631     0.0000     4.0000 </r>
+       <r>    -5.7632     0.0000     4.0000 </r>
+       <r>    -5.5632     0.0000     4.0000 </r>
+       <r>    -5.3632     0.0000     4.0000 </r>
+       <r>    -5.1633     0.0000     4.0000 </r>
+       <r>    -4.9633     0.0000     4.0000 </r>
+       <r>    -4.7634     0.0000     4.0000 </r>
+       <r>    -4.5634     0.0000     4.0000 </r>
+       <r>    -4.3635    -0.0000     4.0000 </r>
+       <r>    -4.1635    -0.0000     4.0000 </r>
+       <r>    -3.9636    -0.0000     4.0000 </r>
+       <r>    -3.7636    -0.0000     4.0000 </r>
+       <r>    -3.5637    -0.0000     4.0000 </r>
+       <r>    -3.3637    -0.0000     4.0000 </r>
+       <r>    -3.1638    -0.0028     3.9994 </r>
+       <r>    -2.9638    -0.1438     3.9707 </r>
+       <r>    -2.7639     0.2605     4.0228 </r>
+       <r>    -2.5639     6.5853     5.3395 </r>
+       <r>    -2.3639     3.6572     6.0708 </r>
+       <r>    -2.1640    -0.3150     6.0078 </r>
+       <r>    -1.9640    -0.0393     6.0000 </r>
+       <r>    -1.7641    -0.0542     5.9891 </r>
+       <r>    -1.5641    -0.3016     5.9288 </r>
+       <r>    -1.3642     3.7379     6.6762 </r>
+       <r>    -1.1642     8.7616     8.4281 </r>
+       <r>    -0.9643    21.9055    12.8082 </r>
+       <r>    -0.7643    14.6432    15.7362 </r>
+       <r>    -0.5644     1.7268    16.0815 </r>
+       <r>    -0.3644    -0.3955    16.0024 </r>
+       <r>    -0.1645    -0.3924    15.9239 </r>
+       <r>     0.0355     1.3743    16.1987 </r>
+       <r>     0.2354    13.7492    18.9479 </r>
+       <r>     0.4354     5.9119    20.1300 </r>
+       <r>     0.6354    -0.8186    19.9663 </r>
+       <r>     0.8353    -0.2845    19.9095 </r>
+       <r>     1.0353    12.2509    22.3591 </r>
+       <r>     1.2352    19.2998    26.2181 </r>
+       <r>     1.4352    22.0817    30.6334 </r>
+       <r>     1.6351    16.8594    34.0045 </r>
+       <r>     1.8351    -0.0476    33.9950 </r>
+       <r>     2.0350     4.3428    34.8634 </r>
+       <r>     2.2350    13.2858    37.5199 </r>
+       <r>     2.4349    14.9563    40.5105 </r>
+       <r>     2.6349    12.1233    42.9346 </r>
+       <r>     2.8348     9.1005    44.7543 </r>
+       <r>     3.0348    24.4763    49.6484 </r>
+       <r>     3.2348    12.0603    52.0599 </r>
+       <r>     3.4347    -0.4578    51.9684 </r>
+       <r>     3.6347    10.4713    54.0621 </r>
+       <r>     3.8346    14.5484    56.9711 </r>
+       <r>     4.0346    23.8692    61.7438 </r>
+       <r>     4.2345    12.1996    64.1832 </r>
+       <r>     4.4345    12.3721    66.6570 </r>
+       <r>     4.6344    24.9274    71.6414 </r>
+       <r>     4.8344    11.3187    73.9046 </r>
+       <r>     5.0343     0.1091    73.9264 </r>
+       <r>     5.2343     5.2130    74.9687 </r>
+       <r>     5.4342    13.7709    77.7223 </r>
+       <r>     5.6342     4.3219    78.5865 </r>
+       <r>     5.8341     6.5427    79.8947 </r>
+       <r>     6.0341    -0.3413    79.8264 </r>
+       <r>     6.2341    10.5304    81.9320 </r>
+       <r>     6.4340    19.8942    85.9099 </r>
+       <r>     6.6340     0.9045    86.0908 </r>
+       <r>     6.8339    -0.4450    86.0018 </r>
+       <r>     7.0339    -0.0091    86.0000 </r>
+       <r>     7.2338    -0.0000    86.0000 </r>
+       <r>     7.4338    -0.0006    85.9999 </r>
+       <r>     7.6337    -0.0617    85.9875 </r>
+       <r>     7.8337    -0.2506    85.9374 </r>
+       <r>     8.0336     4.6765    86.8725 </r>
+       <r>     8.2336     5.7925    88.0307 </r>
+       <r>     8.4335    -0.0523    88.0203 </r>
+       <r>     8.6335    -0.1000    88.0003 </r>
+       <r>     8.8334    -0.0014    88.0000 </r>
+       <r>     9.0334    -0.0000    88.0000 </r>
+       <r>     9.2334    -0.0002    88.0000 </r>
+       <r>     9.4333    -0.0317    87.9936 </r>
+       <r>     9.6333    -0.3216    87.9293 </r>
+       <r>     9.8332     3.1937    88.5679 </r>
+       <r>    10.0332     6.4475    89.8571 </r>
+       <r>    10.2331     4.6736    90.7916 </r>
+       <r>    10.4331    11.6246    93.1160 </r>
+       <r>    10.6330     8.7331    94.8622 </r>
+       <r>    10.8330    10.8106    97.0238 </r>
+       <r>    11.0329     4.9449    98.0126 </r>
+       <r>    11.2329     1.5490    98.3223 </r>
+       <r>    11.4328     6.9944    99.7209 </r>
+       <r>    11.6328     3.7098   100.4627 </r>
+       <r>    11.8328     6.6860   101.7995 </r>
+       <r>    12.0327     3.3716   102.4737 </r>
+       <r>    12.2327     7.0036   103.8741 </r>
+       <r>    12.4326     0.8427   104.0426 </r>
+       <r>    12.6326    -0.2400   103.9946 </r>
+       <r>    12.8325    -0.3278   103.9291 </r>
+       <r>    13.0325     3.2361   104.5761 </r>
+       <r>    13.2324     6.6212   105.9001 </r>
+       <r>    13.4324     5.3603   106.9719 </r>
+       <r>    13.6323     7.1781   108.4072 </r>
+       <r>    13.8323    11.0661   110.6199 </r>
+       <r>    14.0322     7.1168   112.0429 </r>
+       <r>    14.2322    -0.0792   112.0271 </r>
+       <r>    14.4321    -0.1332   112.0004 </r>
+       <r>    14.6321    -0.0034   111.9998 </r>
+       <r>    14.8321    -0.0911   111.9816 </r>
+       <r>    15.0320    -0.1061   111.9603 </r>
+       <r>    15.2320     5.5652   113.0731 </r>
+       <r>    15.4319     4.5039   113.9737 </r>
+       <r>    15.6319     0.9560   114.1649 </r>
+       <r>    15.8318    16.7353   117.5111 </r>
+       <r>    16.0318    12.6246   120.0355 </r>
+       <r>    16.2317     0.0704   120.0496 </r>
+       <r>    16.4317    -0.2453   120.0005 </r>
+       <r>    16.6316    -0.1902   119.9625 </r>
+       <r>    16.8316    -0.1203   119.9384 </r>
+       <r>    17.0315    10.5893   122.0558 </r>
+       <r>    17.2315    10.4107   124.1374 </r>
+       <r>    17.4315     6.5526   125.4477 </r>
+       <r>    17.6314     3.1152   126.0705 </r>
+       <r>    17.8314    -0.4633   125.9779 </r>
+       <r>    18.0313     0.1945   126.0168 </r>
+       <r>    18.2313     6.3247   127.2814 </r>
+       <r>    18.4312     4.1150   128.1042 </r>
+       <r>    18.6312     8.9781   129.8995 </r>
+       <r>    18.8311    10.0316   131.9053 </r>
+       <r>    19.0311     0.7258   132.0504 </r>
+       <r>    19.2310    -0.4382   131.9628 </r>
+       <r>    19.4310     0.6238   132.0875 </r>
+       <r>    19.6309     6.5520   133.3976 </r>
+       <r>    19.8309     6.2714   134.6516 </r>
+       <r>    20.0308    14.1664   137.4842 </r>
+       <r>    20.2308     3.1079   138.1057 </r>
+       <r>    20.4308    -0.7156   137.9626 </r>
+       <r>    20.6307     0.8130   138.1251 </r>
+       <r>    20.8307     7.2084   139.5665 </r>
+       <r>    21.0306     2.4997   140.0663 </r>
+       <r>    21.2306    -0.3175   140.0028 </r>
+       <r>    21.4305    -0.3152   139.9398 </r>
+       <r>    21.6305     0.6970   140.0792 </r>
+       <r>    21.8304    12.7729   142.6332 </r>
+       <r>    22.0304     7.4486   144.1226 </r>
+       <r>    22.2303    -0.9118   143.9402 </r>
+       <r>    22.4303     1.5557   144.2513 </r>
+       <r>    22.6302    13.2935   146.9094 </r>
+       <r>    22.8302     5.9858   148.1063 </r>
+       <r>    23.0301    -0.7830   147.9497 </r>
+       <r>    23.2301     4.3857   148.8266 </r>
+       <r>    23.4301     5.6902   149.9644 </r>
+       <r>    23.6300     7.8751   151.5391 </r>
+       <r>    23.8300    11.4378   153.8261 </r>
+       <r>    24.0299     1.1852   154.0631 </r>
+       <r>    24.2299    -0.4915   153.9648 </r>
+       <r>    24.4298    -0.2302   153.9188 </r>
+       <r>    24.6298     9.6530   155.8489 </r>
+       <r>    24.8297    21.8066   160.2092 </r>
+       <r>    25.0297    17.4988   163.7082 </r>
+       <r>    25.2296     5.1788   164.7437 </r>
+       <r>    25.4296     6.1541   165.9742 </r>
+       <r>    25.6295    -0.0553   165.9632 </r>
+       <r>    25.8295     1.1299   166.1891 </r>
+       <r>    26.0295    11.6475   168.5181 </r>
+       <r>    26.2294     8.3888   170.1954 </r>
+       <r>    26.4294    13.3454   172.8639 </r>
+       <r>    26.6293     6.0742   174.0785 </r>
+       <r>    26.8293     4.0546   174.8892 </r>
+       <r>    27.0292     5.6770   176.0243 </r>
+       <r>    27.2292    -0.5170   175.9209 </r>
+       <r>    27.4291     3.3318   176.5872 </r>
+       <r>    27.6291    12.8646   179.1595 </r>
+       <r>    27.8290    13.5429   181.8674 </r>
+       <r>    28.0290    10.5884   183.9846 </r>
+       <r>    28.2289     3.0381   184.5921 </r>
+       <r>    28.4289     5.7934   185.7505 </r>
+       <r>    28.6288     9.3502   187.6201 </r>
+       <r>    28.8288    20.0597   191.6311 </r>
+       <r>    29.0288     2.9462   192.2202 </r>
+       <r>    29.2287     6.5784   193.5356 </r>
+       <r>    29.4287     2.6107   194.0576 </r>
+       <r>    29.6286    -0.9904   193.8596 </r>
+       <r>    29.8286     4.8208   194.8235 </r>
+       <r>    30.0285    20.2265   198.8679 </r>
+       <r>    30.2285    15.1217   201.8915 </r>
+       <r>    30.4284     0.1656   201.9246 </r>
+       <r>    30.6284     9.1292   203.7500 </r>
+       <r>    30.8283    17.9883   207.3469 </r>
+       <r>    31.0283     3.8093   208.1085 </r>
+       <r>    31.2282    -0.7805   207.9525 </r>
+       <r>    31.4282     1.5059   208.2536 </r>
+       <r>    31.6281     7.3213   209.7175 </r>
+       <r>    31.8281     7.2366   211.1645 </r>
+       <r>    32.0281     9.2535   213.0148 </r>
+       <r>    32.2280     4.9273   214.0000 </r>
+       <r>    32.4280     1.3622   214.2724 </r>
+       <r>    32.6279     7.0708   215.6862 </r>
+       <r>    32.8279     1.7789   216.0419 </r>
+       <r>    33.0278    11.8286   218.4071 </r>
+       <r>    33.2278     9.4077   220.2882 </r>
+       <r>    33.4277    14.4239   223.1723 </r>
+       <r>    33.6277    13.4706   225.8658 </r>
+       <r>    33.8276     1.0158   226.0689 </r>
+       <r>    34.0276    -0.3324   226.0024 </r>
+       <r>    34.2275    -0.0124   225.9999 </r>
+       <r>    34.4275    -0.0505   225.9898 </r>
+       <r>    34.6275    -0.5599   225.8779 </r>
+       <r>    34.8274     4.8293   226.8435 </r>
+       <r>    35.0274    14.4421   229.7313 </r>
+       <r>    35.2273    11.9266   232.1160 </r>
+       <r>    35.4273     9.1764   233.9509 </r>
+       <r>    35.6272     0.4388   234.0386 </r>
+       <r>    35.8272    -0.6018   233.9183 </r>
+       <r>    36.0271     3.1474   234.5477 </r>
+       <r>    36.2271    11.3356   236.8142 </r>
+       <r>    36.4270     6.2037   238.0547 </r>
+       <r>    36.6270    -0.4994   237.9548 </r>
+       <r>    36.8269     2.4451   238.4438 </r>
+       <r>    37.0269     7.1436   239.8721 </r>
+       <r>    37.2268     0.4972   239.9716 </r>
+       <r>    37.4268     3.6717   240.7057 </r>
+       <r>    37.6268     6.4270   241.9908 </r>
+       <r>    37.8267     0.0889   242.0086 </r>
+       <r>    38.0267    -0.6723   241.8742 </r>
+       <r>    38.2266     7.6134   243.3965 </r>
+       <r>    38.4266    12.4983   245.8956 </r>
+       <r>    38.6265     1.2982   246.1552 </r>
+       <r>    38.8265     6.8061   247.5161 </r>
+       <r>    39.0264     8.1166   249.1390 </r>
+       <r>    39.2264     4.1489   249.9686 </r>
+       <r>    39.4263     7.7790   251.5240 </r>
+       <r>    39.6263    14.1894   254.3613 </r>
+       <r>    39.8262     7.8258   255.9261 </r>
+       <r>    40.0262     0.5908   256.0442 </r>
+       <r>    40.2261    -0.2148   256.0012 </r>
+       <r>    40.4261    -0.0062   256.0000 </r>
+       <r>    40.6261    -0.0000   256.0000 </r>
+       <r>    40.8260    -0.0000   256.0000 </r>
+       <r>    41.0260    -0.0000   256.0000 </r>
+       <r>    41.2259     0.0000   256.0000 </r>
+       <r>    41.4259     0.0000   256.0000 </r>
+       <r>    41.6258     0.0000   256.0000 </r>
+       <r>    41.8258     0.0000   256.0000 </r>
+       <r>    42.0257     0.0000   256.0000 </r>
+       <r>    42.2257     0.0000   256.0000 </r>
+       <r>    42.4256     0.0000   256.0000 </r>
+      </set>
+     </set>
+    </array>
+   </total>
+  </dos>
+ </calculation>
+ <structure name="finalpos" >
+  <crystal>
+   <varray name="basis" >
+    <v>       5.87198220       0.00000000       0.00000000 </v>
+    <v>       0.00000000       5.08280575       0.00000000 </v>
+    <v>       0.00000000       0.00000000       4.64769000 </v>
+   </varray>
+   <i name="volume">    138.71562913 </i>
+   <varray name="rec_basis" >
+    <v>       0.17030024       0.00000000       0.00000000 </v>
+    <v>       0.00000000       0.19674173       0.00000000 </v>
+    <v>       0.00000000       0.00000000       0.21516065 </v>
+   </varray>
+  </crystal>
+  <varray name="positions" >
+   <v>       0.04232415       0.10250303       0.24803642 </v>
+   <v>       0.04233768       0.76906824       0.74803113 </v>
+   <v>       0.29233207       0.26906640       0.74803203 </v>
+   <v>       0.29233083       0.60250330       0.24803510 </v>
+   <v>       0.54232415       0.10250303       0.24803642 </v>
+   <v>       0.54233768       0.76906824       0.74803113 </v>
+   <v>       0.79233207       0.26906640       0.74803203 </v>
+   <v>       0.79233083       0.60250330       0.24803510 </v>
+  </varray>
+ </structure>
+</modeling>

--- a/tests/poscars/Ti-aimd-nwrite0/OUTCAR
+++ b/tests/poscars/Ti-aimd-nwrite0/OUTCAR
@@ -1,0 +1,4473 @@
+ vasp.6.3.0 20Jan22 (build Apr 09 2022 18:33:31) complex                        
+  
+ executed on             LinuxIFC date 2025.07.07  11:37:14
+ running on   64 total cores
+ distrk:  each k-point on   64 cores,    1 groups
+ distr:  one band on NCORE=   1 cores,   64 groups
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+ INCAR:
+   SYSTEM = dpgen
+   PREC = Accurate
+   ISTART = 0
+   ICHARG = 2
+   ENCUT = 350
+   NELM = 100
+   NELMIN = 6
+   NELMDL = -5
+   EDIFF = 1e-06
+   LREAL = A
+   ALGO = Normal
+   IBRION = 0
+   POTIM = 2
+   TEBEG = 500
+   TEEND = 500
+   NWRITE = 0
+   ISIF = 2
+   ISYM = 0
+   NSW = 10
+   ISYM = 0
+   NSW = 10
+   ISMEAR = 1
+   SIGMA = 0.20
+   LWAVE = False
+   LCHARG = False
+   KPAR = 1
+   KSPACING = 5.0
+   KGAMMA = False
+   PSTRESS = 0
+
+ POTCAR:    PAW_PBE Ti 08Apr2002                  
+ -----------------------------------------------------------------------------
+|                                                                             |
+|           W    W    AA    RRRRR   N    N  II  N    N   GGGG   !!!           |
+|           W    W   A  A   R    R  NN   N  II  NN   N  G    G  !!!           |
+|           W    W  A    A  R    R  N N  N  II  N N  N  G       !!!           |
+|           W WW W  AAAAAA  RRRRR   N  N N  II  N  N N  G  GGG   !            |
+|           WW  WW  A    A  R   R   N   NN  II  N   NN  G    G                |
+|           W    W  A    A  R    R  N    N  II  N    N   GGGG   !!!           |
+|                                                                             |
+|     For optimal performance we recommend to set                             |
+|       NCORE = 2 up to number-of-cores-per-socket                            |
+|     NCORE specifies how many cores store one orbital (NPAR=cpu/NCORE).      |
+|     This setting can greatly improve the performance of VASP for DFT.       |
+|     The default, NCORE=1 might be grossly inefficient on modern             |
+|     multi-core architectures or massively parallel machines. Do your        |
+|     own testing! More info at https://www.vasp.at/wiki/index.php/NCORE      |
+|     Unfortunately you need to use the default for GW and RPA                |
+|     calculations (for HF NCORE is supported but not extensively tested      |
+|     yet).                                                                   |
+|                                                                             |
+ -----------------------------------------------------------------------------
+
+ POTCAR:    PAW_PBE Ti 08Apr2002                  
+  local pseudopotential read in
+  partial core-charges read in
+  partial kinetic energy density read in
+  atomic valenz-charges read in
+  non local Contribution for L=           2  read in
+    real space projection operators read in
+  non local Contribution for L=           2  read in
+    real space projection operators read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+    PAW grid and wavefunctions read in
+ 
+   number of l-projection  operators is LMAX  =           5
+   number of lm-projection operators is LMMAX =          15
+ 
+ Optimization of the real space projectors (new method)
+
+ maximal supplied QI-value         = 13.42
+ optimisation between [QCUT,QGAM] = [  9.53, 19.05] = [ 25.41,101.65] Ry 
+ Optimized for a Real-space Cutoff    1.71 Angstroem
+
+   l    n(q)    QCUT    max X(q) W(low)/X(q) W(high)/X(q)  e(spline) 
+   2      9     9.526    49.363    0.22E-03    0.19E-03    0.16E-06
+   2      9     9.526    47.669    0.21E-03    0.18E-03    0.15E-06
+   0     10     9.526    26.374    0.66E-04    0.97E-04    0.20E-06
+   0     10     9.526    11.549    0.52E-04    0.76E-04    0.15E-06
+   1      9     9.526     9.492    0.58E-04    0.43E-04    0.22E-07
+  PAW_PBE Ti 08Apr2002                  :
+ energy of atom  1       EATOM=  -94.7928
+ kinetic energy error for atom=    0.0008 (will be added to EATOM!!)
+ 
+ 
+ POSCAR: POSCAR file written by OVITO Basic 3.10.
+  positions in cartesian coordinates
+  No initial velocities read in
+ exchange correlation table for  LEXCH =        8
+   RHO(1)=    0.500       N(1)  =     2000
+   RHO(2)=  100.500       N(2)  =     4000
+ 
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+ ion  position               nearest neighbor table
+   1  0.042  0.051  0.124-  19 2.88  23 2.88   3 2.88   7 2.88  10 2.88  14 2.88  28 2.93  20 2.93
+                            12 2.93   4 2.93  17 2.94  17 2.94
+   2  0.042  0.385  0.374-   4 2.88   8 2.88  20 2.88  24 2.88   9 2.88  13 2.88  11 2.93   3 2.93
+                            27 2.93  19 2.93  18 2.94  18 2.94
+   3  0.292  0.135  0.374-  17 2.88  21 2.88   1 2.88   5 2.88   4 2.88   8 2.88  10 2.93   2 2.93
+                            26 2.93  18 2.93  19 2.94  19 2.94
+   4  0.292  0.301  0.124-   2 2.88   6 2.88  18 2.88  22 2.88   3 2.88   7 2.88  25 2.93  17 2.93
+                             9 2.93   1 2.93  20 2.94  20 2.94
+   5  0.042  0.051  0.624-  23 2.88  19 2.88   7 2.88   3 2.88  14 2.88  10 2.88  32 2.93  24 2.93
+                            16 2.93   8 2.93  21 2.94  21 2.94
+   6  0.042  0.385  0.874-   8 2.88   4 2.88  24 2.88  20 2.88  13 2.88   9 2.88  15 2.93   7 2.93
+                            31 2.93  23 2.93  22 2.94  22 2.94
+   7  0.292  0.135  0.874-  21 2.88  17 2.88   5 2.88   1 2.88   8 2.88   4 2.88  14 2.93   6 2.93
+                            30 2.93  22 2.93  23 2.94  23 2.94
+   8  0.292  0.301  0.624-   6 2.88   2 2.88  22 2.88  18 2.88   7 2.88   3 2.88  29 2.93  21 2.93
+                            13 2.93   5 2.93  24 2.94  24 2.94
+   9  0.042  0.551  0.124-  27 2.88  31 2.88  11 2.88  15 2.88   2 2.88   6 2.88  20 2.93  28 2.93
+                             4 2.93  12 2.93  25 2.94  25 2.94
+  10  0.042  0.885  0.374-  12 2.88  16 2.88  28 2.88  32 2.88   1 2.88   5 2.88   3 2.93  11 2.93
+                            19 2.93  27 2.93  26 2.94  26 2.94
+  11  0.292  0.635  0.374-  25 2.88  29 2.88   9 2.88  13 2.88  12 2.88  16 2.88   2 2.93  10 2.93
+                            18 2.93  26 2.93  27 2.94  27 2.94
+  12  0.292  0.801  0.124-  10 2.88  14 2.88  26 2.88  30 2.88  11 2.88  15 2.88  17 2.93  25 2.93
+                             1 2.93   9 2.93  28 2.94  28 2.94
+  13  0.042  0.551  0.624-  31 2.88  27 2.88  15 2.88  11 2.88   6 2.88   2 2.88  24 2.93  32 2.93
+                             8 2.93  16 2.93  29 2.94  29 2.94
+  14  0.042  0.885  0.874-  16 2.88  12 2.88  32 2.88  28 2.88   5 2.88   1 2.88   7 2.93  15 2.93
+                            23 2.93  31 2.93  30 2.94  30 2.94
+  15  0.292  0.635  0.874-  29 2.88  25 2.88  13 2.88   9 2.88  16 2.88  12 2.88   6 2.93  14 2.93
+                            22 2.93  30 2.93  31 2.94  31 2.94
+  16  0.292  0.801  0.624-  14 2.88  10 2.88  30 2.88  26 2.88  15 2.88  11 2.88  21 2.93  29 2.93
+                             5 2.93  13 2.93  32 2.94  32 2.94
+  17  0.542  0.051  0.124-   3 2.88   7 2.88  19 2.88  23 2.88  26 2.88  30 2.88  12 2.93   4 2.93
+                            28 2.93  20 2.93   1 2.94   1 2.94
+  18  0.542  0.385  0.374-  20 2.88  24 2.88   4 2.88   8 2.88  25 2.88  29 2.88  27 2.93  19 2.93
+                            11 2.93   3 2.93   2 2.94   2 2.94
+  19  0.792  0.135  0.374-   1 2.88   5 2.88  17 2.88  21 2.88  20 2.88  24 2.88  26 2.93  18 2.93
+                            10 2.93   2 2.93   3 2.94   3 2.94
+  20  0.792  0.301  0.124-  18 2.88  22 2.88   2 2.88   6 2.88  19 2.88  23 2.88   9 2.93   1 2.93
+                            25 2.93  17 2.93   4 2.94   4 2.94
+  21  0.542  0.051  0.624-   7 2.88   3 2.88  23 2.88  19 2.88  30 2.88  26 2.88  16 2.93   8 2.93
+                            32 2.93  24 2.93   5 2.94   5 2.94
+  22  0.542  0.385  0.874-  24 2.88  20 2.88   8 2.88   4 2.88  29 2.88  25 2.88  31 2.93  23 2.93
+                            15 2.93   7 2.93   6 2.94   6 2.94
+  23  0.792  0.135  0.874-   5 2.88   1 2.88  21 2.88  17 2.88  24 2.88  20 2.88  30 2.93  22 2.93
+                            14 2.93   6 2.93   7 2.94   7 2.94
+  24  0.792  0.301  0.624-  22 2.88  18 2.88   6 2.88   2 2.88  23 2.88  19 2.88  13 2.93   5 2.93
+                            29 2.93  21 2.93   8 2.94   8 2.94
+  25  0.542  0.551  0.124-  11 2.88  15 2.88  27 2.88  31 2.88  18 2.88  22 2.88   4 2.93  12 2.93
+                            20 2.93  28 2.93   9 2.94   9 2.94
+  26  0.542  0.885  0.374-  28 2.88  32 2.88  12 2.88  16 2.88  17 2.88  21 2.88  19 2.93  27 2.93
+                             3 2.93  11 2.93  10 2.94  10 2.94
+  27  0.792  0.635  0.374-   9 2.88  13 2.88  25 2.88  29 2.88  28 2.88  32 2.88  18 2.93  26 2.93
+                             2 2.93  10 2.93  11 2.94  11 2.94
+  28  0.792  0.801  0.124-  26 2.88  30 2.88  10 2.88  14 2.88  27 2.88  31 2.88   1 2.93   9 2.93
+                            17 2.93  25 2.93  12 2.94  12 2.94
+  29  0.542  0.551  0.624-  15 2.88  11 2.88  31 2.88  27 2.88  22 2.88  18 2.88   8 2.93  16 2.93
+                            24 2.93  32 2.93  13 2.94  13 2.94
+  30  0.542  0.885  0.874-  32 2.88  28 2.88  16 2.88  12 2.88  21 2.88  17 2.88  23 2.93  31 2.93
+                             7 2.93  15 2.93  14 2.94  14 2.94
+  31  0.792  0.635  0.874-  13 2.88   9 2.88  29 2.88  25 2.88  32 2.88  28 2.88  22 2.93  30 2.93
+                             6 2.93  14 2.93  15 2.94  15 2.94
+  32  0.792  0.801  0.624-  30 2.88  26 2.88  14 2.88  10 2.88  31 2.88  27 2.88   5 2.93  13 2.93
+                            21 2.93  29 2.93  16 2.94  16 2.94
+ 
+
+IMPORTANT INFORMATION: All symmetrisations will be switched off!
+NOSYMM: (Re-)initialisation of all symmetry stuff for point group C_1.
+
+
+----------------------------------------------------------------------------------------
+
+                                     Primitive cell                                     
+
+  volume of cell :     554.8625
+
+  direct lattice vectors                    reciprocal lattice vectors
+     5.871982203  0.000000000  0.000000000     0.170300244  0.000000000  0.000000000
+     0.000000000 10.165611494  0.000000000     0.000000000  0.098370865  0.000000000
+     0.000000000  0.000000000  9.295380000     0.000000000  0.000000000  0.107580325
+
+  length of vectors
+     5.871982203 10.165611494  9.295380000     0.170300244  0.098370865  0.107580325
+
+  position of ions in fractional coordinates (direct lattice)
+     0.042324146  0.051251513  0.124018210
+     0.042337684  0.384534122  0.374015565
+     0.292332070  0.134533199  0.374016017
+     0.292330835  0.301251651  0.124017548
+     0.042324146  0.051251513  0.624018210
+     0.042337684  0.384534122  0.874015565
+     0.292332070  0.134533199  0.874016017
+     0.292330835  0.301251651  0.624017548
+     0.042324146  0.551251513  0.124018210
+     0.042337684  0.884534122  0.374015565
+     0.292332070  0.634533199  0.374016017
+     0.292330835  0.801251651  0.124017548
+     0.042324146  0.551251513  0.624018210
+     0.042337684  0.884534122  0.874015565
+     0.292332070  0.634533199  0.874016017
+     0.292330835  0.801251651  0.624017548
+     0.542324146  0.051251513  0.124018210
+     0.542337684  0.384534122  0.374015565
+     0.792332070  0.134533199  0.374016017
+     0.792330835  0.301251651  0.124017548
+     0.542324146  0.051251513  0.624018210
+     0.542337684  0.384534122  0.874015565
+     0.792332070  0.134533199  0.874016017
+     0.792330835  0.301251651  0.624017548
+     0.542324146  0.551251513  0.124018210
+     0.542337684  0.884534122  0.374015565
+     0.792332070  0.634533199  0.374016017
+     0.792330835  0.801251651  0.124017548
+     0.542324146  0.551251513  0.624018210
+     0.542337684  0.884534122  0.874015565
+     0.792332070  0.634533199  0.874016017
+     0.792330835  0.801251651  0.624017548
+
+  ion indices of the primitive-cell ions
+   primitive index   ion index
+                 1           1
+                 2           2
+                 3           3
+                 4           4
+                 5           5
+                 6           6
+                 7           7
+                 8           8
+                 9           9
+                10          10
+                11          11
+                12          12
+                13          13
+                14          14
+                15          15
+                16          16
+                17          17
+                18          18
+                19          19
+                20          20
+                21          21
+                22          22
+                23          23
+                24          24
+                25          25
+                26          26
+                27          27
+                28          28
+                29          29
+                30          30
+                31          31
+                32          32
+
+----------------------------------------------------------------------------------------
+
+ 
+ -----------------------------------------------------------------------------
+|                                                                             |
+|           W    W    AA    RRRRR   N    N  II  N    N   GGGG   !!!           |
+|           W    W   A  A   R    R  NN   N  II  NN   N  G    G  !!!           |
+|           W    W  A    A  R    R  N N  N  II  N N  N  G       !!!           |
+|           W WW W  AAAAAA  RRRRR   N  N N  II  N  N N  G  GGG   !            |
+|           WW  WW  A    A  R   R   N   NN  II  N   NN  G    G                |
+|           W    W  A    A  R    R  N    N  II  N    N   GGGG   !!!           |
+|                                                                             |
+|     The requested file  could not be found or opened for reading            |
+|     k-point information. Automatic k-point generation is used as a          |
+|     fallback, which may lead to unwanted results.                           |
+|                                                                             |
+ -----------------------------------------------------------------------------
+
+ 
+
+Automatic generation of k-mesh.
+ Grid dimensions derived from KSPACING:
+ generate k-points for:    1    1    1
+
+ Generating k-lattice:
+
+  Cartesian coordinates                     Fractional coordinates (reciprocal lattice)
+     0.170300244  0.000000000  0.000000000     1.000000000  0.000000000  0.000000000
+     0.000000000  0.098370865  0.000000000     0.000000000  1.000000000  0.000000000
+     0.000000000  0.000000000  0.107580325     0.000000000  0.000000000  1.000000000
+
+  Length of vectors
+     0.170300244  0.098370865  0.107580325
+
+  Shift w.r.t. Gamma in fractional coordinates (k-lattice)
+     0.000000000  0.000000000  0.000000000
+
+ 
+ Subroutine IBZKPT returns following result:
+ ===========================================
+ 
+ Found      1 irreducible k-points:
+ 
+ Following reciprocal coordinates:
+            Coordinates               Weight
+  0.000000  0.000000  0.000000      1.000000
+ 
+ Following cartesian coordinates:
+            Coordinates               Weight
+  0.000000  0.000000  0.000000      1.000000
+ 
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+ Dimension of arrays:
+   k-points           NKPTS =      1   k-points in BZ     NKDIM =      1   number of bands    NBANDS=    128
+   number of dos      NEDOS =    301   number of ions     NIONS =     32
+   non local maximal  LDIM  =      5   non local SUM 2l+1 LMDIM =     15
+   total plane-waves  NPLWV = 138240
+   max r-space proj   IRMAX =   5276   max aug-charges    IRDMAX=  17404
+   dimension x,y,z NGX =    36 NGY =   64 NGZ =   60
+   dimension x,y,z NGXF=    72 NGYF=  128 NGZF=  120
+   support grid    NGXF=    72 NGYF=  128 NGZF=  120
+   ions per type =              32
+   NGX,Y,Z   is equivalent  to a cutoff of  10.19, 10.47, 10.73 a.u.
+   NGXF,Y,Z  is equivalent  to a cutoff of  20.38, 20.93, 21.46 a.u.
+
+ SYSTEM =  dpgen                                   
+ POSCAR =  POSCAR file written by OVITO Basic 3.10.
+
+ Startparameter for this run:
+   NWRITE =      0    write-flag & timer
+   PREC   = accura    normal or accurate (medium, high low for compatibility)
+   ISTART =      0    job   : 0-new  1-cont  2-samecut
+   ICHARG =      2    charge: 1-file 2-atom 10-const
+   ISPIN  =      1    spin polarized calculation?
+   LNONCOLLINEAR =      F non collinear calculations
+   LSORBIT =      F    spin-orbit coupling
+   INIWAV =      1    electr: 0-lowe 1-rand  2-diag
+   LASPH  =      F    aspherical Exc in radial PAW
+ Electronic Relaxation 1
+   ENCUT  =  350.0 eV  25.72 Ry    5.07 a.u.   8.96 15.51 14.18*2*pi/ulx,y,z
+   ENINI  =  350.0     initial cutoff
+   ENAUG  =  328.9 eV  augmentation charge cutoff
+   NELM   =    100;   NELMIN=  6; NELMDL= -5     # of ELM steps 
+   EDIFF  = 0.1E-05   stopping-criterion for ELM
+   LREAL  =      T    real-space projection
+   NLSPLINE    = F    spline interpolate recip. space projectors
+   LCOMPAT=      F    compatible to vasp.4.4
+   GGA_COMPAT  = T    GGA compatible to vasp.4.4-vasp.4.6
+   LMAXPAW     = -100 max onsite density
+   LMAXMIX     =    2 max onsite mixed and CHGCAR
+   VOSKOWN=      0    Vosko Wilk Nusair interpolation
+   ROPT   =   -0.00025
+ Ionic relaxation
+   EDIFFG = 0.1E-04   stopping-criterion for IOM
+   NSW    =     10    number of steps for IOM
+   NBLOCK =      1;   KBLOCK =     10    inner block; outer block 
+   IBRION =      0    ionic relax: 0-MD 1-quasi-New 2-CG
+   NFREE  =      0    steps in history (QN), initial steepest desc. (CG)
+   ISIF   =      2    stress and relaxation
+   IWAVPR =     12    prediction:  0-non 1-charg 2-wave 3-comb
+   ISYM   =      0    0-nonsym 1-usesym 2-fastsym
+   LCORR  =      T    Harris-Foulkes like correction to forces
+
+   POTIM  = 2.0000    time-step for ionic-motion
+   TEIN   =  500.0    initial temperature
+   TEBEG  =  500.0;   TEEND  = 500.0 temperature during run
+   SMASS  =  -3.00    Nose mass-parameter (am)
+   estimated Nose-frequenzy (Omega)   =  0.10E-29 period in steps = 0.31E+46 mass=  -0.788E-27a.u.
+   SCALEE = 1.0000    scale energy and forces
+   NPACO  =    256;   APACO  = 10.0  distance and # of slots for P.C.
+   PSTRESS=    0.0 pullay stress
+
+  Mass of Ions in am
+   POMASS =  47.88
+  Ionic Valenz
+   ZVAL   =   4.00
+  Atomic Wigner-Seitz radii
+   RWIGS  =  -1.00
+  virtual crystal weights 
+   VCA    =   1.00
+   NELECT =     128.0000    total number of electrons
+   NUPDOWN=      -1.0000    fix difference up-down
+
+ DOS related values:
+   EMIN   =  10.00;   EMAX   =-10.00  energy-range for DOS
+   EFERMI =   0.00
+   ISMEAR =     1;   SIGMA  =   0.20  broadening in eV -4-tet -1-fermi 0-gaus
+
+ Electronic relaxation 2 (details)
+   IALGO  =     38    algorithm
+   LDIAG  =      T    sub-space diagonalisation (order eigenvalues)
+   LSUBROT=      F    optimize rotation matrix (better conditioning)
+   TURBO    =      0    0=normal 1=particle mesh
+   IRESTART =      0    0=no restart 2=restart with 2 vectors
+   NREBOOT  =      0    no. of reboots
+   NMIN     =      0    reboot dimension
+   EREF     =   0.00    reference energy to select bands
+   IMIX   =      4    mixing-type and parameters
+     AMIX     =   0.40;   BMIX     =  1.00
+     AMIX_MAG =   1.60;   BMIX_MAG =  1.00
+     AMIN     =   0.10
+     WC   =   100.;   INIMIX=   1;  MIXPRE=   1;  MAXMIX= -45
+
+ Intra band minimization:
+   WEIMIN = 0.0010     energy-eigenvalue tresh-hold
+   EBREAK =  0.20E-08  absolut break condition
+   DEPER  =   0.30     relativ break condition  
+
+   TIME   =   0.40     timestep for ELM
+
+  volume/ion in A,a.u.               =      17.34       117.01
+  Fermi-wavevector in a.u.,A,eV,Ry     =   1.004037  1.897355 13.715900  1.008090
+  Thomas-Fermi vector in A             =   2.136627
+ 
+ Write flags
+   LWAVE        =      F    write WAVECAR
+   LDOWNSAMPLE  =      F    k-point downsampling of WAVECAR
+   LCHARG       =      F    write CHGCAR
+   LVTOT        =      F    write LOCPOT, total local potential
+   LVHAR        =      F    write LOCPOT, Hartree potential only
+   LELF         =      F    write electronic localiz. function (ELF)
+   LORBIT       =      0    0 simple, 1 ext, 2 COOP (PROOUT), +10 PAW based schemes
+
+
+ Dipole corrections
+   LMONO  =      F    monopole corrections only (constant potential shift)
+   LDIPOL =      F    correct potential (dipole corrections)
+   IDIPOL =      0    1-x, 2-y, 3-z, 4-all directions 
+   EPSILON=  1.0000000 bulk dielectric constant
+
+ Exchange correlation treatment:
+   GGA     =    --    GGA type
+   LEXCH   =     8    internal setting for exchange type
+   LIBXC   =     F    Libxc                    
+   VOSKOWN =     0    Vosko Wilk Nusair interpolation
+   LHFCALC =     F    Hartree Fock is set to
+   LHFONE  =     F    Hartree Fock one center treatment
+   AEXX    =    0.0000 exact exchange contribution
+
+ Linear response parameters
+   LEPSILON=     F    determine dielectric tensor
+   LRPA    =     F    only Hartree local field effects (RPA)
+   LNABLA  =     F    use nabla operator in PAW spheres
+   LVEL    =     F    velocity operator in full k-point grid
+   CSHIFT  =0.1000    complex shift for real part using Kramers Kronig
+   OMEGAMAX=  -1.0    maximum frequency
+   DEG_THRESHOLD= 0.2000000E-02 threshold for treating states as degnerate
+   RTIME   =   -0.100 relaxation time in fs
+  (WPLASMAI=    0.000 imaginary part of plasma frequency in eV, 0.658/RTIME)
+   DFIELD  = 0.0000000 0.0000000 0.0000000 field for delta impulse in time
+ 
+  Optional k-point grid parameters
+   LKPOINTS_OPT  =     F    use optional k-point grid
+   KPOINTS_OPT_MODE=     1    mode for optional k-point grid
+ 
+ Orbital magnetization related:
+   ORBITALMAG=     F  switch on orbital magnetization
+   LCHIMAG   =     F  perturbation theory with respect to B field
+   DQ        =  0.001000  dq finite difference perturbation B field
+   LLRAUG    =     F  two centre corrections for induced B field
+
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+ molecular dynamics for ions
+   using a microcanonical ensemble
+ charge density and potential will be updated during run
+ non-spin polarized calculation
+ Variant of blocked Davidson
+ Davidson routine will perform the subspace rotation
+ perform sub-space diagonalisation
+    after iterative eigenvector-optimisation
+ modified Broyden-mixing scheme, WC =      100.0
+ initial mixing is a Kerker type mixing with AMIX =  0.4000 and BMIX =      1.0000
+ Hartree-type preconditioning will be used
+ using additional bands           64
+ real space projection scheme for non local part
+ use partial core corrections
+ calculate Harris-corrections to forces 
+   (improved forces if not selfconsistent)
+ use gradient corrections 
+ use of overlap-Matrix (Vanderbilt PP)
+ Methfessel and Paxton  Order N= 1 SIGMA  =   0.20
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+  energy-cutoff  :      350.00
+  volume of cell :      554.86
+      direct lattice vectors                 reciprocal lattice vectors
+     5.871982203  0.000000000  0.000000000     0.170300244  0.000000000  0.000000000
+     0.000000000 10.165611494  0.000000000     0.000000000  0.098370865  0.000000000
+     0.000000000  0.000000000  9.295380000     0.000000000  0.000000000  0.107580325
+
+  length of vectors
+     5.871982203 10.165611494  9.295380000     0.170300244  0.098370865  0.107580325
+
+
+ 
+ k-points in units of 2pi/SCALE and weight: read from INCAR                         
+   0.00000000  0.00000000  0.00000000       1.000
+ 
+ k-points in reciprocal lattice and weights: read from INCAR                         
+   0.00000000  0.00000000  0.00000000       1.000
+ 
+ position of ions in fractional coordinates (direct lattice) 
+   0.04232415  0.05125151  0.12401821
+   0.04233768  0.38453412  0.37401556
+   0.29233207  0.13453320  0.37401602
+   0.29233083  0.30125165  0.12401755
+   0.04232415  0.05125151  0.62401821
+   0.04233768  0.38453412  0.87401556
+   0.29233207  0.13453320  0.87401602
+   0.29233083  0.30125165  0.62401755
+   0.04232415  0.55125151  0.12401821
+   0.04233768  0.88453412  0.37401556
+   0.29233207  0.63453320  0.37401602
+   0.29233083  0.80125165  0.12401755
+   0.04232415  0.55125151  0.62401821
+   0.04233768  0.88453412  0.87401556
+   0.29233207  0.63453320  0.87401602
+   0.29233083  0.80125165  0.62401755
+   0.54232415  0.05125151  0.12401821
+   0.54233768  0.38453412  0.37401556
+   0.79233207  0.13453320  0.37401602
+   0.79233083  0.30125165  0.12401755
+   0.54232415  0.05125151  0.62401821
+   0.54233768  0.38453412  0.87401556
+   0.79233207  0.13453320  0.87401602
+   0.79233083  0.30125165  0.62401755
+   0.54232415  0.55125151  0.12401821
+   0.54233768  0.88453412  0.37401556
+   0.79233207  0.63453320  0.37401602
+   0.79233083  0.80125165  0.12401755
+   0.54232415  0.55125151  0.62401821
+   0.54233768  0.88453412  0.87401556
+   0.79233207  0.63453320  0.87401602
+   0.79233083  0.80125165  0.62401755
+ 
+ position of ions in cartesian coordinates  (Angst):
+   0.24852663  0.52100297  1.15279639
+   0.24860612  3.90902449  3.47661680
+   1.71656871  1.36761223  3.47662101
+   1.71656146  3.06240725  1.15279023
+   0.24852663  0.52100297  5.80048639
+   0.24860612  3.90902449  8.12430680
+   1.71656871  1.36761223  8.12431101
+   1.71656146  3.06240725  5.80048023
+   0.24852663  5.60380872  1.15279639
+   0.24860612  8.99183024  3.47661680
+   1.71656871  6.45041798  3.47662101
+   1.71656146  8.14521299  1.15279023
+   0.24852663  5.60380872  5.80048639
+   0.24860612  8.99183024  8.12430680
+   1.71656871  6.45041798  8.12431101
+   1.71656146  8.14521299  5.80048023
+   3.18451774  0.52100297  1.15279639
+   3.18459723  3.90902449  3.47661680
+   4.65255982  1.36761223  3.47662101
+   4.65255256  3.06240725  1.15279023
+   3.18451774  0.52100297  5.80048639
+   3.18459723  3.90902449  8.12430680
+   4.65255982  1.36761223  8.12431101
+   4.65255256  3.06240725  5.80048023
+   3.18451774  5.60380872  1.15279639
+   3.18459723  8.99183024  3.47661680
+   4.65255982  6.45041798  3.47662101
+   4.65255256  8.14521299  1.15279023
+   3.18451774  5.60380872  5.80048639
+   3.18459723  8.99183024  8.12430680
+   4.65255982  6.45041798  8.12431101
+   4.65255256  8.14521299  5.80048023
+ 
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+ k-point   1 :   0.0000 0.0000 0.0000  plane waves:    8227
+
+ maximum and minimum number of plane-waves per node :      8227     8227
+
+ maximum number of plane-waves:      8227
+ maximum index in each direction: 
+   IXMAX=    8   IYMAX=   15   IZMAX=   14
+   IXMIN=   -8   IYMIN=  -15   IZMIN=  -14
+
+
+ serial   3D FFT for wavefunctions
+ parallel 3D FFT for charge:
+    minimum data exchange during FFTs selected (reduces bandwidth)
+
+
+ total amount of memory used by VASP MPI-rank0    63403. kBytes
+=======================================================================
+
+   base      :      30000. kBytes
+   nonlr-proj:      24207. kBytes
+   fftplans  :       1514. kBytes
+   grid      :       7057. kBytes
+   one-center:        345. kBytes
+   wavefun   :        280. kBytes
+ 
+     INWAV:  cpu time      0.0000: real time      0.0000
+ Broyden mixing: mesh for mixing (old mesh)
+   NGX = 17   NGY = 31   NGZ = 29
+  (NGX  = 72   NGY  =128   NGZ  =120)
+  gives a total of  15283 points
+
+ initial charge density was supplied:
+ charge density of overlapping atoms calculated
+ number of electron     128.0000000 magnetization 
+ keeping initial charge density in first step
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+ Maximum index for non-local projection operator         5066
+ Maximum index for augmentation-charges         1176 (set IRDMAX)
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+ First call to EWALD:  gamma=   0.216
+ Maximum number of real-space cells 4x 2x 2
+ Maximum number of reciprocal cells 2x 3x 3
+
+    FEWALD:  cpu time      0.0015: real time      0.0015
+
+
+--------------------------------------- Iteration      1(   1)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0236: real time      0.0277
+    SETDIJ:  cpu time      0.0046: real time      0.0046
+     EDDAV:  cpu time      0.3764: real time      0.4472
+       DOS:  cpu time      0.0022: real time      0.0024
+    --------------------------------------------
+      LOOP:  cpu time      0.4068: real time      0.4819
+
+ eigenvalue-minimisations  :   256
+ total energy-change (2. order) : 0.2409994E+03  (-0.3200279E+04)
+ number of electron     128.0000000 magnetization 
+ augmentation part      128.0000000 magnetization 
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =       650.40088722
+  Ewald energy   TEWEN  =     -4112.86760800
+  -Hartree energ DENC   =      -247.31505106
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =     -1183.82933660
+  PAW double counting   =      4016.50513093    -2721.65315951
+  entropy T*S    EENTRO =        -0.10426590
+  eigenvalues    EBANDS =       806.51795614
+  atomic energy  EATOM  =      3033.34488495
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =       240.99943818 eV
+
+  energy without entropy =      241.10370408  energy(sigma->0) =      241.03419348
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(   2)  ---------------------------------------
+
+
+     EDDAV:  cpu time      0.2870: real time      0.3502
+       DOS:  cpu time      0.0007: real time      0.0022
+    --------------------------------------------
+      LOOP:  cpu time      0.2876: real time      0.3524
+
+ eigenvalue-minimisations  :   256
+ total energy-change (2. order) :-0.4924697E+03  (-0.4486124E+03)
+ number of electron     128.0000000 magnetization 
+ augmentation part      128.0000000 magnetization 
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =       650.40088722
+  Ewald energy   TEWEN  =     -4112.86760800
+  -Hartree energ DENC   =      -247.31505106
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =     -1183.82933660
+  PAW double counting   =      4016.50513093    -2721.65315951
+  entropy T*S    EENTRO =         0.05870724
+  eigenvalues    EBANDS =       313.88523784
+  atomic energy  EATOM  =      3033.34488495
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -251.47030698 eV
+
+  energy without entropy =     -251.52901422  energy(sigma->0) =     -251.48987606
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(   3)  ---------------------------------------
+
+
+     EDDAV:  cpu time      0.4784: real time      0.4896
+       DOS:  cpu time      0.0004: real time      0.0004
+    --------------------------------------------
+      LOOP:  cpu time      0.4788: real time      0.4900
+
+ eigenvalue-minimisations  :   384
+ total energy-change (2. order) :-0.3389607E+02  (-0.2999869E+02)
+ number of electron     128.0000000 magnetization 
+ augmentation part      128.0000000 magnetization 
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =       650.40088722
+  Ewald energy   TEWEN  =     -4112.86760800
+  -Hartree energ DENC   =      -247.31505106
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =     -1183.82933660
+  PAW double counting   =      4016.50513093    -2721.65315951
+  entropy T*S    EENTRO =        -0.05129956
+  eigenvalues    EBANDS =       280.09917301
+  atomic energy  EATOM  =      3033.34488495
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -285.36637861 eV
+
+  energy without entropy =     -285.31507905  energy(sigma->0) =     -285.34927876
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(   4)  ---------------------------------------
+
+
+     EDDAV:  cpu time      0.2733: real time      0.2832
+       DOS:  cpu time      0.0004: real time      0.0004
+    --------------------------------------------
+      LOOP:  cpu time      0.2738: real time      0.2837
+
+ eigenvalue-minimisations  :   256
+ total energy-change (2. order) :-0.1049903E+01  (-0.1047772E+01)
+ number of electron     128.0000000 magnetization 
+ augmentation part      128.0000000 magnetization 
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =       650.40088722
+  Ewald energy   TEWEN  =     -4112.86760800
+  -Hartree energ DENC   =      -247.31505106
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =     -1183.82933660
+  PAW double counting   =      4016.50513093    -2721.65315951
+  entropy T*S    EENTRO =        -0.05782825
+  eigenvalues    EBANDS =       279.05579862
+  atomic energy  EATOM  =      3033.34488495
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -286.41628169 eV
+
+  energy without entropy =     -286.35845344  energy(sigma->0) =     -286.39700560
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(   5)  ---------------------------------------
+
+
+     EDDAV:  cpu time      0.4603: real time      0.4690
+       DOS:  cpu time      0.0004: real time      0.0004
+    CHARGE:  cpu time      0.0194: real time      0.0199
+    MIXING:  cpu time      0.0030: real time      0.0031
+    --------------------------------------------
+      LOOP:  cpu time      0.4831: real time      0.4923
+
+ eigenvalue-minimisations  :   384
+ total energy-change (2. order) :-0.1683371E-01  (-0.1683056E-01)
+ number of electron     128.0000033 magnetization 
+ augmentation part       26.1764894 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.63718E+01    rms(broyden)= 0.63718E+01
+  rms(prec ) = 0.69526E+01
+  weight for this iteration     100.00
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =       650.40088722
+  Ewald energy   TEWEN  =     -4112.86760800
+  -Hartree energ DENC   =      -247.31505106
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =     -1183.82933660
+  PAW double counting   =      4016.50513093    -2721.65315951
+  entropy T*S    EENTRO =        -0.05792649
+  eigenvalues    EBANDS =       279.03906315
+  atomic energy  EATOM  =      3033.34488495
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -286.43311540 eV
+
+  energy without entropy =     -286.37518891  energy(sigma->0) =     -286.41380657
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(   6)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0176: real time      0.0257
+    SETDIJ:  cpu time      0.0040: real time      0.0040
+     EDDAV:  cpu time      0.2704: real time      0.2705
+       DOS:  cpu time      0.0005: real time      0.0005
+    CHARGE:  cpu time      0.0199: real time      0.0199
+    MIXING:  cpu time      0.0020: real time      0.0052
+    --------------------------------------------
+      LOOP:  cpu time      0.3145: real time      0.3258
+
+ eigenvalue-minimisations  :   256
+ total energy-change (2. order) : 0.2961552E+02  (-0.6453117E+01)
+ number of electron     128.0000045 magnetization 
+ augmentation part       32.9289235 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.17648E+01    rms(broyden)= 0.17648E+01
+  rms(prec ) = 0.19838E+01
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   1.3704
+  1.3704
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =       650.40088722
+  Ewald energy   TEWEN  =     -4112.86760800
+  -Hartree energ DENC   =      -151.85949463
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =     -1177.53229587
+  PAW double counting   =      6080.00233043    -4780.25072798
+  entropy T*S    EENTRO =         0.06802617
+  eigenvalues    EBANDS =       201.87640143
+  atomic energy  EATOM  =      3033.34488495
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -256.81759630 eV
+
+  energy without entropy =     -256.88562247  energy(sigma->0) =     -256.84027169
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(   7)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0193: real time      0.0264
+    SETDIJ:  cpu time      0.0038: real time      0.0038
+     EDDAV:  cpu time      0.3578: real time      0.3580
+       DOS:  cpu time      0.0005: real time      0.0005
+    CHARGE:  cpu time      0.0189: real time      0.0189
+    MIXING:  cpu time      0.0007: real time      0.0021
+    --------------------------------------------
+      LOOP:  cpu time      0.4010: real time      0.4096
+
+ eigenvalue-minimisations  :   320
+ total energy-change (2. order) : 0.3431430E+01  (-0.1219957E+01)
+ number of electron     128.0000049 magnetization 
+ augmentation part       35.8083813 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.20097E+00    rms(broyden)= 0.20093E+00
+  rms(prec ) = 0.23060E+00
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   1.6623
+  1.4051  1.9195
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =       650.40088722
+  Ewald energy   TEWEN  =     -4112.86760800
+  -Hartree energ DENC   =      -117.61343650
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =     -1173.51208945
+  PAW double counting   =      7635.23510236    -6338.28412550
+  entropy T*S    EENTRO =        -0.05477519
+  eigenvalues    EBANDS =       169.96499336
+  atomic energy  EATOM  =      3033.34488495
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -253.38616675 eV
+
+  energy without entropy =     -253.33139156  energy(sigma->0) =     -253.36790835
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(   8)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0194: real time      0.0266
+    SETDIJ:  cpu time      0.0037: real time      0.0037
+     EDDAV:  cpu time      0.3502: real time      0.3502
+       DOS:  cpu time      0.0004: real time      0.0004
+    CHARGE:  cpu time      0.0188: real time      0.0188
+    MIXING:  cpu time      0.0004: real time      0.0004
+    --------------------------------------------
+      LOOP:  cpu time      0.3929: real time      0.4002
+
+ eigenvalue-minimisations  :   320
+ total energy-change (2. order) : 0.2203906E+00  (-0.1340090E-01)
+ number of electron     128.0000050 magnetization 
+ augmentation part       35.8172289 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.69802E-01    rms(broyden)= 0.69797E-01
+  rms(prec ) = 0.93820E-01
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   1.5379
+  2.3662  0.8949  1.3526
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =       650.40088722
+  Ewald energy   TEWEN  =     -4112.86760800
+  -Hartree energ DENC   =      -114.31618584
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =     -1172.70676141
+  PAW double counting   =      8218.06549307    -6927.91602154
+  entropy T*S    EENTRO =        -0.06342139
+  eigenvalues    EBANDS =       172.89295679
+  atomic energy  EATOM  =      3033.34488495
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -253.16577616 eV
+
+  energy without entropy =     -253.10235476  energy(sigma->0) =     -253.14463569
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(   9)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0169: real time      0.0258
+    SETDIJ:  cpu time      0.0037: real time      0.0037
+     EDDAV:  cpu time      0.5348: real time      0.5349
+       DOS:  cpu time      0.0005: real time      0.0004
+    CHARGE:  cpu time      0.0190: real time      0.0190
+    MIXING:  cpu time      0.0004: real time      0.0004
+    --------------------------------------------
+      LOOP:  cpu time      0.5752: real time      0.5843
+
+ eigenvalue-minimisations  :   448
+ total energy-change (2. order) :-0.9442191E-03  (-0.7511803E-02)
+ number of electron     128.0000050 magnetization 
+ augmentation part       35.8752976 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.84058E-01    rms(broyden)= 0.84055E-01
+  rms(prec ) = 0.15063E+00
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   1.2952
+  2.5419  1.3178  1.0808  0.2401
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =       650.40088722
+  Ewald energy   TEWEN  =     -4112.86760800
+  -Hartree energ DENC   =      -113.30278077
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =     -1172.48707448
+  PAW double counting   =      8351.61983281    -7062.55741358
+  entropy T*S    EENTRO =        -0.06622724
+  eigenvalues    EBANDS =       172.74877871
+  atomic energy  EATOM  =      3033.34488495
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -253.16672038 eV
+
+  energy without entropy =     -253.10049313  energy(sigma->0) =     -253.14464463
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  10)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0178: real time      0.0282
+    SETDIJ:  cpu time      0.0037: real time      0.0037
+     EDDAV:  cpu time      0.5334: real time      0.5335
+       DOS:  cpu time      0.0004: real time      0.0004
+    CHARGE:  cpu time      0.0188: real time      0.0188
+    MIXING:  cpu time      0.0007: real time      0.0019
+    --------------------------------------------
+      LOOP:  cpu time      0.5747: real time      0.5864
+
+ eigenvalue-minimisations  :   448
+ total energy-change (2. order) : 0.1095154E-01  (-0.3756651E-02)
+ number of electron     128.0000050 magnetization 
+ augmentation part       35.9063415 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.18674E-01    rms(broyden)= 0.18668E-01
+  rms(prec ) = 0.29363E-01
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   1.1929
+  2.5502  1.2481  1.2481  0.6895  0.2287
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =       650.40088722
+  Ewald energy   TEWEN  =     -4112.86760800
+  -Hartree energ DENC   =      -112.76359481
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =     -1172.36467411
+  PAW double counting   =      8426.27316980    -7137.77319059
+  entropy T*S    EENTRO =        -0.06815258
+  eigenvalues    EBANDS =       172.66250929
+  atomic energy  EATOM  =      3033.34488495
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -253.15576883 eV
+
+  energy without entropy =     -253.08761625  energy(sigma->0) =     -253.13305131
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  11)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0182: real time      0.0255
+    SETDIJ:  cpu time      0.0037: real time      0.0037
+     EDDAV:  cpu time      0.5365: real time      0.5365
+       DOS:  cpu time      0.0005: real time      0.0005
+    CHARGE:  cpu time      0.0192: real time      0.0192
+    MIXING:  cpu time      0.0005: real time      0.0005
+    --------------------------------------------
+      LOOP:  cpu time      0.5786: real time      0.5859
+
+ eigenvalue-minimisations  :   448
+ total energy-change (2. order) :-0.2167162E-04  (-0.3582863E-03)
+ number of electron     128.0000050 magnetization 
+ augmentation part       35.9080104 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.15517E-01    rms(broyden)= 0.15517E-01
+  rms(prec ) = 0.24841E-01
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   1.2975
+  2.4891  2.4891  1.3505  0.9981  0.2493  0.2091
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =       650.40088722
+  Ewald energy   TEWEN  =     -4112.86760800
+  -Hartree energ DENC   =      -112.80023817
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =     -1172.36411866
+  PAW double counting   =      8428.10730831    -7139.58225979
+  entropy T*S    EENTRO =        -0.06785988
+  eigenvalues    EBANDS =       172.67321352
+  atomic energy  EATOM  =      3033.34488495
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -253.15579051 eV
+
+  energy without entropy =     -253.08793062  energy(sigma->0) =     -253.13317054
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  12)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0183: real time      0.0255
+    SETDIJ:  cpu time      0.0039: real time      0.0039
+     EDDAV:  cpu time      0.5493: real time      0.5493
+       DOS:  cpu time      0.0005: real time      0.0005
+    CHARGE:  cpu time      0.0192: real time      0.0192
+    MIXING:  cpu time      0.0005: real time      0.0005
+    --------------------------------------------
+      LOOP:  cpu time      0.5917: real time      0.5990
+
+ eigenvalue-minimisations  :   448
+ total energy-change (2. order) : 0.1336778E-03  (-0.1257349E-03)
+ number of electron     128.0000050 magnetization 
+ augmentation part       35.8986205 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.65458E-02    rms(broyden)= 0.65453E-02
+  rms(prec ) = 0.11547E-01
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   1.1831
+  2.5352  2.5352  1.3496  1.0029  0.4059  0.2440  0.2088
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =       650.40088722
+  Ewald energy   TEWEN  =     -4112.86760800
+  -Hartree energ DENC   =      -113.04838297
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =     -1172.38003502
+  PAW double counting   =      8425.51544607    -7136.80167154
+  entropy T*S    EENTRO =        -0.06636499
+  eigenvalues    EBANDS =       172.74718746
+  atomic energy  EATOM  =      3033.34488495
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -253.15565683 eV
+
+  energy without entropy =     -253.08929184  energy(sigma->0) =     -253.13353516
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  13)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0180: real time      0.0274
+    SETDIJ:  cpu time      0.0037: real time      0.0037
+     EDDAV:  cpu time      0.5394: real time      0.5394
+       DOS:  cpu time      0.0004: real time      0.0004
+    CHARGE:  cpu time      0.0195: real time      0.0195
+    MIXING:  cpu time      0.0006: real time      0.0006
+    --------------------------------------------
+      LOOP:  cpu time      0.5816: real time      0.5910
+
+ eigenvalue-minimisations  :   448
+ total energy-change (2. order) : 0.6793913E-04  (-0.4004597E-04)
+ number of electron     128.0000050 magnetization 
+ augmentation part       35.8978188 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.28863E-02    rms(broyden)= 0.28858E-02
+  rms(prec ) = 0.46306E-02
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   1.1325
+  2.5692  2.5692  1.3501  1.0315  0.8538  0.2502  0.2303  0.2059
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =       650.40088722
+  Ewald energy   TEWEN  =     -4112.86760800
+  -Hartree energ DENC   =      -113.06047321
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =     -1172.38028573
+  PAW double counting   =      8425.73083550    -7137.00514280
+  entropy T*S    EENTRO =        -0.06634487
+  eigenvalues    EBANDS =       172.74765805
+  atomic energy  EATOM  =      3033.34488495
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -253.15558889 eV
+
+  energy without entropy =     -253.08924402  energy(sigma->0) =     -253.13347393
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  14)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0179: real time      0.0265
+    SETDIJ:  cpu time      0.0037: real time      0.0037
+     EDDAV:  cpu time      0.5402: real time      0.5403
+       DOS:  cpu time      0.0004: real time      0.0004
+    CHARGE:  cpu time      0.0188: real time      0.0188
+    MIXING:  cpu time      0.0006: real time      0.0006
+    --------------------------------------------
+      LOOP:  cpu time      0.5815: real time      0.5903
+
+ eigenvalue-minimisations  :   448
+ total energy-change (2. order) : 0.6934884E-05  (-0.6289610E-05)
+ number of electron     128.0000050 magnetization 
+ augmentation part       35.8986090 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.19446E-02    rms(broyden)= 0.19445E-02
+  rms(prec ) = 0.33413E-02
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   1.0483
+  2.5865  2.5622  1.3504  1.0504  0.8825  0.3245  0.2516  0.2053  0.2218
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =       650.40088722
+  Ewald energy   TEWEN  =     -4112.86760800
+  -Hartree energ DENC   =      -113.05624006
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =     -1172.37865173
+  PAW double counting   =      8426.62603495    -7137.89530551
+  entropy T*S    EENTRO =        -0.06647951
+  eigenvalues    EBANDS =       172.73689572
+  atomic energy  EATOM  =      3033.34488495
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -253.15558195 eV
+
+  energy without entropy =     -253.08910245  energy(sigma->0) =     -253.13342212
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  15)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0177: real time      0.0264
+    SETDIJ:  cpu time      0.0036: real time      0.0036
+     EDDAV:  cpu time      0.5347: real time      0.5347
+       DOS:  cpu time      0.0005: real time      0.0005
+    CHARGE:  cpu time      0.0187: real time      0.0187
+    MIXING:  cpu time      0.0006: real time      0.0006
+    --------------------------------------------
+      LOOP:  cpu time      0.5757: real time      0.5844
+
+ eigenvalue-minimisations  :   448
+ total energy-change (2. order) : 0.5872651E-05  (-0.2200280E-05)
+ number of electron     128.0000050 magnetization 
+ augmentation part       35.8989244 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.63739E-03    rms(broyden)= 0.63729E-03
+  rms(prec ) = 0.83016E-03
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   1.1056
+  2.7084  2.4842  1.5831  1.3540  0.9962  0.9962  0.2687  0.2454  0.2162  0.2035
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =       650.40088722
+  Ewald energy   TEWEN  =     -4112.86760800
+  -Hartree energ DENC   =      -113.05430911
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =     -1172.37815436
+  PAW double counting   =      8426.87276426    -7138.14100727
+  entropy T*S    EENTRO =        -0.06653130
+  eigenvalues    EBANDS =       172.73349753
+  atomic energy  EATOM  =      3033.34488495
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -253.15557608 eV
+
+  energy without entropy =     -253.08904478  energy(sigma->0) =     -253.13339898
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  16)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0182: real time      0.0263
+    SETDIJ:  cpu time      0.0038: real time      0.0038
+     EDDAV:  cpu time      0.5330: real time      0.5331
+       DOS:  cpu time      0.0004: real time      0.0004
+    CHARGE:  cpu time      0.0194: real time      0.0194
+    MIXING:  cpu time      0.0006: real time      0.0006
+    --------------------------------------------
+      LOOP:  cpu time      0.5754: real time      0.5835
+
+ eigenvalue-minimisations  :   448
+ total energy-change (2. order) :-0.1614097E-05  (-0.5408341E-06)
+ number of electron     128.0000050 magnetization 
+ augmentation part       35.8993284 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.77158E-03    rms(broyden)= 0.77155E-03
+  rms(prec ) = 0.14379E-02
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   1.0538
+  2.7487  2.4604  1.8624  1.3531  0.9941  0.9941  0.2712  0.2446  0.2446  0.2049
+  0.2134
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =       650.40088722
+  Ewald energy   TEWEN  =     -4112.86760800
+  -Hartree energ DENC   =      -113.05188670
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =     -1172.37750763
+  PAW double counting   =      8427.18402000    -7138.45063966
+  entropy T*S    EENTRO =        -0.06663667
+  eigenvalues    EBANDS =       172.72890880
+  atomic energy  EATOM  =      3033.34488495
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -253.15557770 eV
+
+  energy without entropy =     -253.08894102  energy(sigma->0) =     -253.13336547
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  17)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0170: real time      0.0250
+    SETDIJ:  cpu time      0.0037: real time      0.0037
+     EDDAV:  cpu time      0.5345: real time      0.5346
+       DOS:  cpu time      0.0004: real time      0.0004
+    --------------------------------------------
+      LOOP:  cpu time      0.5557: real time      0.5638
+
+ eigenvalue-minimisations  :   448
+ total energy-change (2. order) : 0.3548857E-06  (-0.3151407E-06)
+ number of electron     128.0000050 magnetization 
+ augmentation part       35.8993284 magnetization 
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =       650.40088722
+  Ewald energy   TEWEN  =     -4112.86760800
+  -Hartree energ DENC   =      -113.05115957
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =     -1172.37727028
+  PAW double counting   =      8427.30098750    -7138.56695667
+  entropy T*S    EENTRO =        -0.06668343
+  eigenvalues    EBANDS =       172.72734094
+  atomic energy  EATOM  =      3033.34488495
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -253.15557734 eV
+
+  energy without entropy =     -253.08889391  energy(sigma->0) =     -253.13334953
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+ average (electrostatic) potential at core
+  the test charge radii are     1.2598
+  (the norm of the test charge is              1.0000)
+       1 -26.5880       2 -26.5879       3 -26.5879       4 -26.5880       5 -26.5879
+       6 -26.5879       7 -26.5878       8 -26.5879       9 -26.5880      10 -26.5879
+      11 -26.5880      12 -26.5880      13 -26.5879      14 -26.5879      15 -26.5879
+      16 -26.5879      17 -26.5879      18 -26.5879      19 -26.5879      20 -26.5879
+      21 -26.5879      22 -26.5879      23 -26.5879      24 -26.5879      25 -26.5879
+      26 -26.5879      27 -26.5879      28 -26.5879      29 -26.5879      30 -26.5879
+      31 -26.5879      32 -26.5879
+ 
+ 
+ 
+ E-fermi :   3.0794     XC(G=0): -11.0659     alpha+bet :-10.9574
+
+ Fermi energy:         3.0794282996
+
+ k-point     1 :       0.0000    0.0000    0.0000
+  band No.  band energies     occupation 
+      1      -3.0477      2.00000
+      2      -1.4549      2.00000
+      3      -1.4549      2.00000
+      4      -1.1939      2.00000
+      5      -1.1938      2.00000
+      6      -0.0183      2.00000
+      7      -0.0183      2.00000
+      8      -0.0183      2.00000
+      9      -0.0183      2.00000
+     10       0.4343      2.00000
+     11       0.5637      2.00000
+     12       0.5637      2.00000
+     13       0.5638      2.00000
+     14       0.5638      2.00000
+     15       0.5699      2.00000
+     16       0.5699      2.00000
+     17       0.7753      2.00000
+     18       0.7754      2.00000
+     19       0.7758      2.00000
+     20       0.8088      2.00000
+     21       0.8088      2.00000
+     22       0.9223      2.00000
+     23       0.9508      2.00000
+     24       0.9508      2.00000
+     25       1.1226      2.00000
+     26       1.1226      2.00000
+     27       1.1227      2.00000
+     28       1.1227      2.00000
+     29       1.2368      2.00000
+     30       1.2369      2.00000
+     31       1.2583      2.00000
+     32       1.3401      2.00000
+     33       1.3401      2.00000
+     34       1.4639      2.00000
+     35       1.4639      2.00000
+     36       1.7961      2.00000
+     37       1.7962      2.00000
+     38       1.8791      2.00000
+     39       1.8791      2.00000
+     40       2.1754      2.00000
+     41       2.1754      2.00000
+     42       2.2630      2.00000
+     43       2.2631      2.00000
+     44       2.2770      2.00000
+     45       2.2770      2.00000
+     46       2.2770      2.00000
+     47       2.2771      2.00000
+     48       2.4588      2.00010
+     49       2.4589      2.00010
+     50       2.4785      2.00018
+     51       2.5265      2.00065
+     52       2.5265      2.00066
+     53       2.5266      2.00066
+     54       2.5266      2.00066
+     55       2.5583      2.00143
+     56       2.5583      2.00143
+     57       2.5584      2.00143
+     58       2.5584      2.00143
+     59       2.6769      2.01536
+     60       2.6770      2.01536
+     61       2.9675      1.80240
+     62       2.9675      1.80234
+     63       2.9675      1.80205
+     64       2.9675      1.80202
+     65       3.1634      0.35376
+     66       3.1636      0.35297
+     67       3.2269      0.05539
+     68       3.2270      0.05533
+     69       3.4958     -0.01217
+     70       3.4958     -0.01217
+     71       3.4958     -0.01217
+     72       3.4958     -0.01216
+     73       3.5224     -0.00752
+     74       3.5485     -0.00449
+     75       3.5485     -0.00449
+     76       3.6894     -0.00014
+     77       3.6896     -0.00014
+     78       3.7061     -0.00009
+     79       3.7406     -0.00003
+     80       3.7406     -0.00003
+     81       3.7480     -0.00002
+     82       3.7480     -0.00002
+     83       3.7533     -0.00002
+     84       3.7533     -0.00002
+     85       3.7821     -0.00001
+     86       3.7822     -0.00001
+     87       3.8298     -0.00000
+     88       3.8411     -0.00000
+     89       3.8414     -0.00000
+     90       3.9519     -0.00000
+     91       4.0067     -0.00000
+     92       4.0067     -0.00000
+     93       4.1310     -0.00000
+     94       4.1311     -0.00000
+     95       4.2168     -0.00000
+     96       4.2169     -0.00000
+     97       4.2183     -0.00000
+     98       4.2428     -0.00000
+     99       4.2429     -0.00000
+    100       4.3343     -0.00000
+    101       4.3366     -0.00000
+    102       4.3767     -0.00000
+    103       4.3767     -0.00000
+    104       4.3767     -0.00000
+    105       4.3767     -0.00000
+    106       4.3883     -0.00000
+    107       4.3883     -0.00000
+    108       4.4613     -0.00000
+    109       4.4613     -0.00000
+    110       4.4613     -0.00000
+    111       4.4613     -0.00000
+    112       4.6185     -0.00000
+    113       4.6185     -0.00000
+    114       4.6186     -0.00000
+    115       4.6186     -0.00000
+    116       4.6541     -0.00000
+    117       4.6962     -0.00000
+    118       4.7643     -0.00000
+    119       4.7644     -0.00000
+    120       4.7933     -0.00000
+    121       4.7933     -0.00000
+    122       4.7934     -0.00000
+    123       4.7934     -0.00000
+    124       4.9636     -0.00000
+    125       4.9636     -0.00000
+    126       5.0516     -0.00000
+    127       5.0517     -0.00000
+    128       5.3066     -0.00000
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+ soft charge-density along one line, spin component           1
+         0         1         2         3         4         5         6         7         8         9
+ total charge-density along one line
+ 
+ pseudopotential strength for first ion, spin component:           1
+ -3.640   0.000   0.000   0.000   0.000  -3.641   0.000   0.000
+  0.000  -3.656  -0.000  -0.000  -0.000   0.000  -3.659  -0.000
+  0.000  -0.000  -3.673  -0.000   0.014   0.000  -0.000  -3.679
+  0.000  -0.000  -0.000  -3.683   0.000   0.000  -0.000  -0.000
+  0.000  -0.000   0.014   0.000  -3.640   0.000  -0.000   0.016
+ -3.641   0.000   0.000   0.000   0.000  -3.519   0.000   0.000
+  0.000  -3.659  -0.000  -0.000  -0.000   0.000  -3.540  -0.000
+  0.000  -0.000  -3.679  -0.000   0.016   0.000  -0.000  -3.562
+  0.000  -0.000  -0.000  -3.691   0.000   0.000  -0.000  -0.000
+  0.000  -0.000   0.016   0.000  -3.640   0.000  -0.000   0.019
+  0.000  -0.000   0.004  -0.000   0.004   0.000  -0.000   0.004
+ -0.000   0.000  -0.006   0.000  -0.008  -0.000   0.000  -0.007
+ -0.000   0.000  -0.001  -0.000  -0.001  -0.000   0.000  -0.001
+ -0.000   0.001   0.000  -0.000  -0.000  -0.000   0.001   0.000
+  0.002  -0.000   0.000   0.000  -0.000   0.002  -0.000   0.000
+ total augmentation occupancy for first ion, spin component:           1
+  3.029   0.000   0.000  -0.000   0.000  -1.553   0.000  -0.000   0.000  -0.000  -0.000  -0.000  -0.000  -0.000   0.131
+  0.000   2.615  -0.000  -0.000  -0.000  -0.000  -1.345   0.000   0.000  -0.000  -0.000  -0.000   0.000  -0.046  -0.000
+  0.000  -0.000   3.102   0.000  -0.244  -0.000   0.000  -1.516  -0.000   0.163  -0.003  -0.007  -0.048   0.000   0.000
+ -0.000  -0.000   0.000   2.647   0.000   0.000  -0.000  -0.000  -1.434  -0.000   0.000   0.000  -0.000  -0.000   0.000
+  0.000  -0.000  -0.244   0.000   3.100  -0.000  -0.000   0.164  -0.000  -1.611   0.129   0.007   0.155  -0.000   0.000
+ -1.553  -0.000  -0.000   0.000  -0.000   0.811  -0.000   0.000  -0.000  -0.000   0.000   0.000   0.000   0.000  -0.048
+  0.000  -1.345   0.000  -0.000  -0.000  -0.000   0.711  -0.000   0.000   0.000   0.000   0.000  -0.000   0.017   0.000
+ -0.000   0.000  -1.516  -0.000   0.164   0.000  -0.000   0.769   0.000  -0.100   0.020   0.004   0.017  -0.000  -0.000
+  0.000   0.000  -0.000  -1.434  -0.000  -0.000   0.000   0.000   0.782   0.000  -0.000  -0.000   0.000   0.000  -0.000
+ -0.000  -0.000   0.163  -0.000  -1.611  -0.000   0.000  -0.100   0.000   0.860  -0.103  -0.005  -0.061   0.000  -0.000
+ -0.000  -0.000  -0.003   0.000   0.129   0.000   0.000   0.020  -0.000  -0.103   1.970   0.055  -0.013   0.000  -0.000
+ -0.000  -0.000  -0.007   0.000   0.007   0.000   0.000   0.004  -0.000  -0.005   0.055   0.002   0.000   0.000   0.000
+ -0.000   0.000  -0.048  -0.000   0.155   0.000  -0.000   0.017   0.000  -0.061  -0.013   0.000   0.335   0.000  -0.000
+ -0.000  -0.046   0.000  -0.000  -0.000   0.000   0.017  -0.000   0.000   0.000   0.000   0.000   0.000   0.244  -0.000
+  0.131  -0.000   0.000   0.000   0.000  -0.048   0.000  -0.000  -0.000  -0.000  -0.000   0.000  -0.000  -0.000   0.326
+
+
+------------------------ aborting loop because EDIFF is reached ----------------------------------------
+
+
+    CHARGE:  cpu time      0.0190: real time      0.0190
+    FORLOC:  cpu time      0.0017: real time      0.0018
+    FORNL :  cpu time      0.1494: real time      0.1497
+    STRESS:  cpu time      0.4346: real time      0.4350
+    FORCOR:  cpu time      0.0154: real time      0.0154
+    FORHAR:  cpu time      0.0046: real time      0.0046
+    MIXING:  cpu time      0.0006: real time      0.0006
+    OFIELD:  cpu time      0.0005: real time      0.0005
+
+  FORCE on cell =-STRESS in cart. coord.  units (eV):
+  Direction    XX          YY          ZZ          XY          YZ          ZX
+  --------------------------------------------------------------------------------------
+  Alpha Z   650.40089   650.40089   650.40089
+  Ewald   -1388.92193 -1388.52872 -1335.43393    -0.00751    -0.00000    -0.00000
+  Hartree    34.93690    37.81406    40.30239    -0.00118     0.00009     0.00001
+  E(xc)    -484.72534  -488.09957  -486.51705     0.00041    -0.00008    -0.00001
+  Local     270.99751   261.22480   242.21657     0.00728    -0.00044    -0.00003
+  n-local  -124.94146  -110.82685  -109.53190    -0.00258    -0.00071    -0.00074
+  augment   190.70000   197.30895   191.44223     0.00014     0.00021    -0.00003
+  Kinetic   798.32074   841.78165   806.10072     0.00100     0.00040     0.00005
+  Fock        0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+  -------------------------------------------------------------------------------------
+  Total     -53.23269     1.07521    -1.02010    -0.00244    -0.00054    -0.00075
+  in kB    -153.71054     3.10470    -2.94556    -0.00704    -0.00157    -0.00217
+  external pressure =      -51.18 kB  Pullay stress =        0.00 kB
+
+  kinetic pressure (ideal gas correction) =      3.86 kB
+  total pressure  =    -47.33 kB
+  Total+kin.  -150.778       6.702       2.096      -0.376       0.642      -0.610
+
+ VOLUME and BASIS-vectors are now :
+ -----------------------------------------------------------------------------
+  energy-cutoff  :      350.00
+  volume of cell :      554.86
+      direct lattice vectors                 reciprocal lattice vectors
+     5.871982203  0.000000000  0.000000000     0.170300244  0.000000000  0.000000000
+     0.000000000 10.165611494  0.000000000     0.000000000  0.098370865  0.000000000
+     0.000000000  0.000000000  9.295380000     0.000000000  0.000000000  0.107580325
+
+  length of vectors
+     5.871982203 10.165611494  9.295380000     0.170300244  0.098370865  0.107580325
+
+
+ FORCES acting on ions
+    electron-ion (+dipol)            ewald-force                    non-local-force                 convergence-correction
+ -----------------------------------------------------------------------------------------------
+   0.150E-03 -.248E+00 0.267E-02   0.355E-03 0.320E-02 -.153E-02   -.154E-04 0.445E+00 0.368E-04   -.364E-03 -.990E-04 -.117E-02
+   0.720E-03 0.249E+00 -.304E-02   -.265E-03 -.353E-02 0.148E-02   -.270E-04 -.446E+00 -.882E-04   -.506E-03 -.297E-03 0.153E-02
+   -.270E-03 0.248E+00 -.284E-02   -.117E-03 -.244E-02 0.142E-02   0.449E-04 -.446E+00 -.939E-04   0.279E-03 -.214E-03 0.141E-02
+   -.286E-03 -.248E+00 0.214E-02   0.276E-04 0.278E-02 -.137E-02   -.722E-04 0.445E+00 0.286E-04   0.246E-03 -.202E-03 -.826E-03
+   -.118E-03 -.248E+00 0.132E-03   0.355E-03 0.320E-02 -.153E-02   -.479E-04 0.445E+00 0.939E-04   -.110E-03 0.833E-05 0.118E-02
+   0.753E-03 0.249E+00 0.303E-03   -.265E-03 -.353E-02 0.148E-02   -.250E-04 -.446E+00 -.174E-03   -.534E-03 -.248E-03 -.154E-02
+   -.110E-03 0.248E+00 0.188E-03   -.117E-03 -.244E-02 0.142E-02   0.504E-04 -.446E+00 -.157E-03   0.133E-03 -.338E-03 -.141E-02
+   0.854E-04 -.248E+00 0.378E-03   0.276E-04 0.278E-02 -.137E-02   -.571E-04 0.446E+00 0.104E-03   -.806E-04 -.325E-03 0.845E-03
+   0.504E-03 -.248E+00 0.258E-02   0.355E-03 0.320E-02 -.153E-02   -.276E-06 0.445E+00 0.369E-04   -.653E-03 0.594E-04 -.109E-02
+   0.469E-03 0.249E+00 -.293E-02   -.265E-03 -.353E-02 0.148E-02   -.166E-04 -.446E+00 -.935E-04   -.303E-03 0.719E-04 0.144E-02
+   -.193E-03 0.248E+00 -.264E-02   -.117E-03 -.244E-02 0.142E-02   0.652E-04 -.446E+00 -.832E-04   0.210E-03 -.369E-04 0.122E-02
+   -.411E-03 -.248E+00 0.234E-02   0.276E-04 0.278E-02 -.137E-02   -.878E-04 0.445E+00 0.478E-04   0.367E-03 0.140E-03 -.101E-02
+   0.248E-03 -.248E+00 0.215E-03   0.355E-03 0.320E-02 -.153E-02   -.217E-04 0.445E+00 0.111E-03   -.425E-03 0.448E-05 0.110E-02
+   0.521E-03 0.249E+00 0.168E-03   -.265E-03 -.353E-02 0.148E-02   -.207E-04 -.446E+00 -.156E-03   -.345E-03 0.765E-04 -.143E-02
+   -.634E-04 0.248E+00 -.291E-04   -.117E-03 -.244E-02 0.142E-02   0.614E-04 -.446E+00 -.150E-03   0.913E-04 0.532E-04 -.122E-02
+   -.470E-04 -.248E+00 0.201E-03   0.276E-04 0.278E-02 -.137E-02   -.811E-04 0.445E+00 0.783E-04   0.437E-04 0.256E-03 0.100E-02
+   -.613E-03 -.248E+00 0.251E-02   0.355E-03 0.320E-02 -.153E-02   0.626E-05 0.445E+00 0.324E-04   0.354E-03 -.753E-04 -.102E-02
+   -.479E-03 0.249E+00 -.262E-02   -.265E-03 -.353E-02 0.148E-02   0.544E-05 -.446E+00 -.889E-04   0.526E-03 -.144E-03 0.118E-02
+   0.377E-03 0.247E+00 -.259E-02   -.117E-03 -.244E-02 0.142E-02   0.533E-04 -.446E+00 -.786E-04   -.279E-03 0.171E-03 0.120E-02
+   0.291E-03 -.248E+00 0.222E-02   0.276E-04 0.278E-02 -.137E-02   -.874E-04 0.445E+00 0.313E-04   -.267E-03 0.114E-04 -.892E-03
+   -.342E-03 -.248E+00 0.302E-03   0.355E-03 0.320E-02 -.153E-02   0.236E-04 0.445E+00 0.886E-04   0.909E-04 0.141E-04 0.102E-02
+   -.507E-03 0.249E+00 -.105E-03   -.265E-03 -.353E-02 0.148E-02   0.320E-05 -.446E+00 -.184E-03   0.544E-03 -.103E-03 -.119E-02
+   0.212E-03 0.247E+00 -.656E-04   -.117E-03 -.244E-02 0.142E-02   0.456E-04 -.446E+00 -.159E-03   -.125E-03 0.286E-04 -.120E-02
+   -.893E-04 -.248E+00 0.313E-03   0.276E-04 0.278E-02 -.137E-02   -.107E-03 0.445E+00 0.902E-04   0.788E-04 -.110E-03 0.898E-03
+   -.979E-03 -.248E+00 0.252E-02   0.355E-03 0.320E-02 -.153E-02   -.174E-04 0.445E+00 0.295E-04   0.669E-03 0.198E-03 -.104E-02
+   -.213E-03 0.248E+00 -.276E-02   -.265E-03 -.353E-02 0.148E-02   0.521E-06 -.446E+00 -.941E-04   0.296E-03 0.299E-03 0.128E-02
+   0.298E-03 0.247E+00 -.245E-02   -.117E-03 -.244E-02 0.142E-02   0.364E-04 -.446E+00 -.800E-04   -.208E-03 0.930E-04 0.106E-02
+   0.410E-03 -.248E+00 0.234E-02   0.276E-04 0.278E-02 -.137E-02   -.782E-04 0.445E+00 0.472E-04   -.373E-03 0.249E-05 -.101E-02
+   -.711E-03 -.248E+00 0.280E-03   0.355E-03 0.320E-02 -.153E-02   0.284E-05 0.445E+00 0.808E-04   0.418E-03 0.161E-03 0.105E-02
+   -.268E-03 0.248E+00 0.422E-05   -.265E-03 -.353E-02 0.148E-02   0.354E-05 -.446E+00 -.161E-03   0.345E-03 0.260E-03 -.128E-02
+   0.178E-03 0.247E+00 -.199E-03   -.117E-03 -.244E-02 0.142E-02   0.330E-04 -.446E+00 -.157E-03   -.989E-04 0.190E-03 -.107E-02
+   0.338E-04 -.248E+00 0.215E-03   0.276E-04 0.278E-02 -.137E-02   -.850E-04 0.445E+00 0.785E-04   -.332E-04 0.100E-03 0.993E-03
+ -----------------------------------------------------------------------------------------------
+   -.449E-03 0.243E-03 -.242E-03   -.597E-13 0.476E-13 -.575E-13   -.412E-03 -.183E-02 -.983E-03   -.119E-04 0.621E-05 0.718E-05
+ 
+ 
+ POSITION                                       TOTAL-FORCE (eV/Angst)
+ -----------------------------------------------------------------------------------
+      0.24853      0.52100      1.15280         0.000126      0.200365      0.000010
+      0.24861      3.90902      3.47662        -0.000078     -0.200465     -0.000124
+      1.71657      1.36761      3.47662        -0.000063     -0.200357     -0.000101
+      1.71656      3.06241      1.15279        -0.000085      0.200390     -0.000029
+      0.24853      0.52100      5.80049         0.000079      0.200367     -0.000129
+      0.24861      3.90902      8.12431        -0.000071     -0.200462      0.000072
+      1.71657      1.36761      8.12431        -0.000043     -0.200342      0.000043
+      1.71656      3.06241      5.80048        -0.000025      0.200427     -0.000042
+      0.24853      5.60381      1.15280         0.000205      0.200367     -0.000002
+      0.24861      8.99183      3.47662        -0.000115     -0.200486     -0.000101
+      1.71657      6.45042      3.47662        -0.000035     -0.200370     -0.000074
+      1.71656      8.14521      1.15279        -0.000104      0.200350      0.000009
+      0.24853      5.60381      5.80049         0.000156      0.200357     -0.000104
+      0.24861      8.99183      8.12431        -0.000110     -0.200477      0.000060
+      1.71657      6.45042      8.12431        -0.000028     -0.200412      0.000021
+      1.71656      8.14521      5.80048        -0.000057      0.200351     -0.000085
+      3.18452      0.52100      1.15280         0.000102      0.200351     -0.000015
+      3.18460      3.90902      3.47662        -0.000213     -0.200511     -0.000054
+      4.65256      1.36761      3.47662         0.000034     -0.200482     -0.000055
+      4.65255      3.06241      1.15279        -0.000036      0.200326     -0.000012
+      3.18452      0.52100      5.80049         0.000127      0.200352     -0.000116
+      3.18460      3.90902      8.12431        -0.000225     -0.200506     -0.000003
+      4.65256      1.36761      8.12431         0.000016     -0.200460     -0.000004
+      4.65255      3.06241      5.80048        -0.000090      0.200344     -0.000067
+      3.18452      5.60381      1.15280         0.000027      0.200324     -0.000018
+      3.18460      8.99183      3.47662        -0.000182     -0.200558     -0.000094
+      4.65256      6.45042      3.47662         0.000010     -0.200427     -0.000050
+      4.65255      8.14521      1.15279        -0.000013      0.200385      0.000008
+      3.18452      5.60381      5.80049         0.000065      0.200312     -0.000118
+      3.18460      8.99183      8.12431        -0.000184     -0.200548      0.000042
+      4.65256      6.45042      8.12431        -0.000005     -0.200456     -0.000007
+      4.65255      8.14521      5.80048        -0.000057      0.200372     -0.000082
+ -----------------------------------------------------------------------------------
+    total drift:                               -0.000874     -0.001580     -0.001218
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+  FREE ENERGIE OF THE ION-ELECTRON SYSTEM (eV)
+  ---------------------------------------------------
+  free  energy   TOTEN  =      -253.15557734 eV
+
+  energy  without entropy=     -253.08889391  energy(sigma->0) =     -253.13334953
+ 
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+    POTLOK:  cpu time      0.0210: real time      0.0210
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+           RANDOM_SEED =         223274761                0                0
+           RANDOM_SEED =         223274761                0                0
+   IONSTEP:  cpu time      0.0018: real time      0.0040
+
+  ENERGY OF THE ELECTRON-ION-THERMOSTAT SYSTEM (eV)
+  ---------------------------------------------------
+% ion-electron   TOTEN  =      -253.155577  see above
+  kinetic energy EKIN   =         2.000725
+  kin. lattice  EKIN_LAT=         0.000000  (temperature  499.30 K)
+  nose potential ES     =         0.000000
+  nose kinetic   EPS    =         0.000000
+  ---------------------------------------------------
+  total energy   ETOTAL =      -251.154852 eV
+
+  maximum distance moved by ions :      0.23E-02
+
+    WAVPRE:  cpu time      0.0077: real time      0.0114
+    FEWALD:  cpu time      0.0005: real time      0.0005
+    ORTHCH:  cpu time      0.0260: real time      0.0260
+     LOOP+:  cpu time      8.9493: real time      9.2371
+
+
+--------------------------------------- Iteration      2(   1)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0167: real time      0.0167
+    SETDIJ:  cpu time      0.0038: real time      0.0038
+     EDDAV:  cpu time      0.2724: real time      0.2725
+       DOS:  cpu time      0.0004: real time      0.0004
+    CHARGE:  cpu time      0.0185: real time      0.0185
+    MIXING:  cpu time      0.0004: real time      0.0004
+    --------------------------------------------
+      LOOP:  cpu time      0.3121: real time      0.3123
+
+ eigenvalue-minimisations  :   256
+ total energy-change (2. order) : 0.1016114E-01  (-0.2338706E+00)
+ number of electron     128.0000045 magnetization 
+ augmentation part       35.8997084 magnetization 
+
+  free energy =  -0.253145416557E+03  energy without entropy=  -0.253081790277E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      2(   2)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0201: real time      0.0282
+    SETDIJ:  cpu time      0.0037: real time      0.0037
+     EDDAV:  cpu time      0.5415: real time      0.5418
+       DOS:  cpu time      0.0004: real time      0.0004
+    CHARGE:  cpu time      0.0192: real time      0.0192
+    MIXING:  cpu time      0.0004: real time      0.0004
+    --------------------------------------------
+      LOOP:  cpu time      0.5853: real time      0.5937
+
+ eigenvalue-minimisations  :   448
+ total energy-change (2. order) :-0.2227059E-01  (-0.1211453E-01)
+ number of electron     128.0000045 magnetization 
+ augmentation part       35.9039663 magnetization 
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.2323
+  0.2323
+
+  free energy =  -0.253167687152E+03  energy without entropy=  -0.253103800611E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      2(   3)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0179: real time      0.0270
+    SETDIJ:  cpu time      0.0037: real time      0.0037
+     EDDAV:  cpu time      0.5359: real time      0.5359
+       DOS:  cpu time      0.0004: real time      0.0004
+    CHARGE:  cpu time      0.0191: real time      0.0191
+    MIXING:  cpu time      0.0004: real time      0.0004
+    --------------------------------------------
+      LOOP:  cpu time      0.5774: real time      0.5866
+
+ eigenvalue-minimisations  :   448
+ total energy-change (2. order) : 0.2682024E-01  (-0.6719093E-02)
+ number of electron     128.0000045 magnetization 
+ augmentation part       35.9001974 magnetization 
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.6874
+  1.1471  0.2278
+
+  free energy =  -0.253140866914E+03  energy without entropy=  -0.253077069498E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      2(   4)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0250: real time      0.0272
+    SETDIJ:  cpu time      0.0037: real time      0.0037
+     EDDAV:  cpu time      0.3491: real time      0.3492
+       DOS:  cpu time      0.0004: real time      0.0004
+    CHARGE:  cpu time      0.0184: real time      0.0184
+    MIXING:  cpu time      0.0004: real time      0.0004
+    --------------------------------------------
+      LOOP:  cpu time      0.3971: real time      0.3993
+
+ eigenvalue-minimisations  :   320
+ total energy-change (2. order) :-0.9381133E-04  (-0.8309771E-03)
+ number of electron     128.0000045 magnetization 
+ augmentation part       35.9002892 magnetization 
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.9644
+  2.4307  0.2578  0.2046
+
+  free energy =  -0.253140960725E+03  energy without entropy=  -0.253077141461E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      2(   5)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0280: real time      0.0283
+    SETDIJ:  cpu time      0.0037: real time      0.0037
+     EDDAV:  cpu time      0.5364: real time      0.5365
+       DOS:  cpu time      0.0004: real time      0.0004
+    CHARGE:  cpu time      0.0193: real time      0.0193
+    MIXING:  cpu time      0.0005: real time      0.0005
+    --------------------------------------------
+      LOOP:  cpu time      0.5884: real time      0.5887
+
+ eigenvalue-minimisations  :   448
+ total energy-change (2. order) : 0.1838231E-02  (-0.3690510E-03)
+ number of electron     128.0000045 magnetization 
+ augmentation part       35.8997212 magnetization 
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.9307
+  2.4773  0.7952  0.2477  0.2025
+
+  free energy =  -0.253139122494E+03  energy without entropy=  -0.253075343349E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      2(   6)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0198: real time      0.0266
+    SETDIJ:  cpu time      0.0036: real time      0.0036
+     EDDAV:  cpu time      0.5325: real time      0.5325
+       DOS:  cpu time      0.0004: real time      0.0004
+    CHARGE:  cpu time      0.0190: real time      0.0190
+    MIXING:  cpu time      0.0005: real time      0.0005
+    --------------------------------------------
+      LOOP:  cpu time      0.5758: real time      0.5827
+
+ eigenvalue-minimisations  :   448
+ total energy-change (2. order) :-0.6951669E-04  (-0.7724969E-04)
+ number of electron     128.0000045 magnetization 
+ augmentation part       35.8998837 magnetization 
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.8051
+  2.4771  0.8553  0.2027  0.2585  0.2321
+
+  free energy =  -0.253139192010E+03  energy without entropy=  -0.253075416092E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      2(   7)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0259: real time      0.0266
+    SETDIJ:  cpu time      0.0037: real time      0.0037
+     EDDAV:  cpu time      0.3465: real time      0.3466
+       DOS:  cpu time      0.0005: real time      0.0005
+    CHARGE:  cpu time      0.0186: real time      0.0186
+    MIXING:  cpu time      0.0005: real time      0.0005
+    --------------------------------------------
+      LOOP:  cpu time      0.3957: real time      0.3964
+
+ eigenvalue-minimisations  :   320
+ total energy-change (2. order) : 0.1069777E-03  (-0.3511133E-04)
+ number of electron     128.0000045 magnetization 
+ augmentation part       35.8999163 magnetization 
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.8225
+  2.5004  0.8817  0.8817  0.2471  0.2018  0.2222
+
+  free energy =  -0.253139085033E+03  energy without entropy=  -0.253075299782E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      2(   8)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0250: real time      0.0270
+    SETDIJ:  cpu time      0.0037: real time      0.0037
+     EDDAV:  cpu time      0.5584: real time      0.5586
+       DOS:  cpu time      0.0004: real time      0.0004
+    CHARGE:  cpu time      0.0189: real time      0.0189
+    MIXING:  cpu time      0.0005: real time      0.0005
+    --------------------------------------------
+      LOOP:  cpu time      0.6068: real time      0.6090
+
+ eigenvalue-minimisations  :   448
+ total energy-change (2. order) : 0.3244186E-06  (-0.5755851E-05)
+ number of electron     128.0000045 magnetization 
+ augmentation part       35.8999807 magnetization 
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.8898
+  2.6092  1.6026  1.0924  0.2666  0.2473  0.2011  0.2093
+
+  free energy =  -0.253139084708E+03  energy without entropy=  -0.253075294156E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      2(   9)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0271: real time      0.0276
+    SETDIJ:  cpu time      0.0037: real time      0.0037
+     EDDAV:  cpu time      0.5357: real time      0.5358
+       DOS:  cpu time      0.0005: real time      0.0005
+    CHARGE:  cpu time      0.0188: real time      0.0188
+    MIXING:  cpu time      0.0005: real time      0.0005
+    --------------------------------------------
+      LOOP:  cpu time      0.5864: real time      0.5870
+
+ eigenvalue-minimisations  :   448
+ total energy-change (2. order) : 0.5879174E-05  (-0.2412503E-05)
+ number of electron     128.0000045 magnetization 
+ augmentation part       35.9000281 magnetization 
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.8440
+  2.6379  1.6913  1.0908  0.4158  0.2604  0.2473  0.2020  0.2068
+
+  free energy =  -0.253139078829E+03  energy without entropy=  -0.253075291677E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      2(  10)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0265: real time      0.0276
+    SETDIJ:  cpu time      0.0037: real time      0.0037
+     EDDAV:  cpu time      0.3542: real time      0.3544
+       DOS:  cpu time      0.0004: real time      0.0004
+    CHARGE:  cpu time      0.0191: real time      0.0191
+    MIXING:  cpu time      0.0006: real time      0.0005
+    --------------------------------------------
+      LOOP:  cpu time      0.4045: real time      0.4057
+
+ eigenvalue-minimisations  :   320
+ total energy-change (2. order) : 0.1041426E-05  (-0.7122883E-06)
+ number of electron     128.0000045 magnetization 
+ augmentation part       35.9000419 magnetization 
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.8505
+  2.6687  1.7550  1.1879  0.8795  0.2750  0.2481  0.2325  0.2004  0.2070
+
+  free energy =  -0.253139077788E+03  energy without entropy=  -0.253075290926E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      2(  11)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0264: real time      0.0268
+    SETDIJ:  cpu time      0.0037: real time      0.0037
+     EDDAV:  cpu time      0.4103: real time      0.4105
+       DOS:  cpu time      0.0004: real time      0.0004
+    --------------------------------------------
+      LOOP:  cpu time      0.4407: real time      0.4414
+
+ eigenvalue-minimisations  :   320
+ total energy-change (2. order) : 0.9402720E-07  (-0.9271887E-07)
+ number of electron     128.0000045 magnetization 
+ augmentation part       35.9000419 magnetization 
+
+  free energy =  -0.253139077694E+03  energy without entropy=  -0.253075291169E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+------------------------ aborting loop because EDIFF is reached ----------------------------------------
+
+
+    CHARGE:  cpu time      0.0195: real time      0.0195
+    FORLOC:  cpu time      0.0015: real time      0.0015
+    FORNL :  cpu time      0.1489: real time      0.1489
+    STRESS:  cpu time      0.4346: real time      0.4346
+    FORCOR:  cpu time      0.0143: real time      0.0143
+    FORHAR:  cpu time      0.0044: real time      0.0044
+    MIXING:  cpu time      0.0005: real time      0.0005
+    OFIELD:  cpu time      0.0000: real time      0.0000
+
+  FORCE on cell =-STRESS in cart. coord.  units (eV):
+  Direction    XX          YY          ZZ          XY          YZ          ZX
+  --------------------------------------------------------------------------------------
+  Alpha Z   650.40089   650.40089   650.40089
+  Ewald   -1389.12131 -1388.25992 -1335.41242    -0.08216     0.00223     0.02595
+  Hartree    34.93496    37.86303    40.32860    -0.01383    -0.00253     0.00806
+  E(xc)    -484.71462  -488.11651  -486.53890     0.00413    -0.00010    -0.00055
+  Local     271.18315   261.00301   242.13794     0.07931     0.00372    -0.02957
+  n-local  -124.91295  -110.79660  -109.53828    -0.00971     0.00066     0.00108
+  augment   190.69016   197.29836   191.45645     0.00158    -0.00071    -0.00047
+  Kinetic   798.35592   841.72049   806.17298     0.00941    -0.00292    -0.00151
+  Fock        0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+  -------------------------------------------------------------------------------------
+  Total     -53.18380     1.11275    -0.99275    -0.01128     0.00033     0.00300
+  in kB    -153.56937     3.21310    -2.86658    -0.03258     0.00097     0.00866
+  external pressure =      -51.07 kB  Pullay stress =        0.00 kB
+
+  kinetic pressure (ideal gas correction) =      3.85 kB
+  total pressure  =    -47.23 kB
+  Total+kin.  -150.637       6.779       2.175      -0.405       0.644      -0.599
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+  FREE ENERGIE OF THE ION-ELECTRON SYSTEM (eV)
+  ---------------------------------------------------
+  free  energy   TOTEN  =      -253.13907769 eV
+
+  energy  without entropy=     -253.07529117  energy(sigma->0) =     -253.11781552
+ 
+ d Force =-0.1650296E-01[-0.281E-01,-0.486E-02]  d Energy =-0.1649965E-01-0.332E-05
+ d Force =-0.9086989E-01[-0.182E+00,-0.910E-04]  d Ewald  =-0.9088764E-01 0.178E-04
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+    POTLOK:  cpu time      0.0202: real time      0.0202
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+           RANDOM_SEED =         223274761                0                0
+   IONSTEP:  cpu time      0.0005: real time      0.0005
+
+  ENERGY OF THE ELECTRON-ION-THERMOSTAT SYSTEM (eV)
+  ---------------------------------------------------
+% ion-electron   TOTEN  =      -253.139078  see above
+  kinetic energy EKIN   =         1.984246
+  kin. lattice  EKIN_LAT=         0.000000  (temperature  495.18 K)
+  nose potential ES     =         0.000000
+  nose kinetic   EPS    =         0.000000
+  ---------------------------------------------------
+  total energy   ETOTAL =      -251.154832 eV
+
+  maximum distance moved by ions :      0.23E-02
+
+ Prediction of Wavefunctions ALPHA= 0.994 BETA= 0.000
+    WAVPRE:  cpu time      0.0294: real time      0.0319
+    FEWALD:  cpu time      0.0005: real time      0.0005
+    ORTHCH:  cpu time      0.0237: real time      0.0237
+     LOOP+:  cpu time      6.2020: real time      6.2466
+
+
+--------------------------------------- Iteration      3(   1)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0165: real time      0.0165
+    SETDIJ:  cpu time      0.0037: real time      0.0037
+     EDDAV:  cpu time      0.3515: real time      0.3533
+       DOS:  cpu time      0.0007: real time      0.0024
+    CHARGE:  cpu time      0.0193: real time      0.0193
+    MIXING:  cpu time      0.0004: real time      0.0004
+    --------------------------------------------
+      LOOP:  cpu time      0.3921: real time      0.3957
+
+ eigenvalue-minimisations  :   320
+ total energy-change (2. order) : 0.3838909E-01  (-0.8609942E-03)
+ number of electron     128.0000032 magnetization 
+ augmentation part       35.9128001 magnetization 
+
+  free energy =  -0.253100688699E+03  energy without entropy=  -0.253040330144E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      3(   2)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0267: real time      0.0275
+    SETDIJ:  cpu time      0.0037: real time      0.0037
+     EDDAV:  cpu time      0.5537: real time      0.5538
+       DOS:  cpu time      0.0004: real time      0.0004
+    CHARGE:  cpu time      0.0188: real time      0.0188
+    MIXING:  cpu time      0.0004: real time      0.0004
+    --------------------------------------------
+      LOOP:  cpu time      0.6037: real time      0.6046
+
+ eigenvalue-minimisations  :   448
+ total energy-change (2. order) :-0.2056690E-03  (-0.2299080E-03)
+ number of electron     128.0000032 magnetization 
+ augmentation part       35.9029792 magnetization 
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.3111
+  0.3111
+
+  free energy =  -0.253100894368E+03  energy without entropy=  -0.253040756117E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      3(   3)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0241: real time      0.0259
+    SETDIJ:  cpu time      0.0037: real time      0.0037
+     EDDAV:  cpu time      0.3555: real time      0.3555
+       DOS:  cpu time      0.0004: real time      0.0004
+    CHARGE:  cpu time      0.0188: real time      0.0188
+    MIXING:  cpu time      0.0006: real time      0.0006
+    --------------------------------------------
+      LOOP:  cpu time      0.4032: real time      0.4051
+
+ eigenvalue-minimisations  :   320
+ total energy-change (2. order) : 0.1964339E-03  (-0.7614786E-04)
+ number of electron     128.0000032 magnetization 
+ augmentation part       35.9026521 magnetization 
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.4058
+  0.5888  0.2229
+
+  free energy =  -0.253100697934E+03  energy without entropy=  -0.253040583611E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      3(   4)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0187: real time      0.0280
+    SETDIJ:  cpu time      0.0039: real time      0.0039
+     EDDAV:  cpu time      0.5345: real time      0.5345
+       DOS:  cpu time      0.0005: real time      0.0004
+    CHARGE:  cpu time      0.0187: real time      0.0187
+    MIXING:  cpu time      0.0005: real time      0.0005
+    --------------------------------------------
+      LOOP:  cpu time      0.5767: real time      0.5860
+
+ eigenvalue-minimisations  :   448
+ total energy-change (2. order) :-0.5450511E-06  (-0.4611736E-05)
+ number of electron     128.0000032 magnetization 
+ augmentation part       35.9026117 magnetization 
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.4002
+  0.4875  0.4875  0.2257
+
+  free energy =  -0.253100698479E+03  energy without entropy=  -0.253040587911E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      3(   5)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0230: real time      0.0256
+    SETDIJ:  cpu time      0.0036: real time      0.0036
+     EDDAV:  cpu time      0.5357: real time      0.5357
+       DOS:  cpu time      0.0004: real time      0.0004
+    CHARGE:  cpu time      0.0188: real time      0.0188
+    MIXING:  cpu time      0.0005: real time      0.0005
+    --------------------------------------------
+      LOOP:  cpu time      0.5820: real time      0.5846
+
+ eigenvalue-minimisations  :   448
+ total energy-change (2. order) : 0.3714749E-05  (-0.1965953E-05)
+ number of electron     128.0000032 magnetization 
+ augmentation part       35.9026784 magnetization 
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.8490
+  1.8570  1.0835  0.2467  0.2087
+
+  free energy =  -0.253100694765E+03  energy without entropy=  -0.253040592803E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      3(   6)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0181: real time      0.0253
+    SETDIJ:  cpu time      0.0037: real time      0.0037
+     EDDAV:  cpu time      0.3476: real time      0.3477
+       DOS:  cpu time      0.0004: real time      0.0004
+    CHARGE:  cpu time      0.0184: real time      0.0184
+    MIXING:  cpu time      0.0005: real time      0.0005
+    --------------------------------------------
+      LOOP:  cpu time      0.3886: real time      0.3960
+
+ eigenvalue-minimisations  :   320
+ total energy-change (2. order) :-0.3467817E-05  (-0.1391736E-05)
+ number of electron     128.0000032 magnetization 
+ augmentation part       35.9028530 magnetization 
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.8009
+  2.2560  1.0229  0.2682  0.2512  0.2060
+
+  free energy =  -0.253100698232E+03  energy without entropy=  -0.253040615454E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      3(   7)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0256: real time      0.0266
+    SETDIJ:  cpu time      0.0037: real time      0.0037
+     EDDAV:  cpu time      0.5363: real time      0.5364
+       DOS:  cpu time      0.0004: real time      0.0004
+    CHARGE:  cpu time      0.0189: real time      0.0189
+    MIXING:  cpu time      0.0005: real time      0.0005
+    --------------------------------------------
+      LOOP:  cpu time      0.5854: real time      0.5864
+
+ eigenvalue-minimisations  :   448
+ total energy-change (2. order) : 0.3000395E-05  (-0.1250915E-05)
+ number of electron     128.0000032 magnetization 
+ augmentation part       35.9029143 magnetization 
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.7891
+  2.4041  0.9788  0.6623  0.2601  0.2051  0.2243
+
+  free energy =  -0.253100695232E+03  energy without entropy=  -0.253040615274E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      3(   8)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0237: real time      0.0258
+    SETDIJ:  cpu time      0.0037: real time      0.0037
+     EDDAV:  cpu time      0.4024: real time      0.4025
+       DOS:  cpu time      0.0004: real time      0.0004
+    --------------------------------------------
+      LOOP:  cpu time      0.4302: real time      0.4324
+
+ eigenvalue-minimisations  :   320
+ total energy-change (2. order) : 0.3514924E-07  (-0.1033521E-06)
+ number of electron     128.0000032 magnetization 
+ augmentation part       35.9029143 magnetization 
+
+  free energy =  -0.253100695197E+03  energy without entropy=  -0.253040613980E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+------------------------ aborting loop because EDIFF is reached ----------------------------------------
+
+
+    CHARGE:  cpu time      0.0184: real time      0.0185
+    FORLOC:  cpu time      0.0015: real time      0.0015
+    FORNL :  cpu time      0.1490: real time      0.1491
+    STRESS:  cpu time      0.4367: real time      0.4368
+    FORCOR:  cpu time      0.0141: real time      0.0141
+    FORHAR:  cpu time      0.0043: real time      0.0043
+    MIXING:  cpu time      0.0004: real time      0.0004
+    OFIELD:  cpu time      0.0000: real time      0.0000
+
+  FORCE on cell =-STRESS in cart. coord.  units (eV):
+  Direction    XX          YY          ZZ          XY          YZ          ZX
+  --------------------------------------------------------------------------------------
+  Alpha Z   650.40089   650.40089   650.40089
+  Ewald   -1389.14055 -1388.03339 -1335.34959    -0.18392     0.00794     0.10375
+  Hartree    35.03369    37.93145    40.38084    -0.03237    -0.01006     0.03210
+  E(xc)    -484.72858  -488.13605  -486.57770     0.00848    -0.00073    -0.00221
+  Local     271.14142   260.85963   242.02959     0.17591     0.01410    -0.11781
+  n-local  -124.95968  -110.76738  -109.56740    -0.01866     0.00098     0.00396
+  augment   190.69744   197.27496   191.47251     0.00379    -0.00243    -0.00180
+  Kinetic   798.44460   841.68442   806.30037     0.01830    -0.01006    -0.00571
+  Fock        0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+  -------------------------------------------------------------------------------------
+  Total     -53.11079     1.21452    -0.91049    -0.02846    -0.00026     0.01228
+  in kB    -153.35853     3.50696    -2.62906    -0.08218    -0.00075     0.03546
+  external pressure =      -50.83 kB  Pullay stress =        0.00 kB
+
+  kinetic pressure (ideal gas correction) =      3.79 kB
+  total pressure  =    -47.03 kB
+  Total+kin.  -150.445       7.012       2.333      -0.456       0.633      -0.566
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+  FREE ENERGIE OF THE ION-ELECTRON SYSTEM (eV)
+  ---------------------------------------------------
+  free  energy   TOTEN  =      -253.10069520 eV
+
+  energy  without entropy=     -253.04061398  energy(sigma->0) =     -253.08066812
+ 
+ d Force =-0.3837969E-01[-0.498E-01,-0.269E-01]  d Energy =-0.3838250E-01 0.281E-05
+ d Force =-0.2697497E+00[-0.359E+00,-0.180E+00]  d Ewald  =-0.2697740E+00 0.244E-04
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+    POTLOK:  cpu time      0.0203: real time      0.0203
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+           RANDOM_SEED =         223274761                0                0
+   IONSTEP:  cpu time      0.0007: real time      0.0015
+
+  ENERGY OF THE ELECTRON-ION-THERMOSTAT SYSTEM (eV)
+  ---------------------------------------------------
+% ion-electron   TOTEN  =      -253.100695  see above
+  kinetic energy EKIN   =         1.945935
+  kin. lattice  EKIN_LAT=         0.000000  (temperature  485.62 K)
+  nose potential ES     =         0.000000
+  nose kinetic   EPS    =         0.000000
+  ---------------------------------------------------
+  total energy   ETOTAL =      -251.154760 eV
+
+  maximum distance moved by ions :      0.22E-02
+
+ Prediction of Wavefunctions ALPHA= 2.052 BETA=-1.056
+    WAVPRE:  cpu time      0.0281: real time      0.0312
+    FEWALD:  cpu time      0.0005: real time      0.0005
+    ORTHCH:  cpu time      0.0258: real time      0.0258
+     LOOP+:  cpu time      4.6927: real time      4.7352
+
+
+--------------------------------------- Iteration      4(   1)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0169: real time      0.0170
+    SETDIJ:  cpu time      0.0037: real time      0.0037
+     EDDAV:  cpu time      0.4631: real time      0.4632
+       DOS:  cpu time      0.0004: real time      0.0004
+    CHARGE:  cpu time      0.0191: real time      0.0191
+    MIXING:  cpu time      0.0004: real time      0.0004
+    --------------------------------------------
+      LOOP:  cpu time      0.5037: real time      0.5038
+
+ eigenvalue-minimisations  :   384
+ total energy-change (2. order) : 0.5910571E-01  (-0.5673039E-03)
+ number of electron     128.0000019 magnetization 
+ augmentation part       35.9069856 magnetization 
+
+  free energy =  -0.253041589523E+03  energy without entropy=  -0.252986064216E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      4(   2)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0180: real time      0.0264
+    SETDIJ:  cpu time      0.0037: real time      0.0037
+     EDDAV:  cpu time      0.4539: real time      0.4539
+       DOS:  cpu time      0.0006: real time      0.0006
+    CHARGE:  cpu time      0.0189: real time      0.0189
+    MIXING:  cpu time      0.0004: real time      0.0004
+    --------------------------------------------
+      LOOP:  cpu time      0.4954: real time      0.5039
+
+ eigenvalue-minimisations  :   384
+ total energy-change (2. order) : 0.5244952E-04  (-0.9801012E-05)
+ number of electron     128.0000019 magnetization 
+ augmentation part       35.9075430 magnetization 
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.3017
+  0.3017
+
+  free energy =  -0.253041537073E+03  energy without entropy=  -0.252985964960E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      4(   3)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0185: real time      0.0288
+    SETDIJ:  cpu time      0.0037: real time      0.0037
+     EDDAV:  cpu time      0.5299: real time      0.5305
+       DOS:  cpu time      0.0004: real time      0.0004
+    CHARGE:  cpu time      0.0188: real time      0.0188
+    MIXING:  cpu time      0.0004: real time      0.0004
+    --------------------------------------------
+      LOOP:  cpu time      0.5717: real time      0.5826
+
+ eigenvalue-minimisations  :   448
+ total energy-change (2. order) : 0.5078788E-05  (-0.1516581E-05)
+ number of electron     128.0000019 magnetization 
+ augmentation part       35.9076163 magnetization 
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.4123
+  0.5971  0.2275
+
+  free energy =  -0.253041531995E+03  energy without entropy=  -0.252985940358E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      4(   4)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0250: real time      0.0256
+    SETDIJ:  cpu time      0.0036: real time      0.0036
+     EDDAV:  cpu time      0.2135: real time      0.2135
+       DOS:  cpu time      0.0004: real time      0.0004
+    CHARGE:  cpu time      0.0189: real time      0.0189
+    MIXING:  cpu time      0.0004: real time      0.0004
+    --------------------------------------------
+      LOOP:  cpu time      0.2619: real time      0.2625
+
+ eigenvalue-minimisations  :   192
+ total energy-change (2. order) :-0.5935908E-07  (-0.9759294E-07)
+ number of electron     128.0000019 magnetization 
+ augmentation part       35.9076240 magnetization 
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.4745
+  0.5976  0.5976  0.2283
+
+  free energy =  -0.253041532054E+03  energy without entropy=  -0.252985937886E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      4(   5)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0259: real time      0.0264
+    SETDIJ:  cpu time      0.0037: real time      0.0037
+     EDDAV:  cpu time      0.4059: real time      0.4059
+       DOS:  cpu time      0.0005: real time      0.0005
+    CHARGE:  cpu time      0.0194: real time      0.0260
+    MIXING:  cpu time      0.0005: real time      0.0005
+    --------------------------------------------
+      LOOP:  cpu time      0.4558: real time      0.4629
+
+ eigenvalue-minimisations  :   320
+ total energy-change (2. order) :-0.4143385E-07  (-0.4051448E-07)
+ number of electron     128.0000019 magnetization 
+ augmentation part       35.9076193 magnetization 
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.8501
+  1.7879  1.1179  0.2183  0.2765
+
+  free energy =  -0.253041532095E+03  energy without entropy=  -0.252985938510E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      4(   6)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0176: real time      0.0250
+    SETDIJ:  cpu time      0.0037: real time      0.0037
+     EDDAV:  cpu time      0.2140: real time      0.2140
+       DOS:  cpu time      0.0004: real time      0.0004
+    --------------------------------------------
+      LOOP:  cpu time      0.2357: real time      0.2431
+
+ eigenvalue-minimisations  :   192
+ total energy-change (2. order) :-0.3526256E-06  (-0.4296225E-07)
+ number of electron     128.0000019 magnetization 
+ augmentation part       35.9076193 magnetization 
+
+  free energy =  -0.253041532448E+03  energy without entropy=  -0.252985936104E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+------------------------ aborting loop because EDIFF is reached ----------------------------------------
+
+
+    CHARGE:  cpu time      0.0184: real time      0.0184
+    FORLOC:  cpu time      0.0015: real time      0.0015
+    FORNL :  cpu time      0.1492: real time      0.1492
+    STRESS:  cpu time      0.4372: real time      0.4373
+    FORCOR:  cpu time      0.0143: real time      0.0143
+    FORHAR:  cpu time      0.0042: real time      0.0042
+    MIXING:  cpu time      0.0004: real time      0.0004
+    OFIELD:  cpu time      0.0000: real time      0.0000
+
+  FORCE on cell =-STRESS in cart. coord.  units (eV):
+  Direction    XX          YY          ZZ          XY          YZ          ZX
+  --------------------------------------------------------------------------------------
+  Alpha Z   650.40089   650.40089   650.40089
+  Ewald   -1388.98355 -1387.85035 -1335.24832    -0.31092     0.01536     0.23224
+  Hartree    35.22856    38.01644    40.45664    -0.05624    -0.02267     0.07160
+  E(xc)    -484.76833  -488.15971  -486.63454     0.01334    -0.00186    -0.00515
+  Local     270.87319   260.79032   241.88975     0.29498     0.03223    -0.26315
+  n-local  -125.07256  -110.73788  -109.61699    -0.02925    -0.00020     0.00806
+  augment   190.71751   197.23672   191.48678     0.00693    -0.00483    -0.00380
+  Kinetic   798.58434   841.66930   806.47948     0.02851    -0.02133    -0.01165
+  Fock        0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+  -------------------------------------------------------------------------------------
+  Total     -53.01996     1.36573    -0.78631    -0.05264    -0.00331     0.02814
+  in kB    -153.09626     3.94357    -2.27048    -0.15199    -0.00955     0.08127
+  external pressure =      -50.47 kB  Pullay stress =        0.00 kB
+
+  kinetic pressure (ideal gas correction) =      3.70 kB
+  total pressure  =    -46.78 kB
+  Total+kin.  -150.221       7.358       2.537      -0.526       0.605      -0.507
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+  FREE ENERGIE OF THE ION-ELECTRON SYSTEM (eV)
+  ---------------------------------------------------
+  free  energy   TOTEN  =      -253.04153245 eV
+
+  energy  without entropy=     -252.98593610  energy(sigma->0) =     -253.02300033
+ 
+ d Force =-0.5916581E-01[-0.703E-01,-0.481E-01]  d Energy =-0.5916275E-01-0.306E-05
+ d Force =-0.4409288E+00[-0.528E+00,-0.354E+00]  d Ewald  =-0.4409513E+00 0.225E-04
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+    POTLOK:  cpu time      0.0203: real time      0.0203
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+           RANDOM_SEED =         223274761                0                0
+   IONSTEP:  cpu time      0.0002: real time      0.0002
+
+  ENERGY OF THE ELECTRON-ION-THERMOSTAT SYSTEM (eV)
+  ---------------------------------------------------
+% ion-electron   TOTEN  =      -253.041532  see above
+  kinetic energy EKIN   =         1.886881
+  kin. lattice  EKIN_LAT=         0.000000  (temperature  470.89 K)
+  nose potential ES     =         0.000000
+  nose kinetic   EPS    =         0.000000
+  ---------------------------------------------------
+  total energy   ETOTAL =      -251.154651 eV
+
+  maximum distance moved by ions :      0.22E-02
+
+ Prediction of Wavefunctions ALPHA= 2.105 BETA=-1.109
+    WAVPRE:  cpu time      0.0281: real time      0.0296
+    FEWALD:  cpu time      0.0005: real time      0.0005
+    ORTHCH:  cpu time      0.0251: real time      0.0251
+     LOOP+:  cpu time      3.2581: real time      3.3005
+
+
+--------------------------------------- Iteration      5(   1)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0165: real time      0.0166
+    SETDIJ:  cpu time      0.0037: real time      0.0037
+     EDDAV:  cpu time      0.4661: real time      0.4669
+       DOS:  cpu time      0.0004: real time      0.0004
+    CHARGE:  cpu time      0.0191: real time      0.0191
+    MIXING:  cpu time      0.0003: real time      0.0003
+    --------------------------------------------
+      LOOP:  cpu time      0.5060: real time      0.5069
+
+ eigenvalue-minimisations  :   384
+ total energy-change (2. order) : 0.7814242E-01  (-0.5496237E-03)
+ number of electron     128.0000008 magnetization 
+ augmentation part       35.9124482 magnetization 
+
+  free energy =  -0.252963389675E+03  energy without entropy=  -0.252913079394E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      5(   2)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0214: real time      0.0282
+    SETDIJ:  cpu time      0.0037: real time      0.0037
+     EDDAV:  cpu time      0.4547: real time      0.4547
+       DOS:  cpu time      0.0005: real time      0.0004
+    CHARGE:  cpu time      0.0188: real time      0.0188
+    MIXING:  cpu time      0.0004: real time      0.0004
+    --------------------------------------------
+      LOOP:  cpu time      0.4995: real time      0.5063
+
+ eigenvalue-minimisations  :   384
+ total energy-change (2. order) : 0.4855027E-04  (-0.1333293E-04)
+ number of electron     128.0000008 magnetization 
+ augmentation part       35.9140729 magnetization 
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.3257
+  0.3257
+
+  free energy =  -0.252963341124E+03  energy without entropy=  -0.252912899784E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      5(   3)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0257: real time      0.0277
+    SETDIJ:  cpu time      0.0037: real time      0.0037
+     EDDAV:  cpu time      0.3458: real time      0.3459
+       DOS:  cpu time      0.0004: real time      0.0004
+    CHARGE:  cpu time      0.0185: real time      0.0185
+    MIXING:  cpu time      0.0004: real time      0.0004
+    --------------------------------------------
+      LOOP:  cpu time      0.3946: real time      0.3966
+
+ eigenvalue-minimisations  :   320
+ total energy-change (2. order) : 0.6962588E-05  (-0.2172062E-05)
+ number of electron     128.0000008 magnetization 
+ augmentation part       35.9142079 magnetization 
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.4197
+  0.5852  0.2543
+
+  free energy =  -0.252963334162E+03  energy without entropy=  -0.252912911329E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      5(   4)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0274: real time      0.0284
+    SETDIJ:  cpu time      0.0038: real time      0.0038
+     EDDAV:  cpu time      0.4548: real time      0.4558
+       DOS:  cpu time      0.0005: real time      0.0005
+    CHARGE:  cpu time      0.0188: real time      0.0188
+    MIXING:  cpu time      0.0004: real time      0.0004
+    --------------------------------------------
+      LOOP:  cpu time      0.5058: real time      0.5078
+
+ eigenvalue-minimisations  :   384
+ total energy-change (2. order) : 0.8052666E-07  (-0.2241272E-06)
+ number of electron     128.0000008 magnetization 
+ augmentation part       35.9142391 magnetization 
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.4391
+  0.5388  0.5388  0.2396
+
+  free energy =  -0.252963334081E+03  energy without entropy=  -0.252912904723E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      5(   5)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0227: real time      0.0258
+    SETDIJ:  cpu time      0.0037: real time      0.0037
+     EDDAV:  cpu time      0.2135: real time      0.2136
+       DOS:  cpu time      0.0004: real time      0.0004
+    CHARGE:  cpu time      0.0184: real time      0.0184
+    MIXING:  cpu time      0.0005: real time      0.0005
+    --------------------------------------------
+      LOOP:  cpu time      0.2591: real time      0.2623
+
+ eigenvalue-minimisations  :   192
+ total energy-change (2. order) : 0.2214256E-06  (-0.5295251E-07)
+ number of electron     128.0000008 magnetization 
+ augmentation part       35.9142405 magnetization 
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.7762
+  1.2961  1.2961  0.2847  0.2281
+
+  free energy =  -0.252963333860E+03  energy without entropy=  -0.252912908018E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      5(   6)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0243: real time      0.0254
+    SETDIJ:  cpu time      0.0037: real time      0.0037
+     EDDAV:  cpu time      0.3992: real time      0.3992
+       DOS:  cpu time      0.0004: real time      0.0004
+    --------------------------------------------
+      LOOP:  cpu time      0.4275: real time      0.4287
+
+ eigenvalue-minimisations  :   320
+ total energy-change (2. order) :-0.7417930E-07  (-0.7793240E-07)
+ number of electron     128.0000008 magnetization 
+ augmentation part       35.9142405 magnetization 
+
+  free energy =  -0.252963333934E+03  energy without entropy=  -0.252912900072E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+------------------------ aborting loop because EDIFF is reached ----------------------------------------
+
+
+    CHARGE:  cpu time      0.0192: real time      0.0192
+    FORLOC:  cpu time      0.0015: real time      0.0015
+    FORNL :  cpu time      0.1493: real time      0.1497
+    STRESS:  cpu time      0.4361: real time      0.4361
+    FORCOR:  cpu time      0.0145: real time      0.0145
+    FORHAR:  cpu time      0.0043: real time      0.0043
+    MIXING:  cpu time      0.0004: real time      0.0004
+    OFIELD:  cpu time      0.0000: real time      0.0000
+
+  FORCE on cell =-STRESS in cart. coord.  units (eV):
+  Direction    XX          YY          ZZ          XY          YZ          ZX
+  --------------------------------------------------------------------------------------
+  Alpha Z   650.40089   650.40089   650.40089
+  Ewald   -1388.65679 -1387.71243 -1335.11302    -0.46076     0.02251     0.40863
+  Hartree    35.51419    38.11720    40.55416    -0.08451    -0.04082     0.12546
+  E(xc)    -484.83049  -488.18574  -486.70664     0.01859    -0.00339    -0.00938
+  Local     270.39296   260.79610   241.72603     0.43328     0.06019    -0.46177
+  n-local  -125.24559  -110.70945  -109.68506    -0.04115    -0.00203     0.01328
+  augment   190.75188   197.18757   191.50194     0.01126    -0.00785    -0.00633
+  Kinetic   798.77084   841.67166   806.70691     0.04098    -0.03717    -0.01861
+  Fock        0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+  -------------------------------------------------------------------------------------
+  Total     -52.90212     1.56580    -0.61480    -0.08231    -0.00856     0.05128
+  in kB    -152.75600     4.52128    -1.77524    -0.23767    -0.02473     0.14807
+  external pressure =      -50.00 kB  Pullay stress =        0.00 kB
+
+  kinetic pressure (ideal gas correction) =      3.57 kB
+  total pressure  =    -46.44 kB
+  Total+kin.  -149.935       7.818       2.807      -0.610       0.562      -0.420
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+  FREE ENERGIE OF THE ION-ELECTRON SYSTEM (eV)
+  ---------------------------------------------------
+  free  energy   TOTEN  =      -252.96333393 eV
+
+  energy  without entropy=     -252.91290007  energy(sigma->0) =     -252.94652265
+ 
+ d Force =-0.7820538E-01[-0.888E-01,-0.676E-01]  d Energy =-0.7819851E-01-0.687E-05
+ d Force =-0.5997180E+00[-0.683E+00,-0.517E+00]  d Ewald  =-0.5997367E+00 0.187E-04
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+    POTLOK:  cpu time      0.0205: real time      0.0205
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+           RANDOM_SEED =         223274761                0                0
+   IONSTEP:  cpu time      0.0002: real time      0.0002
+
+  ENERGY OF THE ELECTRON-ION-THERMOSTAT SYSTEM (eV)
+  ---------------------------------------------------
+% ion-electron   TOTEN  =      -252.963334  see above
+  kinetic energy EKIN   =         1.808827
+  kin. lattice  EKIN_LAT=         0.000000  (temperature  451.41 K)
+  nose potential ES     =         0.000000
+  nose kinetic   EPS    =         0.000000
+  ---------------------------------------------------
+  total energy   ETOTAL =      -251.154507 eV
+
+  maximum distance moved by ions :      0.22E-02
+
+ Prediction of Wavefunctions ALPHA= 2.126 BETA=-1.129
+    WAVPRE:  cpu time      0.0282: real time      0.0300
+    FEWALD:  cpu time      0.0005: real time      0.0005
+    ORTHCH:  cpu time      0.0246: real time      0.0246
+     LOOP+:  cpu time      3.3303: real time      3.3515
+
+
+--------------------------------------- Iteration      6(   1)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0164: real time      0.0164
+    SETDIJ:  cpu time      0.0037: real time      0.0037
+     EDDAV:  cpu time      0.4581: real time      0.4582
+       DOS:  cpu time      0.0004: real time      0.0004
+    CHARGE:  cpu time      0.0188: real time      0.0188
+    MIXING:  cpu time      0.0003: real time      0.0003
+    --------------------------------------------
+      LOOP:  cpu time      0.4978: real time      0.4979
+
+ eigenvalue-minimisations  :   384
+ total energy-change (2. order) : 0.9481420E-01  (-0.5176857E-03)
+ number of electron     128.0000000 magnetization 
+ augmentation part       35.9208096 magnetization 
+
+  free energy =  -0.252868519658E+03  energy without entropy=  -0.252823931329E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      6(   2)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0226: real time      0.0252
+    SETDIJ:  cpu time      0.0038: real time      0.0038
+     EDDAV:  cpu time      0.5373: real time      0.5374
+       DOS:  cpu time      0.0005: real time      0.0005
+    CHARGE:  cpu time      0.0195: real time      0.0195
+    MIXING:  cpu time      0.0005: real time      0.0005
+    --------------------------------------------
+      LOOP:  cpu time      0.5841: real time      0.5867
+
+ eigenvalue-minimisations  :   448
+ total energy-change (2. order) : 0.3297165E-04  (-0.2237878E-04)
+ number of electron     128.0000000 magnetization 
+ augmentation part       35.9225285 magnetization 
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.2686
+  0.2686
+
+  free energy =  -0.252868486686E+03  energy without entropy=  -0.252823798196E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      6(   3)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0194: real time      0.0291
+    SETDIJ:  cpu time      0.0038: real time      0.0038
+     EDDAV:  cpu time      0.3536: real time      0.3538
+       DOS:  cpu time      0.0007: real time      0.0007
+    CHARGE:  cpu time      0.0191: real time      0.0191
+    MIXING:  cpu time      0.0004: real time      0.0004
+    --------------------------------------------
+      LOOP:  cpu time      0.3969: real time      0.4069
+
+ eigenvalue-minimisations  :   320
+ total energy-change (2. order) : 0.1995818E-04  (-0.6942980E-05)
+ number of electron     128.0000000 magnetization 
+ augmentation part       35.9225998 magnetization 
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.3486
+  0.4671  0.2301
+
+  free energy =  -0.252868466728E+03  energy without entropy=  -0.252823754141E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      6(   4)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0187: real time      0.0280
+    SETDIJ:  cpu time      0.0039: real time      0.0039
+     EDDAV:  cpu time      0.4580: real time      0.4580
+       DOS:  cpu time      0.0004: real time      0.0004
+    CHARGE:  cpu time      0.0191: real time      0.0191
+    MIXING:  cpu time      0.0005: real time      0.0005
+    --------------------------------------------
+      LOOP:  cpu time      0.5006: real time      0.5100
+
+ eigenvalue-minimisations  :   384
+ total energy-change (2. order) : 0.2746119E-06  (-0.3938896E-06)
+ number of electron     128.0000000 magnetization 
+ augmentation part       35.9226121 magnetization 
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.3703
+  0.4448  0.4448  0.2213
+
+  free energy =  -0.252868466453E+03  energy without entropy=  -0.252823747505E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      6(   5)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0256: real time      0.0267
+    SETDIJ:  cpu time      0.0037: real time      0.0037
+     EDDAV:  cpu time      0.2137: real time      0.2137
+       DOS:  cpu time      0.0004: real time      0.0004
+    CHARGE:  cpu time      0.0183: real time      0.0183
+    MIXING:  cpu time      0.0005: real time      0.0005
+    --------------------------------------------
+      LOOP:  cpu time      0.2622: real time      0.2632
+
+ eigenvalue-minimisations  :   192
+ total energy-change (2. order) : 0.2670549E-06  (-0.6531390E-07)
+ number of electron     128.0000000 magnetization 
+ augmentation part       35.9226119 magnetization 
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.6944
+  1.1506  1.1506  0.2654  0.2108
+
+  free energy =  -0.252868466186E+03  energy without entropy=  -0.252823748077E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      6(   6)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0246: real time      0.0258
+    SETDIJ:  cpu time      0.0037: real time      0.0037
+     EDDAV:  cpu time      0.4560: real time      0.4564
+       DOS:  cpu time      0.0004: real time      0.0004
+    --------------------------------------------
+      LOOP:  cpu time      0.4847: real time      0.4863
+
+ eigenvalue-minimisations  :   320
+ total energy-change (2. order) :-0.1536500E-07  (-0.7251205E-07)
+ number of electron     128.0000000 magnetization 
+ augmentation part       35.9226119 magnetization 
+
+  free energy =  -0.252868466202E+03  energy without entropy=  -0.252823743433E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+------------------------ aborting loop because EDIFF is reached ----------------------------------------
+
+
+    CHARGE:  cpu time      0.0194: real time      0.0194
+    FORLOC:  cpu time      0.0015: real time      0.0015
+    FORNL :  cpu time      0.1500: real time      0.1500
+    STRESS:  cpu time      0.4374: real time      0.4374
+    FORCOR:  cpu time      0.0144: real time      0.0144
+    FORHAR:  cpu time      0.0109: real time      0.0141
+    MIXING:  cpu time      0.0028: real time      0.0033
+    OFIELD:  cpu time      0.0000: real time      0.0000
+
+  FORCE on cell =-STRESS in cart. coord.  units (eV):
+  Direction    XX          YY          ZZ          XY          YZ          ZX
+  --------------------------------------------------------------------------------------
+  Alpha Z   650.40089   650.40089   650.40089
+  Ewald   -1388.16936 -1387.62159 -1334.94939    -0.63069     0.02725     0.62859
+  Hartree    35.88321    38.23161    40.66974    -0.11651    -0.06431     0.19247
+  E(xc)    -484.91366  -488.21438  -486.79275     0.02405    -0.00524    -0.01486
+  Local     269.71357   260.87394   241.54398     0.58809     0.09894    -0.70903
+  n-local  -125.47245  -110.68598  -109.77205    -0.05538    -0.00544     0.01896
+  augment   190.79840   197.12825   191.51691     0.01694    -0.01136    -0.00924
+  Kinetic   799.00056   841.68966   806.97817     0.05693    -0.05755    -0.02579
+  Fock        0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+  -------------------------------------------------------------------------------------
+  Total     -52.75885     1.80241    -0.40449    -0.11657    -0.01772     0.08110
+  in kB    -152.34231     5.20450    -1.16798    -0.33661    -0.05116     0.23417
+  external pressure =      -49.44 kB  Pullay stress =        0.00 kB
+
+  kinetic pressure (ideal gas correction) =      3.40 kB
+  total pressure  =    -46.04 kB
+  Total+kin.  -149.593       8.359       3.127      -0.705       0.501      -0.308
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+  FREE ENERGIE OF THE ION-ELECTRON SYSTEM (eV)
+  ---------------------------------------------------
+  free  energy   TOTEN  =      -252.86846620 eV
+
+  energy  without entropy=     -252.82374343  energy(sigma->0) =     -252.85355861
+ 
+ d Force =-0.9488417E-01[-0.105E+00,-0.849E-01]  d Energy =-0.9486773E-01-0.164E-04
+ d Force =-0.7417623E+00[-0.820E+00,-0.663E+00]  d Ewald  =-0.7417762E+00 0.139E-04
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+    POTLOK:  cpu time      0.0263: real time      0.0264
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+           RANDOM_SEED =         223274761                0                0
+   IONSTEP:  cpu time      0.0005: real time      0.0005
+
+  ENERGY OF THE ELECTRON-ION-THERMOSTAT SYSTEM (eV)
+  ---------------------------------------------------
+% ion-electron   TOTEN  =      -252.868466  see above
+  kinetic energy EKIN   =         1.714128
+  kin. lattice  EKIN_LAT=         0.000000  (temperature  427.77 K)
+  nose potential ES     =         0.000000
+  nose kinetic   EPS    =         0.000000
+  ---------------------------------------------------
+  total energy   ETOTAL =      -251.154338 eV
+
+  maximum distance moved by ions :      0.21E-02
+
+ Prediction of Wavefunctions ALPHA= 2.126 BETA=-1.128
+    WAVPRE:  cpu time      0.0285: real time      0.0298
+    FEWALD:  cpu time      0.0005: real time      0.0005
+    ORTHCH:  cpu time      0.0242: real time      0.0242
+     LOOP+:  cpu time      3.4743: real time      3.5137
+
+
+--------------------------------------- Iteration      7(   1)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0165: real time      0.0165
+    SETDIJ:  cpu time      0.0036: real time      0.0036
+     EDDAV:  cpu time      0.4580: real time      0.4608
+       DOS:  cpu time      0.0008: real time      0.0029
+    CHARGE:  cpu time      0.0196: real time      0.0196
+    MIXING:  cpu time      0.0003: real time      0.0003
+    --------------------------------------------
+      LOOP:  cpu time      0.4988: real time      0.5038
+
+ eigenvalue-minimisations  :   384
+ total energy-change (2. order) : 0.1085995E+00  (-0.4903421E-03)
+ number of electron     127.9999996 magnetization 
+ augmentation part       35.9304629 magnetization 
+
+  free energy =  -0.252759866724E+03  energy without entropy=  -0.252721344290E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      7(   2)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0322: real time      0.0417
+    SETDIJ:  cpu time      0.0037: real time      0.0037
+     EDDAV:  cpu time      0.5332: real time      0.5332
+       DOS:  cpu time      0.0005: real time      0.0005
+    CHARGE:  cpu time      0.0187: real time      0.0187
+    MIXING:  cpu time      0.0004: real time      0.0004
+    --------------------------------------------
+      LOOP:  cpu time      0.5886: real time      0.5982
+
+ eigenvalue-minimisations  :   448
+ total energy-change (2. order) : 0.3299301E-04  (-0.2256588E-04)
+ number of electron     127.9999996 magnetization 
+ augmentation part       35.9323535 magnetization 
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.2953
+  0.2953
+
+  free energy =  -0.252759833731E+03  energy without entropy=  -0.252721135194E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      7(   3)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0176: real time      0.0260
+    SETDIJ:  cpu time      0.0037: real time      0.0037
+     EDDAV:  cpu time      0.3461: real time      0.3461
+       DOS:  cpu time      0.0004: real time      0.0004
+    CHARGE:  cpu time      0.0184: real time      0.0184
+    MIXING:  cpu time      0.0004: real time      0.0004
+    --------------------------------------------
+      LOOP:  cpu time      0.3865: real time      0.3949
+
+ eigenvalue-minimisations  :   320
+ total energy-change (2. order) : 0.1732592E-04  (-0.6403255E-05)
+ number of electron     127.9999996 magnetization 
+ augmentation part       35.9324200 magnetization 
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.3667
+  0.4677  0.2657
+
+  free energy =  -0.252759816405E+03  energy without entropy=  -0.252721137583E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      7(   4)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0260: real time      0.0276
+    SETDIJ:  cpu time      0.0037: real time      0.0037
+     EDDAV:  cpu time      0.5327: real time      0.5327
+       DOS:  cpu time      0.0004: real time      0.0004
+    CHARGE:  cpu time      0.0188: real time      0.0188
+    MIXING:  cpu time      0.0004: real time      0.0004
+    --------------------------------------------
+      LOOP:  cpu time      0.5821: real time      0.5837
+
+ eigenvalue-minimisations  :   448
+ total energy-change (2. order) : 0.1708067E-06  (-0.3808883E-06)
+ number of electron     127.9999996 magnetization 
+ augmentation part       35.9324335 magnetization 
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.3672
+  0.4344  0.4344  0.2327
+
+  free energy =  -0.252759816234E+03  energy without entropy=  -0.252721137773E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      7(   5)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0263: real time      0.0270
+    SETDIJ:  cpu time      0.0037: real time      0.0037
+     EDDAV:  cpu time      0.4025: real time      0.4026
+       DOS:  cpu time      0.0004: real time      0.0004
+    CHARGE:  cpu time      0.0188: real time      0.0188
+    MIXING:  cpu time      0.0010: real time      0.0010
+    --------------------------------------------
+      LOOP:  cpu time      0.4528: real time      0.4536
+
+ eigenvalue-minimisations  :   320
+ total energy-change (2. order) : 0.2834895E-06  (-0.5518728E-07)
+ number of electron     127.9999996 magnetization 
+ augmentation part       35.9324332 magnetization 
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.7333
+  1.2203  1.2203  0.2825  0.2103
+
+  free energy =  -0.252759815951E+03  energy without entropy=  -0.252721134302E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      7(   6)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0243: real time      0.0259
+    SETDIJ:  cpu time      0.0037: real time      0.0037
+     EDDAV:  cpu time      0.2936: real time      0.2937
+       DOS:  cpu time      0.0004: real time      0.0004
+    --------------------------------------------
+      LOOP:  cpu time      0.3221: real time      0.3237
+
+ eigenvalue-minimisations  :   256
+ total energy-change (2. order) :-0.9144787E-07  (-0.8684560E-07)
+ number of electron     127.9999996 magnetization 
+ augmentation part       35.9324332 magnetization 
+
+  free energy =  -0.252759816042E+03  energy without entropy=  -0.252721128037E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+------------------------ aborting loop because EDIFF is reached ----------------------------------------
+
+
+    CHARGE:  cpu time      0.0194: real time      0.0194
+    FORLOC:  cpu time      0.0015: real time      0.0015
+    FORNL :  cpu time      0.1496: real time      0.1496
+    STRESS:  cpu time      0.4373: real time      0.4374
+    FORCOR:  cpu time      0.0143: real time      0.0143
+    FORHAR:  cpu time      0.0043: real time      0.0043
+    MIXING:  cpu time      0.0004: real time      0.0004
+    OFIELD:  cpu time      0.0000: real time      0.0000
+
+  FORCE on cell =-STRESS in cart. coord.  units (eV):
+  Direction    XX          YY          ZZ          XY          YZ          ZX
+  --------------------------------------------------------------------------------------
+  Alpha Z   650.40089   650.40089   650.40089
+  Ewald   -1387.53292 -1387.57992 -1334.76421    -0.81769     0.02746     0.88640
+  Hartree    36.32566    38.35571    40.79905    -0.15088    -0.09393     0.27077
+  E(xc)    -485.01563  -488.24472  -486.89071     0.02963    -0.00724    -0.02157
+  Local     268.85169   261.02241   241.35089     0.75501     0.15138    -0.99835
+  n-local  -125.74729  -110.66877  -109.87876    -0.07164    -0.01053     0.02509
+  augment   190.85520   197.06035   191.53121     0.02392    -0.01532    -0.01231
+  Kinetic   799.26884   841.72137   807.28641     0.07713    -0.08243    -0.03227
+  Fock        0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+  -------------------------------------------------------------------------------------
+  Total     -52.59357     2.06730    -0.16524    -0.15450    -0.03062     0.11776
+  in kB    -151.86505     5.96938    -0.47714    -0.44614    -0.08842     0.34003
+  external pressure =      -48.79 kB  Pullay stress =        0.00 kB
+
+  kinetic pressure (ideal gas correction) =      3.20 kB
+  total pressure  =    -45.59 kB
+  Total+kin.  -149.203       8.959       3.479      -0.809       0.421      -0.169
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+  FREE ENERGIE OF THE ION-ELECTRON SYSTEM (eV)
+  ---------------------------------------------------
+  free  energy   TOTEN  =      -252.75981604 eV
+
+  energy  without entropy=     -252.72112804  energy(sigma->0) =     -252.74692004
+ 
+ d Force =-0.1086677E+00[-0.118E+00,-0.995E-01]  d Energy =-0.1086502E+00-0.175E-04
+ d Force =-0.8631845E+00[-0.936E+00,-0.790E+00]  d Ewald  =-0.8631983E+00 0.139E-04
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+    POTLOK:  cpu time      0.0204: real time      0.0204
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+           RANDOM_SEED =         223274761                0                0
+   IONSTEP:  cpu time      0.0003: real time      0.0011
+
+  ENERGY OF THE ELECTRON-ION-THERMOSTAT SYSTEM (eV)
+  ---------------------------------------------------
+% ion-electron   TOTEN  =      -252.759816  see above
+  kinetic energy EKIN   =         1.605674
+  kin. lattice  EKIN_LAT=         0.000000  (temperature  400.71 K)
+  nose potential ES     =         0.000000
+  nose kinetic   EPS    =         0.000000
+  ---------------------------------------------------
+  total energy   ETOTAL =      -251.154142 eV
+
+  maximum distance moved by ions :      0.20E-02
+
+ Prediction of Wavefunctions ALPHA= 2.117 BETA=-1.118
+    WAVPRE:  cpu time      0.0279: real time      0.0308
+    FEWALD:  cpu time      0.0005: real time      0.0005
+    ORTHCH:  cpu time      0.0248: real time      0.0248
+     LOOP+:  cpu time      3.5704: real time      3.6036
+
+
+--------------------------------------- Iteration      8(   1)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0165: real time      0.0166
+    SETDIJ:  cpu time      0.0036: real time      0.0036
+     EDDAV:  cpu time      0.5393: real time      0.5398
+       DOS:  cpu time      0.0004: real time      0.0004
+    CHARGE:  cpu time      0.0184: real time      0.0184
+    MIXING:  cpu time      0.0004: real time      0.0004
+    --------------------------------------------
+      LOOP:  cpu time      0.5786: real time      0.5791
+
+ eigenvalue-minimisations  :   448
+ total energy-change (2. order) : 0.1190388E+00  (-0.4579144E-03)
+ number of electron     127.9999996 magnetization 
+ augmentation part       35.9416425 magnetization 
+
+  free energy =  -0.252640777122E+03  energy without entropy=  -0.252608379259E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      8(   2)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0261: real time      0.0280
+    SETDIJ:  cpu time      0.0037: real time      0.0037
+     EDDAV:  cpu time      0.5370: real time      0.5370
+       DOS:  cpu time      0.0004: real time      0.0004
+    CHARGE:  cpu time      0.0186: real time      0.0186
+    MIXING:  cpu time      0.0004: real time      0.0004
+    --------------------------------------------
+      LOOP:  cpu time      0.5862: real time      0.5881
+
+ eigenvalue-minimisations  :   448
+ total energy-change (2. order) : 0.2208290E-04  (-0.2641141E-04)
+ number of electron     127.9999996 magnetization 
+ augmentation part       35.9434209 magnetization 
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.2700
+  0.2700
+
+  free energy =  -0.252640755039E+03  energy without entropy=  -0.252608252367E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      8(   3)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0267: real time      0.0279
+    SETDIJ:  cpu time      0.0038: real time      0.0038
+     EDDAV:  cpu time      0.5351: real time      0.5352
+       DOS:  cpu time      0.0004: real time      0.0004
+    CHARGE:  cpu time      0.0187: real time      0.0187
+    MIXING:  cpu time      0.0004: real time      0.0004
+    --------------------------------------------
+      LOOP:  cpu time      0.5850: real time      0.5863
+
+ eigenvalue-minimisations  :   448
+ total energy-change (2. order) : 0.2547835E-04  (-0.9066092E-05)
+ number of electron     127.9999996 magnetization 
+ augmentation part       35.9435066 magnetization 
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.3399
+  0.4325  0.2474
+
+  free energy =  -0.252640729561E+03  energy without entropy=  -0.252608189291E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      8(   4)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0176: real time      0.0277
+    SETDIJ:  cpu time      0.0037: real time      0.0038
+     EDDAV:  cpu time      0.5574: real time      0.5594
+       DOS:  cpu time      0.0004: real time      0.0004
+    CHARGE:  cpu time      0.0189: real time      0.0189
+    MIXING:  cpu time      0.0004: real time      0.0004
+    --------------------------------------------
+      LOOP:  cpu time      0.5984: real time      0.6106
+
+ eigenvalue-minimisations  :   448
+ total energy-change (2. order) : 0.2783727E-06  (-0.4668962E-06)
+ number of electron     127.9999996 magnetization 
+ augmentation part       35.9435289 magnetization 
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.3582
+  0.4235  0.4235  0.2277
+
+  free energy =  -0.252640729282E+03  energy without entropy=  -0.252608187184E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      8(   5)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0241: real time      0.0250
+    SETDIJ:  cpu time      0.0037: real time      0.0037
+     EDDAV:  cpu time      0.2915: real time      0.2919
+       DOS:  cpu time      0.0006: real time      0.0006
+    CHARGE:  cpu time      0.0187: real time      0.0187
+    MIXING:  cpu time      0.0005: real time      0.0005
+    --------------------------------------------
+      LOOP:  cpu time      0.3391: real time      0.3403
+
+ eigenvalue-minimisations  :   256
+ total energy-change (2. order) : 0.2515217E-06  (-0.5870510E-07)
+ number of electron     127.9999996 magnetization 
+ augmentation part       35.9435223 magnetization 
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.6536
+  1.0626  1.0626  0.2701  0.2193
+
+  free energy =  -0.252640729031E+03  energy without entropy=  -0.252608185784E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      8(   6)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0172: real time      0.0270
+    SETDIJ:  cpu time      0.0037: real time      0.0037
+     EDDAV:  cpu time      0.1582: real time      0.1582
+       DOS:  cpu time      0.0004: real time      0.0004
+    --------------------------------------------
+      LOOP:  cpu time      0.1795: real time      0.1893
+
+ eigenvalue-minimisations  :   128
+ total energy-change (2. order) :-0.3623518E-07  (-0.6349788E-07)
+ number of electron     127.9999996 magnetization 
+ augmentation part       35.9435223 magnetization 
+
+  free energy =  -0.252640729067E+03  energy without entropy=  -0.252608183384E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+------------------------ aborting loop because EDIFF is reached ----------------------------------------
+
+
+    CHARGE:  cpu time      0.0195: real time      0.0195
+    FORLOC:  cpu time      0.0015: real time      0.0015
+    FORNL :  cpu time      0.1498: real time      0.1499
+    STRESS:  cpu time      0.4371: real time      0.4371
+    FORCOR:  cpu time      0.0143: real time      0.0143
+    FORHAR:  cpu time      0.0042: real time      0.0042
+    MIXING:  cpu time      0.0004: real time      0.0004
+    OFIELD:  cpu time      0.0000: real time      0.0000
+
+  FORCE on cell =-STRESS in cart. coord.  units (eV):
+  Direction    XX          YY          ZZ          XY          YZ          ZX
+  --------------------------------------------------------------------------------------
+  Alpha Z   650.40089   650.40089   650.40089
+  Ewald   -1386.76150 -1387.58955 -1334.56526    -1.01857     0.02123     1.17512
+  Hartree    36.83025    38.48529    40.93948    -0.18691    -0.12906     0.35823
+  E(xc)    -485.13328  -488.27564  -486.99753     0.03524    -0.00934    -0.02934
+  Local     267.82961   261.24072   241.15332     0.93138     0.21719    -1.32188
+  n-local  -126.06421  -110.66111  -110.00225    -0.08989    -0.01750     0.03125
+  augment   190.92084   196.98628   191.54482     0.03232    -0.01958    -0.01539
+  Kinetic   799.56907   841.76461   807.62244     0.10213    -0.11167    -0.03740
+  Fock        0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+  -------------------------------------------------------------------------------------
+  Total     -52.40832     2.35149     0.09591    -0.19430    -0.04873     0.16059
+  in kB    -151.33014     6.78999     0.27694    -0.56104    -0.14071     0.46369
+  external pressure =      -48.09 kB  Pullay stress =        0.00 kB
+
+  kinetic pressure (ideal gas correction) =      2.98 kB
+  total pressure  =    -45.11 kB
+  Total+kin.  -148.767       9.598       3.854      -0.916       0.321      -0.005
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+  FREE ENERGIE OF THE ION-ELECTRON SYSTEM (eV)
+  ---------------------------------------------------
+  free  energy   TOTEN  =      -252.64072907 eV
+
+  energy  without entropy=     -252.60818338  energy(sigma->0) =     -252.62988051
+ 
+ d Force =-0.1191013E+00[-0.127E+00,-0.111E+00]  d Energy =-0.1190870E+00-0.143E-04
+ d Force =-0.9606935E+00[-0.103E+01,-0.894E+00]  d Ewald  =-0.9607064E+00 0.129E-04
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+    POTLOK:  cpu time      0.0202: real time      0.0202
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+           RANDOM_SEED =         223274761                0                0
+   IONSTEP:  cpu time      0.0002: real time      0.0002
+
+  ENERGY OF THE ELECTRON-ION-THERMOSTAT SYSTEM (eV)
+  ---------------------------------------------------
+% ion-electron   TOTEN  =      -252.640729  see above
+  kinetic energy EKIN   =         1.486808
+  kin. lattice  EKIN_LAT=         0.000000  (temperature  371.04 K)
+  nose potential ES     =         0.000000
+  nose kinetic   EPS    =         0.000000
+  ---------------------------------------------------
+  total energy   ETOTAL =      -251.153921 eV
+
+  maximum distance moved by ions :      0.20E-02
+
+ Prediction of Wavefunctions ALPHA= 2.103 BETA=-1.105
+    WAVPRE:  cpu time      0.0278: real time      0.0297
+    FEWALD:  cpu time      0.0006: real time      0.0006
+    ORTHCH:  cpu time      0.0244: real time      0.0244
+     LOOP+:  cpu time      3.5993: real time      3.6366
+
+
+--------------------------------------- Iteration      9(   1)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0165: real time      0.0166
+    SETDIJ:  cpu time      0.0037: real time      0.0037
+     EDDAV:  cpu time      0.6433: real time      0.6435
+       DOS:  cpu time      0.0004: real time      0.0004
+    CHARGE:  cpu time      0.0188: real time      0.0188
+    MIXING:  cpu time      0.0003: real time      0.0003
+    --------------------------------------------
+      LOOP:  cpu time      0.6830: real time      0.6833
+
+ eigenvalue-minimisations  :   512
+ total energy-change (2. order) : 0.1257780E+00  (-0.4194696E-03)
+ number of electron     127.9999999 magnetization 
+ augmentation part       35.9537803 magnetization 
+
+  free energy =  -0.252514950992E+03  energy without entropy=  -0.252488559626E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      9(   2)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0228: real time      0.0266
+    SETDIJ:  cpu time      0.0037: real time      0.0037
+     EDDAV:  cpu time      0.5353: real time      0.5353
+       DOS:  cpu time      0.0005: real time      0.0005
+    CHARGE:  cpu time      0.0188: real time      0.0188
+    MIXING:  cpu time      0.0004: real time      0.0004
+    --------------------------------------------
+      LOOP:  cpu time      0.5815: real time      0.5853
+
+ eigenvalue-minimisations  :   448
+ total energy-change (2. order) : 0.2416325E-04  (-0.2218183E-04)
+ number of electron     127.9999999 magnetization 
+ augmentation part       35.9555062 magnetization 
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.2810
+  0.2810
+
+  free energy =  -0.252514926829E+03  energy without entropy=  -0.252488360503E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      9(   3)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0260: real time      0.0264
+    SETDIJ:  cpu time      0.0037: real time      0.0037
+     EDDAV:  cpu time      0.5342: real time      0.5342
+       DOS:  cpu time      0.0004: real time      0.0004
+    CHARGE:  cpu time      0.0189: real time      0.0189
+    MIXING:  cpu time      0.0004: real time      0.0004
+    --------------------------------------------
+      LOOP:  cpu time      0.5835: real time      0.5840
+
+ eigenvalue-minimisations  :   448
+ total energy-change (2. order) : 0.2017578E-04  (-0.7519731E-05)
+ number of electron     127.9999999 magnetization 
+ augmentation part       35.9555792 magnetization 
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.3424
+  0.4234  0.2613
+
+  free energy =  -0.252514906653E+03  energy without entropy=  -0.252488346421E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      9(   4)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0242: real time      0.0256
+    SETDIJ:  cpu time      0.0037: real time      0.0037
+     EDDAV:  cpu time      0.5348: real time      0.5349
+       DOS:  cpu time      0.0005: real time      0.0005
+    CHARGE:  cpu time      0.0188: real time      0.0188
+    MIXING:  cpu time      0.0004: real time      0.0004
+    --------------------------------------------
+      LOOP:  cpu time      0.5825: real time      0.5839
+
+ eigenvalue-minimisations  :   448
+ total energy-change (2. order) : 0.3333016E-06  (-0.4160613E-06)
+ number of electron     127.9999999 magnetization 
+ augmentation part       35.9556002 magnetization 
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.3706
+  0.4426  0.4426  0.2265
+
+  free energy =  -0.252514906320E+03  energy without entropy=  -0.252488353845E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      9(   5)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0260: real time      0.0271
+    SETDIJ:  cpu time      0.0037: real time      0.0037
+     EDDAV:  cpu time      0.1585: real time      0.1586
+       DOS:  cpu time      0.0004: real time      0.0004
+    CHARGE:  cpu time      0.0190: real time      0.0190
+    MIXING:  cpu time      0.0004: real time      0.0004
+    --------------------------------------------
+      LOOP:  cpu time      0.2081: real time      0.2093
+
+ eigenvalue-minimisations  :   128
+ total energy-change (2. order) : 0.2431025E-06  (-0.4900986E-07)
+ number of electron     127.9999999 magnetization 
+ augmentation part       35.9555946 magnetization 
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.7211
+  1.1977  1.1977  0.2796  0.2095
+
+  free energy =  -0.252514906077E+03  energy without entropy=  -0.252488347483E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      9(   6)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0176: real time      0.0283
+    SETDIJ:  cpu time      0.0038: real time      0.0038
+     EDDAV:  cpu time      0.2919: real time      0.2920
+       DOS:  cpu time      0.0005: real time      0.0005
+    --------------------------------------------
+      LOOP:  cpu time      0.3138: real time      0.3245
+
+ eigenvalue-minimisations  :   256
+ total energy-change (2. order) :-0.5055881E-07  (-0.7354223E-07)
+ number of electron     127.9999999 magnetization 
+ augmentation part       35.9555946 magnetization 
+
+  free energy =  -0.252514906127E+03  energy without entropy=  -0.252488343493E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+------------------------ aborting loop because EDIFF is reached ----------------------------------------
+
+
+    CHARGE:  cpu time      0.0192: real time      0.0192
+    FORLOC:  cpu time      0.0015: real time      0.0015
+    FORNL :  cpu time      0.1492: real time      0.1492
+    STRESS:  cpu time      0.4371: real time      0.4371
+    FORCOR:  cpu time      0.0143: real time      0.0143
+    FORHAR:  cpu time      0.0043: real time      0.0043
+    MIXING:  cpu time      0.0004: real time      0.0004
+    OFIELD:  cpu time      0.0000: real time      0.0000
+
+  FORCE on cell =-STRESS in cart. coord.  units (eV):
+  Direction    XX          YY          ZZ          XY          YZ          ZX
+  --------------------------------------------------------------------------------------
+  Alpha Z   650.40089   650.40089   650.40089
+  Ewald   -1385.87135 -1387.65246 -1334.36075    -1.23004     0.00694     1.48671
+  Hartree    37.38452    38.61729    41.08423    -0.22330    -0.17009     0.45237
+  E(xc)    -485.26401  -488.30629  -487.11057     0.04086    -0.01132    -0.03803
+  Local     266.66956   261.52438   240.96141     1.11278     0.29868    -1.67062
+  n-local  -126.41822  -110.66726  -110.14075    -0.10984    -0.02572     0.03704
+  augment   190.99304   196.90750   191.55706     0.04195    -0.02408    -0.01836
+  Kinetic   799.89501   841.81877   807.97808     0.13192    -0.14443    -0.04069
+  Fock        0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+  -------------------------------------------------------------------------------------
+  Total     -52.21056     2.64281     0.36959    -0.23567    -0.07004     0.20841
+  in kB    -150.75910     7.63116     1.06721    -0.68051    -0.20223     0.60179
+  external pressure =      -47.35 kB  Pullay stress =        0.00 kB
+
+  kinetic pressure (ideal gas correction) =      2.75 kB
+  total pressure  =    -44.61 kB
+  Total+kin.  -148.307      10.245       4.239      -1.025       0.206       0.179
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+  FREE ENERGIE OF THE ION-ELECTRON SYSTEM (eV)
+  ---------------------------------------------------
+  free  energy   TOTEN  =      -252.51490613 eV
+
+  energy  without entropy=     -252.48834349  energy(sigma->0) =     -252.50605192
+ 
+ d Force =-0.1258336E+00[-0.133E+00,-0.118E+00]  d Energy =-0.1258229E+00-0.107E-04
+ d Force =-0.1031733E+01[-0.109E+01,-0.972E+00]  d Ewald  =-0.1031746E+01 0.126E-04
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+    POTLOK:  cpu time      0.0203: real time      0.0203
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+           RANDOM_SEED =         223274761                0                0
+   IONSTEP:  cpu time      0.0001: real time      0.0001
+
+  ENERGY OF THE ELECTRON-ION-THERMOSTAT SYSTEM (eV)
+  ---------------------------------------------------
+% ion-electron   TOTEN  =      -252.514906  see above
+  kinetic energy EKIN   =         1.361223
+  kin. lattice  EKIN_LAT=         0.000000  (temperature  339.70 K)
+  nose potential ES     =         0.000000
+  nose kinetic   EPS    =         0.000000
+  ---------------------------------------------------
+  total energy   ETOTAL =      -251.153683 eV
+
+  maximum distance moved by ions :      0.19E-02
+
+ Prediction of Wavefunctions ALPHA= 2.090 BETA=-1.091
+    WAVPRE:  cpu time      0.0280: real time      0.0298
+    FEWALD:  cpu time      0.0004: real time      0.0004
+    ORTHCH:  cpu time      0.0258: real time      0.0258
+     LOOP+:  cpu time      3.6836: real time      3.7150
+
+
+--------------------------------------- Iteration     10(   1)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0164: real time      0.0166
+    SETDIJ:  cpu time      0.0037: real time      0.0037
+     EDDAV:  cpu time      0.6441: real time      0.6446
+       DOS:  cpu time      0.0006: real time      0.0006
+    CHARGE:  cpu time      0.0190: real time      0.0190
+    MIXING:  cpu time      0.0004: real time      0.0004
+    --------------------------------------------
+      LOOP:  cpu time      0.6841: real time      0.6848
+
+ eigenvalue-minimisations  :   512
+ total energy-change (2. order) : 0.1286035E+00  (-0.3827319E-03)
+ number of electron     128.0000001 magnetization 
+ augmentation part       35.9667066 magnetization 
+
+  free energy =  -0.252386302580E+03  energy without entropy=  -0.252365494288E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration     10(   2)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0166: real time      0.0255
+    SETDIJ:  cpu time      0.0037: real time      0.0037
+     EDDAV:  cpu time      0.5321: real time      0.5322
+       DOS:  cpu time      0.0004: real time      0.0004
+    CHARGE:  cpu time      0.0188: real time      0.0188
+    MIXING:  cpu time      0.0004: real time      0.0004
+    --------------------------------------------
+      LOOP:  cpu time      0.5721: real time      0.5810
+
+ eigenvalue-minimisations  :   448
+ total energy-change (2. order) : 0.2199397E-04  (-0.1972667E-04)
+ number of electron     128.0000001 magnetization 
+ augmentation part       35.9682848 magnetization 
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.2802
+  0.2802
+
+  free energy =  -0.252386280586E+03  energy without entropy=  -0.252365353487E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration     10(   3)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0263: real time      0.0269
+    SETDIJ:  cpu time      0.0037: real time      0.0037
+     EDDAV:  cpu time      0.5349: real time      0.5350
+       DOS:  cpu time      0.0004: real time      0.0004
+    CHARGE:  cpu time      0.0411: real time      0.0413
+    MIXING:  cpu time      0.0005: real time      0.0005
+    --------------------------------------------
+      LOOP:  cpu time      0.6070: real time      0.6078
+
+ eigenvalue-minimisations  :   448
+ total energy-change (2. order) : 0.1754161E-04  (-0.6394458E-05)
+ number of electron     128.0000001 magnetization 
+ augmentation part       35.9683705 magnetization 
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.3592
+  0.4655  0.2529
+
+  free energy =  -0.252386263044E+03  energy without entropy=  -0.252365306310E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration     10(   4)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0172: real time      0.0265
+    SETDIJ:  cpu time      0.0061: real time      0.0061
+     EDDAV:  cpu time      0.4625: real time      0.4626
+       DOS:  cpu time      0.0005: real time      0.0005
+    CHARGE:  cpu time      0.0188: real time      0.0188
+    MIXING:  cpu time      0.0004: real time      0.0004
+    --------------------------------------------
+      LOOP:  cpu time      0.5054: real time      0.5148
+
+ eigenvalue-minimisations  :   384
+ total energy-change (2. order) : 0.1861472E-06  (-0.3532306E-06)
+ number of electron     128.0000001 magnetization 
+ augmentation part       35.9683836 magnetization 
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.3660
+  0.4333  0.4333  0.2315
+
+  free energy =  -0.252386262858E+03  energy without entropy=  -0.252365307026E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration     10(   5)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0175: real time      0.0260
+    SETDIJ:  cpu time      0.0037: real time      0.0037
+     EDDAV:  cpu time      0.1581: real time      0.1581
+       DOS:  cpu time      0.0004: real time      0.0004
+    CHARGE:  cpu time      0.0190: real time      0.0190
+    MIXING:  cpu time      0.0005: real time      0.0005
+    --------------------------------------------
+      LOOP:  cpu time      0.1991: real time      0.2077
+
+ eigenvalue-minimisations  :   128
+ total energy-change (2. order) : 0.2292418E-06  (-0.4738344E-07)
+ number of electron     128.0000001 magnetization 
+ augmentation part       35.9683794 magnetization 
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.6542
+  1.0601  1.0601  0.2748  0.2217
+
+  free energy =  -0.252386262629E+03  energy without entropy=  -0.252365304640E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration     10(   6)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0168: real time      0.0255
+    SETDIJ:  cpu time      0.0037: real time      0.0037
+     EDDAV:  cpu time      0.2985: real time      0.2987
+       DOS:  cpu time      0.0004: real time      0.0004
+    --------------------------------------------
+      LOOP:  cpu time      0.3195: real time      0.3283
+
+ eigenvalue-minimisations  :   256
+ total energy-change (2. order) :-0.3469722E-08  (-0.4462892E-07)
+ number of electron     128.0000001 magnetization 
+ augmentation part       35.9683794 magnetization 
+
+  free energy =  -0.252386262632E+03  energy without entropy=  -0.252365303952E+03
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+ average (electrostatic) potential at core
+  the test charge radii are     1.2598
+  (the norm of the test charge is              1.0000)
+       1 -26.6102       2 -26.5819       3 -26.6045       4 -26.5651       5 -26.4979
+       6 -26.5446       7 -26.5911       8 -26.6153       9 -26.5718      10 -26.5426
+      11 -26.6255      12 -26.5790      13 -26.5861      14 -26.5316      15 -26.5664
+      16 -26.5189      17 -26.5693      18 -26.5606      19 -26.6367      20 -26.6494
+      21 -26.5299      22 -26.6104      23 -26.6262      24 -26.5886      25 -26.5822
+      26 -26.5869      27 -26.6326      28 -26.5512      29 -26.5516      30 -26.5507
+      31 -26.5926      32 -26.6177
+ 
+ 
+ 
+ E-fermi :   3.0783     XC(G=0): -11.0609     alpha+bet :-10.9574
+
+ Fermi energy:         3.0783040692
+
+ k-point     1 :       0.0000    0.0000    0.0000
+  band No.  band energies     occupation 
+      1      -3.0415      2.00000
+      2      -1.4762      2.00000
+      3      -1.4243      2.00000
+      4      -1.1901      2.00000
+      5      -1.1823      2.00000
+      6      -0.0426      2.00000
+      7      -0.0336      2.00000
+      8       0.0037      2.00000
+      9       0.0151      2.00000
+     10       0.4257      2.00000
+     11       0.5328      2.00000
+     12       0.5454      2.00000
+     13       0.5638      2.00000
+     14       0.5717      2.00000
+     15       0.5733      2.00000
+     16       0.5894      2.00000
+     17       0.7647      2.00000
+     18       0.7807      2.00000
+     19       0.7818      2.00000
+     20       0.8062      2.00000
+     21       0.8259      2.00000
+     22       0.9170      2.00000
+     23       0.9384      2.00000
+     24       0.9508      2.00000
+     25       1.0876      2.00000
+     26       1.0934      2.00000
+     27       1.1283      2.00000
+     28       1.1559      2.00000
+     29       1.2282      2.00000
+     30       1.2522      2.00000
+     31       1.2784      2.00000
+     32       1.3127      2.00000
+     33       1.3611      2.00000
+     34       1.4298      2.00000
+     35       1.5176      2.00000
+     36       1.7624      2.00000
+     37       1.8079      2.00000
+     38       1.8549      2.00000
+     39       1.8917      2.00000
+     40       2.1188      2.00000
+     41       2.1777      2.00000
+     42       2.2152      2.00000
+     43       2.2363      2.00000
+     44       2.2567      2.00000
+     45       2.2781      2.00000
+     46       2.2802      2.00000
+     47       2.2947      2.00000
+     48       2.4012      2.00002
+     49       2.4232      2.00004
+     50       2.4664      2.00013
+     51       2.4821      2.00021
+     52       2.5056      2.00039
+     53       2.5176      2.00054
+     54       2.5289      2.00072
+     55       2.5540      2.00132
+     56       2.5917      2.00311
+     57       2.6073      2.00432
+     58       2.6470      2.00934
+     59       2.6704      2.01405
+     60       2.7486      2.04168
+     61       2.9133      1.99235
+     62       2.9577      1.84289
+     63       2.9652      1.80809
+     64       3.0067      1.56474
+     65       3.1548      0.40187
+     66       3.1716      0.29756
+     67       3.1963      0.16904
+     68       3.2593     -0.02454
+     69       3.3987     -0.04593
+     70       3.4073     -0.04198
+     71       3.4932     -0.01248
+     72       3.5064     -0.00989
+     73       3.5267     -0.00678
+     74       3.5457     -0.00465
+     75       3.5472     -0.00451
+     76       3.6248     -0.00077
+     77       3.6442     -0.00047
+     78       3.6866     -0.00015
+     79       3.6997     -0.00010
+     80       3.7191     -0.00006
+     81       3.7382     -0.00003
+     82       3.7530     -0.00002
+     83       3.7625     -0.00001
+     84       3.7831     -0.00001
+     85       3.8159     -0.00000
+     86       3.8294     -0.00000
+     87       3.8337     -0.00000
+     88       3.8472     -0.00000
+     89       3.8706     -0.00000
+     90       3.9369     -0.00000
+     91       3.9542     -0.00000
+     92       4.0153     -0.00000
+     93       4.0762     -0.00000
+     94       4.1335     -0.00000
+     95       4.1629     -0.00000
+     96       4.2146     -0.00000
+     97       4.2218     -0.00000
+     98       4.2392     -0.00000
+     99       4.2563     -0.00000
+    100       4.2815     -0.00000
+    101       4.3030     -0.00000
+    102       4.3477     -0.00000
+    103       4.3656     -0.00000
+    104       4.3884     -0.00000
+    105       4.3996     -0.00000
+    106       4.4176     -0.00000
+    107       4.4418     -0.00000
+    108       4.4689     -0.00000
+    109       4.4931     -0.00000
+    110       4.5228     -0.00000
+    111       4.5478     -0.00000
+    112       4.5737     -0.00000
+    113       4.6128     -0.00000
+    114       4.6642     -0.00000
+    115       4.6973     -0.00000
+    116       4.7070     -0.00000
+    117       4.7531     -0.00000
+    118       4.7688     -0.00000
+    119       4.7892     -0.00000
+    120       4.8003     -0.00000
+    121       4.8368     -0.00000
+    122       4.8536     -0.00000
+    123       4.8721     -0.00000
+    124       4.9643     -0.00000
+    125       5.0242     -0.00000
+    126       5.0579     -0.00000
+    127       5.1246     -0.00000
+    128       5.2895     -0.00000
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+ soft charge-density along one line, spin component           1
+         0         1         2         3         4         5         6         7         8         9
+ total charge-density along one line
+ 
+ pseudopotential strength for first ion, spin component:           1
+ -3.647   0.003   0.005  -0.002   0.000  -3.649   0.003   0.006
+  0.003  -3.673  -0.001  -0.003   0.003   0.003  -3.679  -0.001
+  0.005  -0.001  -3.691   0.001   0.014   0.006  -0.001  -3.700
+ -0.002  -0.003   0.001  -3.698   0.003  -0.002  -0.004   0.002
+  0.000   0.003   0.014   0.003  -3.647   0.000   0.004   0.016
+ -3.649   0.003   0.006  -0.002   0.000  -3.529   0.004   0.007
+  0.003  -3.679  -0.001  -0.004   0.004   0.004  -3.564  -0.001
+  0.006  -0.001  -3.700   0.002   0.016   0.007  -0.001  -3.588
+ -0.002  -0.004   0.002  -3.708   0.003  -0.003  -0.005   0.002
+  0.000   0.004   0.016   0.003  -3.648   0.000   0.004   0.019
+  0.001   0.001   0.006  -0.001   0.004   0.001   0.001   0.007
+ -0.002  -0.002  -0.010   0.002  -0.008  -0.002  -0.003  -0.012
+ -0.002  -0.003   0.002  -0.000   0.003  -0.002  -0.003   0.003
+ -0.000  -0.002  -0.004  -0.000  -0.000  -0.000  -0.002  -0.004
+ -0.002  -0.000   0.001  -0.003   0.001  -0.002  -0.000   0.001
+ total augmentation occupancy for first ion, spin component:           1
+  2.936  -0.018  -0.019  -0.009  -0.010  -1.487   0.010   0.013   0.006  -0.017   0.039   0.001   0.004   0.000   0.119
+ -0.018   2.372  -0.000   0.041   0.069   0.011  -1.225   0.001  -0.033  -0.035  -0.023  -0.001  -0.020  -0.068   0.017
+ -0.019  -0.000   2.974  -0.007  -0.202   0.013   0.002  -1.422   0.004   0.152  -0.023  -0.007  -0.044   0.001  -0.013
+ -0.009   0.041  -0.007   2.589   0.005   0.005  -0.033   0.004  -1.383   0.004  -0.017  -0.000   0.010   0.018  -0.033
+ -0.010   0.069  -0.202   0.005   3.020  -0.017  -0.035   0.155   0.003  -1.533   0.148   0.008   0.145   0.017   0.017
+ -1.487   0.011   0.013   0.005  -0.017   0.768  -0.006  -0.009  -0.003   0.018  -0.029  -0.001  -0.013  -0.002  -0.043
+  0.010  -1.225   0.002  -0.033  -0.035  -0.006   0.649  -0.001   0.022   0.019   0.013   0.000   0.014   0.027  -0.007
+  0.013   0.001  -1.422   0.004   0.155  -0.009  -0.001   0.710  -0.002  -0.098   0.025   0.004   0.020   0.006   0.010
+  0.006  -0.033   0.004  -1.383   0.003  -0.003   0.022  -0.002   0.745  -0.005   0.012   0.000  -0.005  -0.007   0.019
+ -0.017  -0.035   0.152   0.004  -1.533   0.018   0.019  -0.098  -0.005   0.804  -0.116  -0.005  -0.053  -0.008  -0.007
+  0.039  -0.023  -0.023  -0.017   0.148  -0.029   0.013   0.025   0.012  -0.116   1.933   0.053  -0.015  -0.007   0.022
+  0.001  -0.001  -0.007  -0.000   0.008  -0.001   0.000   0.004   0.000  -0.005   0.053   0.002   0.001  -0.000   0.001
+  0.004  -0.020  -0.044   0.010   0.145  -0.013   0.014   0.020  -0.005  -0.053  -0.015   0.001   0.318   0.001   0.005
+  0.000  -0.068   0.001   0.018   0.017  -0.002   0.027   0.006  -0.007  -0.008  -0.007  -0.000   0.001   0.240  -0.001
+  0.119   0.017  -0.013  -0.033   0.017  -0.043  -0.007   0.010   0.019  -0.007   0.022   0.001   0.005  -0.001   0.312
+
+
+------------------------ aborting loop because EDIFF is reached ----------------------------------------
+
+
+    CHARGE:  cpu time      0.0190: real time      0.0191
+    FORLOC:  cpu time      0.0015: real time      0.0015
+    FORNL :  cpu time      0.1534: real time      0.1535
+    STRESS:  cpu time      0.4382: real time      0.4390
+    FORCOR:  cpu time      0.0143: real time      0.0143
+    FORHAR:  cpu time      0.0042: real time      0.0042
+    MIXING:  cpu time      0.0004: real time      0.0004
+    OFIELD:  cpu time      0.0000: real time      0.0000
+
+  FORCE on cell =-STRESS in cart. coord.  units (eV):
+  Direction    XX          YY          ZZ          XY          YZ          ZX
+  --------------------------------------------------------------------------------------
+  Alpha Z   650.40089   650.40089   650.40089
+  Ewald   -1384.88049 -1387.77038 -1334.15909    -1.44890    -0.01662     1.81232
+  Hartree    37.97456    38.74569    41.23105    -0.25933    -0.21632     0.55051
+  E(xc)    -485.40458  -488.33503  -487.22648     0.04654    -0.01320    -0.04737
+  Local     265.39868   261.87407   240.78126     1.29681     0.39461    -2.03463
+  n-local  -126.79999  -110.68611  -110.29464    -0.13040    -0.03484     0.04209
+  augment   191.07075   196.82613   191.56805     0.05259    -0.02874    -0.02110
+  Kinetic   800.23949   841.88136   808.34273     0.16572    -0.18027    -0.04192
+  Fock        0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+  -------------------------------------------------------------------------------------
+  Total     -52.00069     2.93661     0.64378    -0.27698    -0.09539     0.25990
+  in kB    -150.15310     8.47953     1.85892    -0.79979    -0.27543     0.75046
+  external pressure =      -46.60 kB  Pullay stress =        0.00 kB
+
+  kinetic pressure (ideal gas correction) =      2.50 kB
+  total pressure  =    -44.10 kB
+  Total+kin.  -147.821      10.894       4.613      -1.132       0.075       0.379
+
+ VOLUME and BASIS-vectors are now :
+ -----------------------------------------------------------------------------
+  energy-cutoff  :      350.00
+  volume of cell :      554.86
+      direct lattice vectors                 reciprocal lattice vectors
+     5.871982203  0.000000000  0.000000000     0.170300244  0.000000000  0.000000000
+     0.000000000 10.165611494  0.000000000     0.000000000  0.098370865  0.000000000
+     0.000000000  0.000000000  9.295380000     0.000000000  0.000000000  0.107580325
+
+  length of vectors
+     5.871982203 10.165611494  9.295380000     0.170300244  0.098370865  0.107580325
+
+
+ FORCES acting on ions
+    electron-ion (+dipol)            ewald-force                    non-local-force                 convergence-correction
+ -----------------------------------------------------------------------------------------------
+   0.272E+01 -.821E+00 -.314E+01   -.269E+01 0.648E+00 0.335E+01   -.130E+00 0.602E+00 -.658E-01   -.354E-03 -.512E-03 0.269E-02
+   0.346E+01 0.339E+01 0.221E+01   -.354E+01 -.321E+01 -.250E+01   -.475E-01 -.535E+00 0.125E+00   -.886E-03 0.390E-03 -.683E-03
+   0.223E+01 -.310E+00 0.233E+01   -.236E+01 0.627E+00 -.204E+01   -.787E-01 -.712E+00 0.463E+00   -.117E-03 -.435E-03 -.432E-03
+   -.231E+01 0.213E+00 -.161E+01   0.231E+01 -.464E+00 0.172E+01   0.139E+00 0.493E+00 -.169E+00   -.694E-04 0.863E-05 0.271E-02
+   0.189E+01 -.102E+02 0.209E+01   -.199E+01 0.106E+02 -.218E+01   -.182E+00 0.593E+00 -.277E-01   -.139E-03 -.189E-02 -.270E-02
+   -.246E+01 0.456E+00 0.256E+01   0.272E+01 -.211E+00 -.263E+01   0.526E-01 -.429E+00 -.295E+00   -.536E-03 0.501E-03 0.720E-03
+   0.170E+01 -.344E+01 -.114E+01   -.187E+01 0.371E+01 0.614E+00   -.424E-02 -.473E+00 -.183E+00   -.215E-03 -.559E-03 0.526E-03
+   0.375E+01 0.175E+01 -.201E+01   -.385E+01 -.228E+01 0.201E+01   -.288E-01 0.463E+00 -.214E-01   -.190E-03 0.276E-03 -.272E-02
+   0.985E+00 -.189E+01 0.110E+00   -.102E+01 0.196E+01 0.765E-01   -.125E+00 0.857E+00 0.184E+00   -.963E-03 0.393E-03 0.250E-02
+   -.221E+01 0.199E+01 0.951E+01   0.220E+01 -.192E+01 -.101E+02   0.203E+00 -.462E+00 -.343E+00   -.759E-03 -.387E-03 0.582E-03
+   0.228E+00 -.376E+01 -.821E-01   -.259E+00 0.414E+01 -.542E-02   0.115E+00 -.553E+00 0.500E-02   0.201E-03 0.175E-03 0.425E-04
+   0.671E+00 -.388E+01 -.461E+01   -.713E+00 0.396E+01 0.478E+01   -.108E+00 0.646E+00 0.272E+00   -.188E-04 -.564E-04 0.230E-02
+   0.278E+01 0.493E+00 0.164E+01   -.313E+01 -.653E+00 -.200E+01   -.450E-01 0.970E-01 -.508E-01   -.708E-03 0.136E-02 -.246E-02
+   0.151E+01 0.141E+00 -.957E+01   -.170E+01 0.212E-01 0.106E+02   0.144E+00 -.378E+00 0.378E+00   -.266E-03 -.578E-03 -.966E-03
+   -.211E+01 0.404E+01 -.304E+01   0.238E+01 -.389E+01 0.356E+01   0.382E-02 -.606E+00 0.526E-01   0.111E-03 0.448E-03 -.411E-03
+   -.359E+01 0.890E+01 0.350E+01   0.400E+01 -.995E+01 -.335E+01   -.748E-01 0.260E+00 0.821E-02   -.508E-03 0.410E-04 -.221E-02
+   -.383E+01 -.326E+00 -.211E+01   0.424E+01 0.206E+00 0.196E+01   0.972E-01 0.413E+00 -.885E-02   0.342E-03 -.180E-03 0.269E-02
+   -.274E+01 0.199E+01 0.538E+01   0.274E+01 -.192E+01 -.565E+01   0.818E-01 -.102E+00 -.192E+00   0.883E-03 0.737E-03 -.817E-03
+   -.218E+01 -.292E+01 0.626E+01   0.224E+01 0.317E+01 -.647E+01   0.113E+00 -.362E+00 -.367E+00   0.144E-03 -.256E-03 -.628E-03
+   0.285E+01 0.384E+01 -.565E+01   -.297E+01 -.432E+01 0.599E+01   -.121E+00 0.210E+00 0.295E+00   -.364E-05 0.236E-03 0.273E-02
+   -.108E+01 -.589E+01 0.309E+01   0.112E+01 0.587E+01 -.345E+01   0.260E+00 0.434E+00 -.140E+00   0.129E-03 -.144E-02 -.270E-02
+   0.204E+01 -.127E+01 -.338E+01   -.207E+01 0.149E+01 0.330E+01   -.138E+00 -.462E+00 0.258E+00   0.538E-03 0.876E-03 0.746E-03
+   -.157E+01 -.217E+01 -.451E+01   0.162E+01 0.262E+01 0.489E+01   0.673E-01 -.443E+00 0.312E+00   0.259E-03 -.209E-03 0.516E-03
+   -.392E+01 -.130E+00 -.563E+00   0.393E+01 -.885E-01 0.989E+00   0.125E+00 0.508E+00 0.408E-01   0.201E-03 0.249E-03 -.294E-02
+   -.108E+01 0.287E+01 0.432E+01   0.992E+00 -.347E+01 -.508E+01   0.115E+00 0.168E+00 -.275E+00   0.114E-02 0.611E-03 0.264E-02
+   0.236E+01 0.230E+01 0.718E+01   -.250E+01 -.216E+01 -.740E+01   -.221E+00 -.284E+00 -.187E+00   0.802E-03 -.400E-03 0.281E-03
+   -.889E+00 -.103E+01 -.232E+01   0.110E+01 0.163E+01 0.279E+01   -.357E-02 -.645E+00 0.275E+00   -.230E-03 0.264E-03 -.364E-04
+   -.191E-01 -.220E+01 -.114E+01   -.102E+00 0.204E+01 0.119E+01   -.581E-01 0.504E-01 -.130E+00   0.846E-05 -.735E-03 0.289E-02
+   -.189E+01 -.436E+01 0.123E+01   0.201E+01 0.438E+01 -.113E+01   0.286E-01 0.665E+00 0.479E-01   0.756E-03 0.156E-02 -.265E-02
+   -.467E+00 0.187E+01 -.711E+01   0.250E+00 -.175E+01 0.717E+01   -.152E-01 -.491E+00 0.121E-01   0.307E-03 -.626E-03 -.345E-03
+   0.132E+01 0.257E+01 -.311E+01   -.129E+01 -.237E+01 0.287E+01   0.333E-01 -.327E+00 -.847E-02   -.215E-04 0.411E-03 -.747E-05
+   0.182E+01 0.775E+01 0.359E+01   -.182E+01 -.841E+01 -.388E+01   -.163E+00 0.790E+00 -.169E+00   0.485E-03 -.545E-03 -.292E-02
+ -----------------------------------------------------------------------------------------------
+   -.351E-01 0.177E-01 -.970E-01   0.164E-13 -.195E-13 0.444E-13   0.349E-01 -.156E-01 0.980E-01   0.324E-03 -.285E-03 -.107E-02
+ 
+ 
+ POSITION                                       TOTAL-FORCE (eV/Angst)
+ -----------------------------------------------------------------------------------
+      0.19928      0.46431      1.11318        -0.096170      0.428988      0.148203
+      0.30136      3.93065      3.52343        -0.134825     -0.347534     -0.168248
+      1.72738      1.36534      3.43936        -0.205251     -0.396006      0.747604
+      1.69592      3.05420      1.14241         0.139203      0.242245     -0.057927
+      0.28785      0.48957      5.81083        -0.284430      1.042296     -0.120273
+      0.17035      3.89112      8.14171         0.313168     -0.184057     -0.367164
+      1.74217      1.36858      8.20133        -0.179336     -0.204486     -0.712401
+      1.74675      3.09319      5.80556        -0.125077     -0.064238     -0.020551
+      0.29966      5.52105      1.12134        -0.158519      0.931329      0.372750
+      0.20709      9.02253      3.55783         0.193617     -0.397138     -0.936827
+      1.69773      6.42805      3.50240         0.083855     -0.172193     -0.082474
+      1.73762      8.04650      1.08057        -0.150873      0.721752      0.440370
+      0.30313      5.64119      5.84771        -0.397487     -0.061162     -0.416364
+      0.32016      8.99214      7.98818        -0.045417     -0.216190      1.400061
+      1.69355      6.49787      8.04015         0.276496     -0.453234      0.577277
+      1.66385      8.29479      5.75304         0.330694     -0.794107      0.158491
+      3.08199      0.47154      1.17663         0.512758      0.292947     -0.154250
+      3.17430      3.90467      3.52450         0.082345     -0.036879     -0.457972
+      4.61432      1.34867      3.51486         0.171990     -0.111473     -0.574358
+      4.66627      3.10230      1.08617        -0.233489     -0.273542      0.639832
+      3.14933      0.50907      5.86138         0.294224      0.412969     -0.499146
+      3.17456      3.92439      8.12555        -0.162024     -0.236549      0.176803
+      4.63470      1.34754      8.07574         0.119141      0.004409      0.696336
+      4.62886      3.06345      5.75141         0.133858      0.289386      0.464157
+      3.18014      5.67115      1.26746         0.027807     -0.439333     -1.029526
+      3.23243      8.98314      3.52243        -0.358752     -0.145623     -0.405847
+      4.66457      6.40725      3.42617         0.209547     -0.049814      0.747763
+      4.73034      8.12276      1.14394        -0.179117     -0.111276     -0.070448
+      3.20451      5.56114      5.81825         0.145687      0.691519      0.148339
+      3.24468      9.00605      8.10746        -0.232071     -0.366913      0.073082
+      4.63630      6.47137      8.12419         0.067868     -0.125053     -0.252075
+      4.60681      8.20968      5.83847        -0.159353      0.130727     -0.465234
+ -----------------------------------------------------------------------------------
+    total drift:                                0.000068      0.001768     -0.000018
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+  FREE ENERGIE OF THE ION-ELECTRON SYSTEM (eV)
+  ---------------------------------------------------
+  free  energy   TOTEN  =      -252.38626263 eV
+
+  energy  without entropy=     -252.36530395  energy(sigma->0) =     -252.37927641
+ 
+ d Force =-0.1286529E+00[-0.135E+00,-0.122E+00]  d Energy =-0.1286435E+00-0.945E-05
+ d Force =-0.1074575E+01[-0.113E+01,-0.102E+01]  d Ewald  =-0.1074589E+01 0.143E-04
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+    POTLOK:  cpu time      0.0205: real time      0.0205
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+           RANDOM_SEED =         223274761                0                0
+   IONSTEP:  cpu time      0.0002: real time      0.0002
+
+  ENERGY OF THE ELECTRON-ION-THERMOSTAT SYSTEM (eV)
+  ---------------------------------------------------
+% ion-electron   TOTEN  =      -252.386263  see above
+  kinetic energy EKIN   =         1.232824
+  kin. lattice  EKIN_LAT=         0.000000  (temperature  307.66 K)
+  nose potential ES     =         0.000000
+  nose kinetic   EPS    =         0.000000
+  ---------------------------------------------------
+  total energy   ETOTAL =      -251.153438 eV
+
+  maximum distance moved by ions :      0.18E-02
+
+
+ mean value of Nose-termostat <S>:     1.000 mean value of <T> :   424.929
+ mean temperature <T/S>/<1/S>  :   424.929
+
+ Prediction of Wavefunctions ALPHA= 2.076 BETA=-1.077
+    WAVPRE:  cpu time      0.0300: real time      0.0341
+    FEWALD:  cpu time      0.0005: real time      0.0005
+    ORTHCH:  cpu time      0.0250: real time      0.0250
+    POTLOK:  cpu time      0.0197: real time      0.0199
+    EDDIAG:  cpu time      0.0292: real time      0.0295
+     LOOP+:  cpu time      3.6752: real time      3.7288
+    4ORBIT:  cpu time      0.0000: real time      0.0000
+
+ total amount of memory used by VASP MPI-rank0    63963. kBytes
+=======================================================================
+
+   base      :      30000. kBytes
+   nonlr-proj:      24207. kBytes
+   fftplans  :       1514. kBytes
+   grid      :       7057. kBytes
+   one-center:        345. kBytes
+   wavefun   :        840. kBytes
+ 
+  
+  
+ General timing and accounting informations for this job:
+ ========================================================
+  
+                  Total CPU time used (sec):       46.642
+                            User time (sec):       43.138
+                          System time (sec):        3.504
+                         Elapsed time (sec):       50.687
+  
+                   Maximum memory used (kb):      256040.
+                   Average memory used (kb):          N/A
+  
+                          Minor page faults:        75566
+                          Major page faults:            0
+                 Voluntary context switches:         7193

--- a/tests/poscars/Ti-aimd-nwrite0/vasprun.xml
+++ b/tests/poscars/Ti-aimd-nwrite0/vasprun.xml
@@ -1,0 +1,3348 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<modeling>
+ <generator>
+  <i name="program" type="string">vasp </i>
+  <i name="version" type="string">6.3.0  </i>
+  <i name="subversion" type="string">20Jan22 (build Apr 09 2022 18:33:31) complex                          parallel </i>
+  <i name="platform" type="string">LinuxIFC </i>
+  <i name="date" type="string">2025 07 07 </i>
+  <i name="time" type="string">11:37:14 </i>
+ </generator>
+ <incar>
+  <i type="string" name="SYSTEM">dpgen</i>
+  <i type="int" name="ISTART">     0</i>
+  <i type="string" name="PREC">Accurate</i>
+  <i type="string" name="ALGO">Normal</i>
+  <i type="int" name="ICHARG">     2</i>
+  <i type="int" name="NELM">   100</i>
+  <i type="int" name="NELMDL">    -5</i>
+  <i type="int" name="NELMIN">     6</i>
+  <i type="int" name="IBRION">     0</i>
+  <i name="EDIFF">      0.00000100</i>
+  <i type="int" name="NSW">    10</i>
+  <i type="int" name="ISIF">     2</i>
+  <i type="int" name="ISYM">     0</i>
+  <i name="ENCUT">    350.00000000</i>
+  <i name="POTIM">      2.00000000</i>
+  <i name="TEBEG">    500.00000000</i>
+  <i name="TEEND">    500.00000000</i>
+  <i type="string" name="LREAL">A</i>
+  <i type="int" name="ISMEAR">     1</i>
+  <i name="SIGMA">      0.20000000</i>
+  <i name="KSPACING">      5.00000000</i>
+  <i type="logical" name="KGAMMA"> F  </i>
+  <i type="int" name="NWRITE">     0</i>
+  <i name="PSTRESS">      0.00000000</i>
+  <i type="logical" name="LWAVE"> F  </i>
+  <i type="logical" name="LCHARG"> F  </i>
+ </incar>
+ <primitive_cell>
+  <structure name="primitive_cell" >
+   <crystal>
+    <varray name="basis" >
+     <v>       5.87198220       0.00000000       0.00000000 </v>
+     <v>       0.00000000      10.16561149       0.00000000 </v>
+     <v>       0.00000000       0.00000000       9.29538000 </v>
+    </varray>
+    <i name="volume">    554.86251651 </i>
+    <varray name="rec_basis" >
+     <v>       0.17030024       0.00000000       0.00000000 </v>
+     <v>       0.00000000       0.09837087       0.00000000 </v>
+     <v>       0.00000000       0.00000000       0.10758032 </v>
+    </varray>
+   </crystal>
+   <varray name="positions" >
+    <v>       0.04232415       0.05125151       0.12401821 </v>
+    <v>       0.04233768       0.38453412       0.37401556 </v>
+    <v>       0.29233207       0.13453320       0.37401602 </v>
+    <v>       0.29233083       0.30125165       0.12401755 </v>
+    <v>       0.04232415       0.05125151       0.62401821 </v>
+    <v>       0.04233768       0.38453412       0.87401556 </v>
+    <v>       0.29233207       0.13453320       0.87401602 </v>
+    <v>       0.29233083       0.30125165       0.62401755 </v>
+    <v>       0.04232415       0.55125151       0.12401821 </v>
+    <v>       0.04233768       0.88453412       0.37401556 </v>
+    <v>       0.29233207       0.63453320       0.37401602 </v>
+    <v>       0.29233083       0.80125165       0.12401755 </v>
+    <v>       0.04232415       0.55125151       0.62401821 </v>
+    <v>       0.04233768       0.88453412       0.87401556 </v>
+    <v>       0.29233207       0.63453320       0.87401602 </v>
+    <v>       0.29233083       0.80125165       0.62401755 </v>
+    <v>       0.54232415       0.05125151       0.12401821 </v>
+    <v>       0.54233768       0.38453412       0.37401556 </v>
+    <v>       0.79233207       0.13453320       0.37401602 </v>
+    <v>       0.79233083       0.30125165       0.12401755 </v>
+    <v>       0.54232415       0.05125151       0.62401821 </v>
+    <v>       0.54233768       0.38453412       0.87401556 </v>
+    <v>       0.79233207       0.13453320       0.87401602 </v>
+    <v>       0.79233083       0.30125165       0.62401755 </v>
+    <v>       0.54232415       0.55125151       0.12401821 </v>
+    <v>       0.54233768       0.88453412       0.37401556 </v>
+    <v>       0.79233207       0.63453320       0.37401602 </v>
+    <v>       0.79233083       0.80125165       0.12401755 </v>
+    <v>       0.54232415       0.55125151       0.62401821 </v>
+    <v>       0.54233768       0.88453412       0.87401556 </v>
+    <v>       0.79233207       0.63453320       0.87401602 </v>
+    <v>       0.79233083       0.80125165       0.62401755 </v>
+   </varray>
+  </structure>
+  <varray name="primitive_index" >
+   <v type="int" >        1 </v>
+   <v type="int" >        2 </v>
+   <v type="int" >        3 </v>
+   <v type="int" >        4 </v>
+   <v type="int" >        5 </v>
+   <v type="int" >        6 </v>
+   <v type="int" >        7 </v>
+   <v type="int" >        8 </v>
+   <v type="int" >        9 </v>
+   <v type="int" >       10 </v>
+   <v type="int" >       11 </v>
+   <v type="int" >       12 </v>
+   <v type="int" >       13 </v>
+   <v type="int" >       14 </v>
+   <v type="int" >       15 </v>
+   <v type="int" >       16 </v>
+   <v type="int" >       17 </v>
+   <v type="int" >       18 </v>
+   <v type="int" >       19 </v>
+   <v type="int" >       20 </v>
+   <v type="int" >       21 </v>
+   <v type="int" >       22 </v>
+   <v type="int" >       23 </v>
+   <v type="int" >       24 </v>
+   <v type="int" >       25 </v>
+   <v type="int" >       26 </v>
+   <v type="int" >       27 </v>
+   <v type="int" >       28 </v>
+   <v type="int" >       29 </v>
+   <v type="int" >       30 </v>
+   <v type="int" >       31 </v>
+   <v type="int" >       32 </v>
+  </varray>
+ </primitive_cell>
+ <kpoints>
+  <generation param="Monkhorst-Pack">
+   <v type="int" name="divisions">       1        1        1 </v>
+   <v name="usershift">      0.00000000       0.00000000       0.00000000 </v>
+   <v name="genvec1">      1.00000000       0.00000000       0.00000000 </v>
+   <v name="genvec2">      0.00000000       1.00000000       0.00000000 </v>
+   <v name="genvec3">      0.00000000       0.00000000       1.00000000 </v>
+   <v name="shift">      0.00000000       0.00000000       0.00000000 </v>
+  </generation>
+  <varray name="kpointlist" >
+   <v>       0.00000000       0.00000000       0.00000000 </v>
+  </varray>
+  <varray name="weights" >
+   <v>       1.00000000 </v>
+  </varray>
+ </kpoints>
+ <parameters>
+  <separator name="general" >
+   <i type="string" name="SYSTEM">dpgen</i>
+   <i type="logical" name="LCOMPAT"> F  </i>
+  </separator>
+  <separator name="electronic" >
+   <i type="string" name="PREC">accura</i>
+   <i name="ENMAX">    350.00000000</i>
+   <i name="ENAUG">    328.88300000</i>
+   <i name="EDIFF">      0.00000100</i>
+   <i type="int" name="IALGO">    38</i>
+   <i type="int" name="IWAVPR">    12</i>
+   <i type="int" name="NBANDS">   128</i>
+   <i type="int" name="NBANDSLOW">    -1</i>
+   <i type="int" name="NBANDSHIGH">    -1</i>
+   <i name="NELECT">    128.00000000</i>
+   <i type="int" name="TURBO">     0</i>
+   <i type="int" name="IRESTART">     0</i>
+   <i type="int" name="NREBOOT">     0</i>
+   <i type="int" name="NMIN">     0</i>
+   <i name="EREF">      0.00000000</i>
+   <separator name="electronic smearing" >
+    <i type="int" name="ISMEAR">     1</i>
+    <i name="SIGMA">      0.20000000</i>
+    <i name="KSPACING">      5.00000000</i>
+    <i type="logical" name="KGAMMA"> F  </i>
+    <i type="logical" name="KBLOWUP"> T  </i>
+   </separator>
+   <separator name="electronic projectors" >
+    <i type="logical" name="LREAL"> T  </i>
+    <v name="ROPT">     -0.00025000</v>
+    <i type="int" name="LMAXPAW">  -100</i>
+    <i type="int" name="LMAXMIX">     2</i>
+    <i type="logical" name="NLSPLINE"> F  </i>
+   </separator>
+   <separator name="electronic startup" >
+    <i type="int" name="ISTART">     0</i>
+    <i type="int" name="ICHARG">     2</i>
+    <i type="int" name="INIWAV">     1</i>
+   </separator>
+   <separator name="electronic spin" >
+    <i type="int" name="ISPIN">     1</i>
+    <i type="logical" name="LNONCOLLINEAR"> F  </i>
+    <v name="MAGMOM">      1.00000000      1.00000000      1.00000000      1.00000000      1.00000000      1.00000000      1.00000000      1.00000000      1.00000000      1.00000000      1.00000000      1.00000000      1.00000000      1.00000000      1.00000000      1.00000000      1.00000000      1.00000000      1.00000000      1.00000000
+      1.00000000      1.00000000      1.00000000      1.00000000      1.00000000      1.00000000      1.00000000      1.00000000      1.00000000      1.00000000      1.00000000      1.00000000</v>
+    <i name="NUPDOWN">     -1.00000000</i>
+    <i type="logical" name="LSORBIT"> F  </i>
+    <v name="SAXIS">      0.00000000      0.00000000      1.00000000</v>
+    <i type="logical" name="LSPIRAL"> F  </i>
+    <v name="QSPIRAL">      0.00000000      0.00000000      0.00000000</v>
+    <i type="logical" name="LZEROZ"> F  </i>
+   </separator>
+   <separator name="electronic exchange-correlation" >
+    <i type="logical" name="LASPH"> F  </i>
+    <i type="logical" name="LMETAGGA"> F  </i>
+   </separator>
+   <separator name="electronic convergence" >
+    <i type="int" name="NELM">   100</i>
+    <i type="int" name="NELMDL">    -5</i>
+    <i type="int" name="NELMIN">     6</i>
+    <i name="ENINI">    350.00000000</i>
+    <separator name="electronic convergence detail" >
+     <i type="logical" name="LDIAG"> T  </i>
+     <i type="logical" name="LSUBROT"> F  </i>
+     <i name="WEIMIN">      0.00100000</i>
+     <i name="EBREAK">      0.00000000</i>
+     <i name="DEPER">      0.30000000</i>
+     <i type="int" name="NRMM">     4</i>
+     <i name="TIME">      0.40000000</i>
+    </separator>
+   </separator>
+   <separator name="electronic mixer" >
+    <i name="AMIX">      0.40000000</i>
+    <i name="BMIX">      1.00000000</i>
+    <i name="AMIN">      0.10000000</i>
+    <i name="AMIX_MAG">      1.60000000</i>
+    <i name="BMIX_MAG">      1.00000000</i>
+    <separator name="electronic mixer details" >
+     <i type="int" name="IMIX">     4</i>
+     <i type="logical" name="MIXFIRST"> F  </i>
+     <i type="int" name="MAXMIX">   -45</i>
+     <i name="WC">    100.00000000</i>
+     <i type="int" name="INIMIX">     1</i>
+     <i type="int" name="MIXPRE">     1</i>
+     <i type="int" name="MREMOVE">     5</i>
+    </separator>
+   </separator>
+   <separator name="electronic dipolcorrection" >
+    <i type="logical" name="LDIPOL"> F  </i>
+    <i type="logical" name="LMONO"> F  </i>
+    <i type="int" name="IDIPOL">     0</i>
+    <i name="EPSILON">      1.00000000</i>
+    <v name="DIPOL">   -100.00000000   -100.00000000   -100.00000000</v>
+    <i name="EFIELD">      0.00000000</i>
+   </separator>
+  </separator>
+  <separator name="grids" >
+   <i type="int" name="NGX">    36</i>
+   <i type="int" name="NGY">    64</i>
+   <i type="int" name="NGZ">    60</i>
+   <i type="int" name="NGXF">    72</i>
+   <i type="int" name="NGYF">   128</i>
+   <i type="int" name="NGZF">   120</i>
+   <i type="logical" name="ADDGRID"> F  </i>
+  </separator>
+  <separator name="ionic" >
+   <i type="int" name="NSW">    10</i>
+   <i type="int" name="IBRION">     0</i>
+   <i type="int" name="MDALGO">     0</i>
+   <i type="int" name="ISIF">     2</i>
+   <i name="PSTRESS">      0.00000000</i>
+   <i name="EDIFFG">      0.00001000</i>
+   <i type="int" name="NFREE">     0</i>
+   <i name="POTIM">      2.00000000</i>
+   <i name="SMASS">     -3.00000000</i>
+   <i name="SCALEE">      1.00000000</i>
+  </separator>
+  <separator name="ionic md" >
+   <i name="TEBEG">    500.00000000</i>
+   <i name="TEEND">    500.00000000</i>
+   <i type="int" name="NBLOCK">     1</i>
+   <i type="int" name="KBLOCK">    10</i>
+   <i type="int" name="NPACO">   256</i>
+   <i name="APACO">     10.00000000</i>
+  </separator>
+  <separator name="symmetry" >
+   <i type="int" name="ISYM">     0</i>
+   <i name="SYMPREC">      0.00001000</i>
+  </separator>
+  <separator name="dos" >
+   <i type="int" name="LORBIT">     0</i>
+   <v name="RWIGS">     -1.00000000</v>
+   <i type="int" name="NEDOS">   301</i>
+   <i name="EMIN">     10.00000000</i>
+   <i name="EMAX">    -10.00000000</i>
+   <i name="EFERMI">      0.00000000</i>
+  </separator>
+  <separator name="writing" >
+   <i type="int" name="NWRITE">     0</i>
+   <i type="logical" name="LWAVE"> F  </i>
+   <i type="logical" name="LDOWNSAMPLE"> F  </i>
+   <i type="logical" name="LCHARG"> F  </i>
+   <i type="logical" name="LPARD"> F  </i>
+   <i type="logical" name="LVTOT"> F  </i>
+   <i type="logical" name="LVHAR"> F  </i>
+   <i type="logical" name="LELF"> F  </i>
+   <i type="logical" name="LOPTICS"> F  </i>
+   <v name="STM">      0.00000000      0.00000000      0.00000000      0.00000000      0.00000000      0.00000000      0.00000000</v>
+  </separator>
+  <separator name="performance" >
+   <i type="int" name="NPAR">    64</i>
+   <i type="int" name="NSIM">     4</i>
+   <i type="int" name="NBLK">    -1</i>
+   <i type="logical" name="LPLANE"> T  </i>
+   <i type="logical" name="LSCALAPACK"> T  </i>
+   <i type="logical" name="LSCAAWARE"> F  </i>
+   <i type="logical" name="LSCALU"> F  </i>
+   <i type="logical" name="LASYNC"> F  </i>
+   <i type="logical" name="LORBITALREAL"> F  </i>
+  </separator>
+  <separator name="miscellaneous" >
+   <i type="int" name="IDIOT">     3</i>
+   <i type="int" name="PHON_NSTRUCT">    -1</i>
+   <i type="logical" name="LMUSIC"> F  </i>
+   <v name="POMASS">     47.88000000</v>
+   <v name="DARWINR">      0.00000000</v>
+   <v name="DARWINV">      1.00000000</v>
+   <i type="logical" name="LCORR"> T  </i>
+  </separator>
+  <i type="logical" name="GGA_COMPAT"> T  </i>
+  <i type="logical" name="LBERRY"> F  </i>
+  <i type="int" name="ICORELEVEL">     0</i>
+  <i type="logical" name="LDAU"> F  </i>
+  <i type="int" name="I_CONSTRAINED_M">     0</i>
+  <separator name="electronic exchange-correlation" >
+   <i type="string" name="GGA">--</i>
+   <i type="int" name="VOSKOWN">     0</i>
+   <i type="logical" name="LHFCALC"> F  </i>
+   <i type="string" name="PRECFOCK"></i>
+   <i type="logical" name="LSYMGRAD"> F  </i>
+   <i type="logical" name="LHFONE"> F  </i>
+   <i type="logical" name="LRHFCALC"> F  </i>
+   <i type="logical" name="LTHOMAS"> F  </i>
+   <i type="logical" name="LMODELHF"> F  </i>
+   <i type="logical" name="LFOCKACE"> F  </i>
+   <i name="ENCUT4O">     -1.00000000</i>
+   <i type="int" name="EXXOEP">     0</i>
+   <i type="int" name="FOURORBIT">     0</i>
+   <i name="AEXX">      0.00000000</i>
+   <i name="HFALPHA">      0.00000000</i>
+   <i name="MCALPHA">      0.00000000</i>
+   <i name="ALDAX">      1.00000000</i>
+   <i name="AGGAX">      1.00000000</i>
+   <i name="ALDAC">      1.00000000</i>
+   <i name="AGGAC">      1.00000000</i>
+   <i type="int" name="NKREDX">     1</i>
+   <i type="int" name="NKREDY">     1</i>
+   <i type="int" name="NKREDZ">     1</i>
+   <i type="logical" name="SHIFTRED"> F  </i>
+   <i type="logical" name="ODDONLY"> F  </i>
+   <i type="logical" name="EVENONLY"> F  </i>
+   <i type="int" name="LMAXFOCK">     0</i>
+   <i type="int" name="NMAXFOCKAE">     0</i>
+   <i type="logical" name="LFOCKAEDFT"> F  </i>
+   <i name="HFSCREEN">      0.00000000</i>
+   <i name="HFSCREENC">      0.00000000</i>
+   <i type="int" name="NBANDSGWLOW">     0</i>
+  </separator>
+  <separator name="vdW DFT" >
+   <i type="logical" name="LUSE_VDW"> F  </i>
+   <i name="Zab_VDW">     -0.84910000</i>
+   <i name="PARAM1">      0.12340000</i>
+   <i name="PARAM2">      1.00000000</i>
+   <i name="PARAM3">      0.00000000</i>
+  </separator>
+  <separator name="model GW" >
+   <i type="int" name="MODEL_GW">     0</i>
+   <i name="MODEL_EPS0">     10.40367218</i>
+   <i name="MODEL_ALPHA">      1.00000000</i>
+  </separator>
+  <separator name="linear response parameters" >
+   <i type="logical" name="LEPSILON"> F  </i>
+   <i type="logical" name="LRPA"> F  </i>
+   <i type="logical" name="LNABLA"> F  </i>
+   <i type="logical" name="LVEL"> F  </i>
+   <i name="CSHIFT">      0.10000000</i>
+   <i name="OMEGAMAX">     -1.00000000</i>
+   <i name="DEG_THRESHOLD">      0.00200000</i>
+   <i name="RTIME">     -0.10000000</i>
+   <i name="WPLASMAI">      0.00000000</i>
+   <v name="DFIELD">      0.00000000      0.00000000      0.00000000</v>
+   <v name="WPLASMA">      0.00000000      0.00000000      0.00000000      0.00000000      0.00000000      0.00000000      0.00000000      0.00000000      0.00000000</v>
+  </separator>
+  <separator name="orbital magnetization" >
+   <i type="logical" name="NUCIND"> F  </i>
+   <v name="MAGPOS">      0.00000000      0.00000000      0.00000000</v>
+   <i type="logical" name="LNICSALL"> T  </i>
+   <i type="logical" name="ORBITALMAG"> F  </i>
+   <i type="logical" name="LMAGBLOCH"> F  </i>
+   <i type="logical" name="LCHIMAG"> F  </i>
+   <i type="logical" name="LGAUGE"> T  </i>
+   <i type="int" name="MAGATOM">     0</i>
+   <v name="MAGDIPOL">      0.00000000      0.00000000      0.00000000</v>
+   <v name="AVECCONST">      0.00000000      0.00000000      0.00000000</v>
+  </separator>
+  <separator name="response functions" >
+   <i type="logical" name="LFINITE_TEMPERATURE"> F  </i>
+   <i type="logical" name="LADDER"> F  </i>
+   <i type="logical" name="LRPAFORCE"> F  </i>
+   <i type="logical" name="LFXC"> F  </i>
+   <i type="logical" name="LHARTREE"> T  </i>
+   <i type="int" name="IBSE">     0</i>
+   <v type="int" name="KPOINT">    -1     0     0     0</v>
+   <i type="logical" name="LTCTC"> F  </i>
+   <i type="logical" name="LTCTE"> F  </i>
+   <i type="logical" name="LTETE"> F  </i>
+   <i type="logical" name="LTRIPLET"> F  </i>
+   <i type="logical" name="LFXCEPS"> F  </i>
+   <i type="logical" name="LFXHEG"> F  </i>
+   <i type="int" name="NATURALO">     2</i>
+   <i type="logical" name="LHOLEGF"> F  </i>
+   <i type="logical" name="L2ORDER"> F  </i>
+   <i type="logical" name="LDMP1"> F  </i>
+   <i type="logical" name="LMP2LT"> F  </i>
+   <i type="logical" name="LSMP2LT"> F  </i>
+   <i type="logical" name="LGWLF"> F  </i>
+   <i name="ENCUTGW">     -2.00000000</i>
+   <i name="ENCUTGWSOFT">     -2.00000000</i>
+   <i name="ENCUTLF">     -1.00000000</i>
+   <i type="logical" name="LESF_SPLINES"> F  </i>
+   <i type="int" name="LMAXMP2">    -1</i>
+   <i name="SCISSOR">      0.00000000</i>
+   <i type="int" name="NOMEGA">     0</i>
+   <i type="int" name="NOMEGAR">     0</i>
+   <i type="int" name="NBANDSGW">    -1</i>
+   <i type="int" name="NBANDSO">    -1</i>
+   <i type="int" name="NBANDSV">    -1</i>
+   <i type="int" name="NELMGW">     1</i>
+   <i type="int" name="NELMHF">     1</i>
+   <i type="int" name="DIM">     3</i>
+   <i type="int" name="IESPILON">     4</i>
+   <i type="int" name="ANTIRES">     0</i>
+   <i name="OMEGAMAX">    -30.00000000</i>
+   <i name="OMEGAMIN">    -30.00000000</i>
+   <i name="OMEGATL">   -200.00000000</i>
+   <i type="int" name="OMEGAGRID">     0</i>
+   <i name="CSHIFT">     -0.10000000</i>
+   <i type="logical" name="LSELFENERGY"> F  </i>
+   <i type="logical" name="LSPECTRAL"> F  </i>
+   <i type="logical" name="LSPECTRALGW"> F  </i>
+   <i type="logical" name="LSINGLES"> F  </i>
+   <i type="logical" name="LFERMIGW"> F  </i>
+   <i type="logical" name="ODDONLYGW"> F  </i>
+   <i type="logical" name="EVENONLYGW"> F  </i>
+   <i type="int" name="NKREDLFX">     1</i>
+   <i type="int" name="NKREDLFY">     1</i>
+   <i type="int" name="NKREDLFZ">     1</i>
+   <i type="int" name="MAXMEM">  2800</i>
+   <i type="int" name="TELESCOPE">     0</i>
+   <i type="int" name="NTAUPAR">    -1</i>
+   <i type="int" name="NOMEGAPAR">    -1</i>
+   <i name="DAMP_NEWTON">      0.80000001</i>
+   <i name="LAMBDA">      1.00000000</i>
+  </separator>
+  <separator name="External order field" >
+   <i name="OFIELD_KAPPA">      0.00000000</i>
+   <v name="OFIELD_K">      0.00000000      0.00000000      0.00000000</v>
+   <i name="OFIELD_Q6_NEAR">      0.00000000</i>
+   <i name="OFIELD_Q6_FAR">      0.00000000</i>
+   <i name="OFIELD_A">      0.00000000</i>
+  </separator>
+  <separator name="optional k-points parameters" >
+   <i type="int" name="KPOINTS_OPT_MODE">     1</i>
+   <i type="logical" name="LKPOINTS_OPT"> F  </i>
+  </separator>
+ </parameters>
+ <atominfo>
+  <atoms>      32 </atoms>
+  <types>       1 </types>
+  <array name="atoms" >
+   <dimension dim="1">ion</dimension>
+   <field type="string">element</field>
+   <field type="int">atomtype</field>
+   <set>
+    <rc><c>Ti</c><c>   1</c></rc>
+    <rc><c>Ti</c><c>   1</c></rc>
+    <rc><c>Ti</c><c>   1</c></rc>
+    <rc><c>Ti</c><c>   1</c></rc>
+    <rc><c>Ti</c><c>   1</c></rc>
+    <rc><c>Ti</c><c>   1</c></rc>
+    <rc><c>Ti</c><c>   1</c></rc>
+    <rc><c>Ti</c><c>   1</c></rc>
+    <rc><c>Ti</c><c>   1</c></rc>
+    <rc><c>Ti</c><c>   1</c></rc>
+    <rc><c>Ti</c><c>   1</c></rc>
+    <rc><c>Ti</c><c>   1</c></rc>
+    <rc><c>Ti</c><c>   1</c></rc>
+    <rc><c>Ti</c><c>   1</c></rc>
+    <rc><c>Ti</c><c>   1</c></rc>
+    <rc><c>Ti</c><c>   1</c></rc>
+    <rc><c>Ti</c><c>   1</c></rc>
+    <rc><c>Ti</c><c>   1</c></rc>
+    <rc><c>Ti</c><c>   1</c></rc>
+    <rc><c>Ti</c><c>   1</c></rc>
+    <rc><c>Ti</c><c>   1</c></rc>
+    <rc><c>Ti</c><c>   1</c></rc>
+    <rc><c>Ti</c><c>   1</c></rc>
+    <rc><c>Ti</c><c>   1</c></rc>
+    <rc><c>Ti</c><c>   1</c></rc>
+    <rc><c>Ti</c><c>   1</c></rc>
+    <rc><c>Ti</c><c>   1</c></rc>
+    <rc><c>Ti</c><c>   1</c></rc>
+    <rc><c>Ti</c><c>   1</c></rc>
+    <rc><c>Ti</c><c>   1</c></rc>
+    <rc><c>Ti</c><c>   1</c></rc>
+    <rc><c>Ti</c><c>   1</c></rc>
+   </set>
+  </array>
+  <array name="atomtypes" >
+   <dimension dim="1">type</dimension>
+   <field type="int">atomspertype</field>
+   <field type="string">element</field>
+   <field>mass</field>
+   <field>valence</field>
+   <field type="string">pseudopotential</field>
+   <set>
+    <rc><c>  32</c><c>Ti</c><c>     47.88000000</c><c>      4.00000000</c><c>  PAW_PBE Ti 08Apr2002                  </c></rc>
+   </set>
+  </array>
+ </atominfo>
+ <structure name="initialpos" >
+  <crystal>
+   <varray name="basis" >
+    <v>       5.87198220       0.00000000       0.00000000 </v>
+    <v>       0.00000000      10.16561149       0.00000000 </v>
+    <v>       0.00000000       0.00000000       9.29538000 </v>
+   </varray>
+   <i name="volume">    554.86251651 </i>
+   <varray name="rec_basis" >
+    <v>       0.17030024       0.00000000       0.00000000 </v>
+    <v>       0.00000000       0.09837087       0.00000000 </v>
+    <v>       0.00000000       0.00000000       0.10758032 </v>
+   </varray>
+  </crystal>
+  <varray name="positions" >
+   <v>       0.04232415       0.05125151       0.12401821 </v>
+   <v>       0.04233768       0.38453412       0.37401556 </v>
+   <v>       0.29233207       0.13453320       0.37401602 </v>
+   <v>       0.29233083       0.30125165       0.12401755 </v>
+   <v>       0.04232415       0.05125151       0.62401821 </v>
+   <v>       0.04233768       0.38453412       0.87401556 </v>
+   <v>       0.29233207       0.13453320       0.87401602 </v>
+   <v>       0.29233083       0.30125165       0.62401755 </v>
+   <v>       0.04232415       0.55125151       0.12401821 </v>
+   <v>       0.04233768       0.88453412       0.37401556 </v>
+   <v>       0.29233207       0.63453320       0.37401602 </v>
+   <v>       0.29233083       0.80125165       0.12401755 </v>
+   <v>       0.04232415       0.55125151       0.62401821 </v>
+   <v>       0.04233768       0.88453412       0.87401556 </v>
+   <v>       0.29233207       0.63453320       0.87401602 </v>
+   <v>       0.29233083       0.80125165       0.62401755 </v>
+   <v>       0.54232415       0.05125151       0.12401821 </v>
+   <v>       0.54233768       0.38453412       0.37401556 </v>
+   <v>       0.79233207       0.13453320       0.37401602 </v>
+   <v>       0.79233083       0.30125165       0.12401755 </v>
+   <v>       0.54232415       0.05125151       0.62401821 </v>
+   <v>       0.54233768       0.38453412       0.87401556 </v>
+   <v>       0.79233207       0.13453320       0.87401602 </v>
+   <v>       0.79233083       0.30125165       0.62401755 </v>
+   <v>       0.54232415       0.55125151       0.12401821 </v>
+   <v>       0.54233768       0.88453412       0.37401556 </v>
+   <v>       0.79233207       0.63453320       0.37401602 </v>
+   <v>       0.79233083       0.80125165       0.12401755 </v>
+   <v>       0.54232415       0.55125151       0.62401821 </v>
+   <v>       0.54233768       0.88453412       0.87401556 </v>
+   <v>       0.79233207       0.63453320       0.87401602 </v>
+   <v>       0.79233083       0.80125165       0.62401755 </v>
+  </varray>
+  <varray name="velocities" >
+   <v>      -0.00090485      -0.00072776      -0.00049560 </v>
+   <v>       0.00102761       0.00033604       0.00058209 </v>
+   <v>       0.00024769       0.00008196      -0.00055041 </v>
+   <v>      -0.00041825      -0.00017398      -0.00011612 </v>
+   <v>       0.00079709      -0.00052067       0.00014051 </v>
+   <v>      -0.00154752      -0.00011920       0.00026002 </v>
+   <v>       0.00052249       0.00009205       0.00102233 </v>
+   <v>       0.00060215       0.00028920       0.00006396 </v>
+   <v>       0.00100105      -0.00107871      -0.00043097 </v>
+   <v>      -0.00083118       0.00043638       0.00110083 </v>
+   <v>      -0.00037038      -0.00016756       0.00032735 </v>
+   <v>       0.00042325      -0.00121584      -0.00093714 </v>
+   <v>       0.00112258       0.00036304       0.00062583 </v>
+   <v>       0.00136893       0.00008287      -0.00181287 </v>
+   <v>      -0.00049276       0.00063280      -0.00109093 </v>
+   <v>      -0.00106719       0.00167139      -0.00059439 </v>
+   <v>      -0.00205316      -0.00063386       0.00029949 </v>
+   <v>      -0.00021441       0.00001131       0.00063881 </v>
+   <v>      -0.00076288      -0.00014150       0.00054466 </v>
+   <v>       0.00030566       0.00042217      -0.00089239 </v>
+   <v>      -0.00073141      -0.00023418       0.00079309 </v>
+   <v>      -0.00015609       0.00024785      -0.00001055 </v>
+   <v>      -0.00036313      -0.00016724      -0.00068089 </v>
+   <v>      -0.00047498      -0.00008178      -0.00065038 </v>
+   <v>      -0.00008144       0.00073785       0.00151865 </v>
+   <v>       0.00098672      -0.00002458       0.00060737 </v>
+   <v>       0.00018617      -0.00041125      -0.00071263 </v>
+   <v>       0.00149440      -0.00028395      -0.00009510 </v>
+   <v>       0.00034511      -0.00060738       0.00019045 </v>
+   <v>       0.00119029       0.00025413      -0.00019838 </v>
+   <v>      -0.00031441       0.00030074       0.00003319 </v>
+   <v>      -0.00083717       0.00062968       0.00052014 </v>
+  </varray>
+ </structure>
+ <calculation>
+  <scstep>
+   <time name="dav">    0.38    0.45</time>
+   <time name="total">    0.41    0.48</time>
+   <energy>
+    <i name="alphaZ">    650.40088722 </i>
+    <i name="ewald">  -4112.86760800 </i>
+    <i name="hartreedc">   -247.31505106 </i>
+    <i name="XCdc">  -1183.82933660 </i>
+    <i name="pawpsdc">   4016.50513093 </i>
+    <i name="pawaedc">  -2721.65315951 </i>
+    <i name="eentropy">     -0.10426590 </i>
+    <i name="bandstr">    806.51795614 </i>
+    <i name="atom">   3033.34488495 </i>
+    <i name="e_fr_energy">    240.99943818 </i>
+    <i name="e_wo_entrp">    241.10370408 </i>
+    <i name="e_0_energy">    241.03419348 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.29    0.35</time>
+   <time name="total">    0.29    0.35</time>
+   <energy>
+    <i name="e_fr_energy">   -251.47030698 </i>
+    <i name="e_wo_entrp">   -251.52901422 </i>
+    <i name="e_0_energy">   -251.48987606 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.48    0.49</time>
+   <time name="total">    0.48    0.49</time>
+   <energy>
+    <i name="e_fr_energy">   -285.36637861 </i>
+    <i name="e_wo_entrp">   -285.31507905 </i>
+    <i name="e_0_energy">   -285.34927876 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.27    0.28</time>
+   <time name="total">    0.27    0.28</time>
+   <energy>
+    <i name="e_fr_energy">   -286.41628169 </i>
+    <i name="e_wo_entrp">   -286.35845344 </i>
+    <i name="e_0_energy">   -286.39700560 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.46    0.47</time>
+   <time name="total">    0.48    0.49</time>
+   <energy>
+    <i name="e_fr_energy">   -286.43311540 </i>
+    <i name="e_wo_entrp">   -286.37518891 </i>
+    <i name="e_0_energy">   -286.41380657 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.27    0.27</time>
+   <time name="total">    0.31    0.33</time>
+   <energy>
+    <i name="e_fr_energy">   -256.81759630 </i>
+    <i name="e_wo_entrp">   -256.88562247 </i>
+    <i name="e_0_energy">   -256.84027169 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.36    0.36</time>
+   <time name="total">    0.40    0.41</time>
+   <energy>
+    <i name="e_fr_energy">   -253.38616675 </i>
+    <i name="e_wo_entrp">   -253.33139156 </i>
+    <i name="e_0_energy">   -253.36790835 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.35    0.35</time>
+   <time name="total">    0.39    0.40</time>
+   <energy>
+    <i name="e_fr_energy">   -253.16577616 </i>
+    <i name="e_wo_entrp">   -253.10235476 </i>
+    <i name="e_0_energy">   -253.14463569 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.53    0.53</time>
+   <time name="total">    0.58    0.58</time>
+   <energy>
+    <i name="e_fr_energy">   -253.16672038 </i>
+    <i name="e_wo_entrp">   -253.10049313 </i>
+    <i name="e_0_energy">   -253.14464463 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.53    0.53</time>
+   <time name="total">    0.57    0.59</time>
+   <energy>
+    <i name="e_fr_energy">   -253.15576883 </i>
+    <i name="e_wo_entrp">   -253.08761625 </i>
+    <i name="e_0_energy">   -253.13305131 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.54    0.54</time>
+   <time name="total">    0.58    0.59</time>
+   <energy>
+    <i name="e_fr_energy">   -253.15579051 </i>
+    <i name="e_wo_entrp">   -253.08793062 </i>
+    <i name="e_0_energy">   -253.13317054 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.55    0.55</time>
+   <time name="total">    0.59    0.60</time>
+   <energy>
+    <i name="e_fr_energy">   -253.15565683 </i>
+    <i name="e_wo_entrp">   -253.08929184 </i>
+    <i name="e_0_energy">   -253.13353516 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.54    0.54</time>
+   <time name="total">    0.58    0.59</time>
+   <energy>
+    <i name="e_fr_energy">   -253.15558889 </i>
+    <i name="e_wo_entrp">   -253.08924402 </i>
+    <i name="e_0_energy">   -253.13347393 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.54    0.54</time>
+   <time name="total">    0.58    0.59</time>
+   <energy>
+    <i name="e_fr_energy">   -253.15558195 </i>
+    <i name="e_wo_entrp">   -253.08910245 </i>
+    <i name="e_0_energy">   -253.13342212 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.53    0.53</time>
+   <time name="total">    0.58    0.58</time>
+   <energy>
+    <i name="e_fr_energy">   -253.15557608 </i>
+    <i name="e_wo_entrp">   -253.08904478 </i>
+    <i name="e_0_energy">   -253.13339898 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.53    0.53</time>
+   <time name="total">    0.58    0.58</time>
+   <energy>
+    <i name="e_fr_energy">   -253.15557770 </i>
+    <i name="e_wo_entrp">   -253.08894102 </i>
+    <i name="e_0_energy">   -253.13336547 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.53    0.53</time>
+   <time name="total">    0.56    0.56</time>
+   <energy>
+    <i name="alphaZ">    650.40088722 </i>
+    <i name="ewald">  -4112.86760800 </i>
+    <i name="hartreedc">   -113.05115957 </i>
+    <i name="XCdc">  -1172.37727028 </i>
+    <i name="pawpsdc">   8427.30098750 </i>
+    <i name="pawaedc">  -7138.56695667 </i>
+    <i name="eentropy">     -0.06668343 </i>
+    <i name="bandstr">    172.72734094 </i>
+    <i name="atom">   3033.34488495 </i>
+    <i name="e_fr_energy">   -253.15557734 </i>
+    <i name="e_wo_entrp">   -253.08889391 </i>
+    <i name="e_0_energy">   -253.13334953 </i>
+   </energy>
+  </scstep>
+  <structure>
+   <crystal>
+    <varray name="basis" >
+     <v>       5.87198220       0.00000000       0.00000000 </v>
+     <v>       0.00000000      10.16561149       0.00000000 </v>
+     <v>       0.00000000       0.00000000       9.29538000 </v>
+    </varray>
+    <i name="volume">    554.86251651 </i>
+    <varray name="rec_basis" >
+     <v>       0.17030024       0.00000000       0.00000000 </v>
+     <v>       0.00000000       0.09837087       0.00000000 </v>
+     <v>       0.00000000       0.00000000       0.10758032 </v>
+    </varray>
+   </crystal>
+   <varray name="positions" >
+    <v>       0.04232415       0.05125151       0.12401821 </v>
+    <v>       0.04233768       0.38453412       0.37401556 </v>
+    <v>       0.29233207       0.13453320       0.37401602 </v>
+    <v>       0.29233083       0.30125165       0.12401755 </v>
+    <v>       0.04232415       0.05125151       0.62401821 </v>
+    <v>       0.04233768       0.38453412       0.87401556 </v>
+    <v>       0.29233207       0.13453320       0.87401602 </v>
+    <v>       0.29233083       0.30125165       0.62401755 </v>
+    <v>       0.04232415       0.55125151       0.12401821 </v>
+    <v>       0.04233768       0.88453412       0.37401556 </v>
+    <v>       0.29233207       0.63453320       0.37401602 </v>
+    <v>       0.29233083       0.80125165       0.12401755 </v>
+    <v>       0.04232415       0.55125151       0.62401821 </v>
+    <v>       0.04233768       0.88453412       0.87401556 </v>
+    <v>       0.29233207       0.63453320       0.87401602 </v>
+    <v>       0.29233083       0.80125165       0.62401755 </v>
+    <v>       0.54232415       0.05125151       0.12401821 </v>
+    <v>       0.54233768       0.38453412       0.37401556 </v>
+    <v>       0.79233207       0.13453320       0.37401602 </v>
+    <v>       0.79233083       0.30125165       0.12401755 </v>
+    <v>       0.54232415       0.05125151       0.62401821 </v>
+    <v>       0.54233768       0.38453412       0.87401556 </v>
+    <v>       0.79233207       0.13453320       0.87401602 </v>
+    <v>       0.79233083       0.30125165       0.62401755 </v>
+    <v>       0.54232415       0.55125151       0.12401821 </v>
+    <v>       0.54233768       0.88453412       0.37401556 </v>
+    <v>       0.79233207       0.63453320       0.37401602 </v>
+    <v>       0.79233083       0.80125165       0.12401755 </v>
+    <v>       0.54232415       0.55125151       0.62401821 </v>
+    <v>       0.54233768       0.88453412       0.87401556 </v>
+    <v>       0.79233207       0.63453320       0.87401602 </v>
+    <v>       0.79233083       0.80125165       0.62401755 </v>
+   </varray>
+  </structure>
+  <varray name="forces" >
+   <v>       0.00012569       0.20036532       0.00001043 </v>
+   <v>      -0.00007844      -0.20046516      -0.00012355 </v>
+   <v>      -0.00006316      -0.20035720      -0.00010088 </v>
+   <v>      -0.00008502       0.20039019      -0.00002935 </v>
+   <v>       0.00007865       0.20036653      -0.00012894 </v>
+   <v>      -0.00007125      -0.20046234       0.00007176 </v>
+   <v>      -0.00004294      -0.20034214       0.00004266 </v>
+   <v>      -0.00002474       0.20042729      -0.00004165 </v>
+   <v>       0.00020525       0.20036713      -0.00000152 </v>
+   <v>      -0.00011547      -0.20048616      -0.00010122 </v>
+   <v>      -0.00003512      -0.20037010      -0.00007381 </v>
+   <v>      -0.00010400       0.20034969       0.00000905 </v>
+   <v>       0.00015608       0.20035706      -0.00010444 </v>
+   <v>      -0.00011004      -0.20047695       0.00005951 </v>
+   <v>      -0.00002760      -0.20041250       0.00002139 </v>
+   <v>      -0.00005686       0.20035089      -0.00008453 </v>
+   <v>       0.00010171       0.20035144      -0.00001509 </v>
+   <v>      -0.00021262      -0.20051115      -0.00005354 </v>
+   <v>       0.00003423      -0.20048245      -0.00005485 </v>
+   <v>      -0.00003562       0.20032629      -0.00001167 </v>
+   <v>       0.00012747       0.20035227      -0.00011553 </v>
+   <v>      -0.00022492      -0.20050614      -0.00000318 </v>
+   <v>       0.00001586      -0.20046022      -0.00000431 </v>
+   <v>      -0.00009032       0.20034423      -0.00006685 </v>
+   <v>       0.00002691       0.20032410      -0.00001757 </v>
+   <v>      -0.00018207      -0.20055778      -0.00009412 </v>
+   <v>       0.00000962      -0.20042688      -0.00004989 </v>
+   <v>      -0.00001329       0.20038475       0.00000813 </v>
+   <v>       0.00006463       0.20031196      -0.00011808 </v>
+   <v>      -0.00018425      -0.20054792       0.00004241 </v>
+   <v>      -0.00000523      -0.20045581      -0.00000743 </v>
+   <v>      -0.00005689       0.20037212      -0.00008171 </v>
+  </varray>
+  <varray name="stress" >
+   <v>    -153.71053858      -0.00704312      -0.00216512 </v>
+   <v>      -0.00704312       3.10469616      -0.00157252 </v>
+   <v>      -0.00216515      -0.00157260      -2.94555568 </v>
+  </varray>
+  <energy>
+   <i name="e_fr_energy">   -253.15557734 </i>
+   <i name="e_wo_entrp">   -253.08889391 </i>
+   <i name="e_0_energy">   -253.13334953 </i>
+   <i name="kinetic">      2.00072509 </i>
+   <i name="lattice kinetic">      0.00000000 </i>
+   <i name="nosepot">      0.00000000 </i>
+   <i name="nosekinetic">      0.00000000 </i>
+   <i name="total">   -251.15485226 </i>
+  </energy>
+  <time name="totalsc">    8.95    9.24</time>
+ </calculation>
+ <calculation>
+  <scstep>
+   <time name="dav">    0.27    0.27</time>
+   <time name="total">    0.31    0.31</time>
+   <energy>
+    <i name="alphaZ">    650.40088722 </i>
+    <i name="ewald">  -4112.77672035 </i>
+    <i name="hartreedc">   -113.13046476 </i>
+    <i name="XCdc">  -1172.37739773 </i>
+    <i name="pawpsdc">   8427.28168718 </i>
+    <i name="pawaedc">  -7138.54780970 </i>
+    <i name="eentropy">     -0.06362628 </i>
+    <i name="bandstr">    172.72314291 </i>
+    <i name="atom">   3033.34488495 </i>
+    <i name="e_fr_energy">   -253.14541656 </i>
+    <i name="e_wo_entrp">   -253.08179028 </i>
+    <i name="e_0_energy">   -253.12420780 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.54    0.54</time>
+   <time name="total">    0.59    0.59</time>
+   <energy>
+    <i name="e_fr_energy">   -253.16768715 </i>
+    <i name="e_wo_entrp">   -253.10380061 </i>
+    <i name="e_0_energy">   -253.14639164 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.54    0.54</time>
+   <time name="total">    0.58    0.59</time>
+   <energy>
+    <i name="e_fr_energy">   -253.14086691 </i>
+    <i name="e_wo_entrp">   -253.07706950 </i>
+    <i name="e_0_energy">   -253.11960111 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.35    0.35</time>
+   <time name="total">    0.40    0.40</time>
+   <energy>
+    <i name="e_fr_energy">   -253.14096072 </i>
+    <i name="e_wo_entrp">   -253.07714146 </i>
+    <i name="e_0_energy">   -253.11968764 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.54    0.54</time>
+   <time name="total">    0.59    0.59</time>
+   <energy>
+    <i name="e_fr_energy">   -253.13912249 </i>
+    <i name="e_wo_entrp">   -253.07534335 </i>
+    <i name="e_0_energy">   -253.11786278 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.53    0.53</time>
+   <time name="total">    0.58    0.58</time>
+   <energy>
+    <i name="e_fr_energy">   -253.13919201 </i>
+    <i name="e_wo_entrp">   -253.07541609 </i>
+    <i name="e_0_energy">   -253.11793337 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.35    0.35</time>
+   <time name="total">    0.40    0.40</time>
+   <energy>
+    <i name="e_fr_energy">   -253.13908503 </i>
+    <i name="e_wo_entrp">   -253.07529978 </i>
+    <i name="e_0_energy">   -253.11782328 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.56    0.56</time>
+   <time name="total">    0.61    0.61</time>
+   <energy>
+    <i name="e_fr_energy">   -253.13908471 </i>
+    <i name="e_wo_entrp">   -253.07529416 </i>
+    <i name="e_0_energy">   -253.11782119 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.54    0.54</time>
+   <time name="total">    0.59    0.59</time>
+   <energy>
+    <i name="e_fr_energy">   -253.13907883 </i>
+    <i name="e_wo_entrp">   -253.07529168 </i>
+    <i name="e_0_energy">   -253.11781644 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.35    0.35</time>
+   <time name="total">    0.40    0.41</time>
+   <energy>
+    <i name="e_fr_energy">   -253.13907779 </i>
+    <i name="e_wo_entrp">   -253.07529093 </i>
+    <i name="e_0_energy">   -253.11781550 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.41    0.41</time>
+   <time name="total">    0.44    0.44</time>
+   <energy>
+    <i name="alphaZ">    650.40088722 </i>
+    <i name="ewald">  -4112.77672035 </i>
+    <i name="hartreedc">   -113.12630585 </i>
+    <i name="XCdc">  -1172.37710455 </i>
+    <i name="pawpsdc">   8428.04819085 </i>
+    <i name="pawaedc">  -7139.31984915 </i>
+    <i name="eentropy">     -0.06378653 </i>
+    <i name="bandstr">    172.73072570 </i>
+    <i name="atom">   3033.34488495 </i>
+    <i name="e_fr_energy">   -253.13907769 </i>
+    <i name="e_wo_entrp">   -253.07529117 </i>
+    <i name="e_0_energy">   -253.11781552 </i>
+   </energy>
+  </scstep>
+  <structure>
+   <crystal>
+    <varray name="basis" >
+     <v>       5.87198220       0.00000000       0.00000000 </v>
+     <v>       0.00000000      10.16561149       0.00000000 </v>
+     <v>       0.00000000       0.00000000       9.29538000 </v>
+    </varray>
+    <i name="volume">    554.86251651 </i>
+    <varray name="rec_basis" >
+     <v>       0.17030024       0.00000000       0.00000000 </v>
+     <v>       0.00000000       0.09837087       0.00000000 </v>
+     <v>       0.00000000       0.00000000       0.10758032 </v>
+    </varray>
+   </crystal>
+   <varray name="positions" >
+    <v>       0.04141932       0.05053965       0.12352262 </v>
+    <v>       0.04336528       0.38485427       0.37459764 </v>
+    <v>       0.29257975       0.13459928       0.37346560 </v>
+    <v>       0.29191258       0.30109356       0.12390143 </v>
+    <v>       0.04312126       0.05074674       0.62415871 </v>
+    <v>       0.04079016       0.38439903       0.87427559 </v>
+    <v>       0.29285456       0.13460937       0.87503835 </v>
+    <v>       0.29293298       0.30155675       0.62408150 </v>
+    <v>       0.04332523       0.55018869       0.12358724 </v>
+    <v>       0.04150649       0.88495461       0.37511638 </v>
+    <v>       0.29196168       0.63434976       0.37434336 </v>
+    <v>       0.29275408       0.80005170       0.12308041 </v>
+    <v>       0.04344676       0.55163045       0.62464403 </v>
+    <v>       0.04370660       0.88460110       0.87220271 </v>
+    <v>       0.29183931       0.63515011       0.87292510 </v>
+    <v>       0.29126364       0.80293893       0.62342315 </v>
+    <v>       0.54027101       0.05063355       0.12431770 </v>
+    <v>       0.54212325       0.38452953       0.37465437 </v>
+    <v>       0.79156920       0.13437580       0.37456067 </v>
+    <v>       0.79263649       0.30168971       0.12312516 </v>
+    <v>       0.54159276       0.05103322       0.62481129 </v>
+    <v>       0.54218157       0.38476607       0.87400502 </v>
+    <v>       0.79196895       0.13435006       0.87333513 </v>
+    <v>       0.79185585       0.30118576       0.62336717 </v>
+    <v>       0.54224271       0.55200525       0.12553686 </v>
+    <v>       0.54332438       0.88449364       0.37462293 </v>
+    <v>       0.79251824       0.63410606       0.37330339 </v>
+    <v>       0.79382524       0.80098360       0.12392246 </v>
+    <v>       0.54266927       0.55066002       0.62420866 </v>
+    <v>       0.54352795       0.88477236       0.87381719 </v>
+    <v>       0.79201766       0.63481805       0.87404921 </v>
+    <v>       0.79149366       0.80189722       0.62453769 </v>
+   </varray>
+  </structure>
+  <varray name="forces" >
+   <v>      -0.01642773       0.22666079       0.02164253 </v>
+   <v>      -0.01778503      -0.22231837      -0.02079316 </v>
+   <v>      -0.02335325      -0.22888616       0.09261008 </v>
+   <v>       0.01372092       0.20508133      -0.00644410 </v>
+   <v>      -0.02638942       0.28821402      -0.01393951 </v>
+   <v>       0.03740642      -0.19539896      -0.04520385 </v>
+   <v>      -0.02050765      -0.20397366      -0.09239398 </v>
+   <v>      -0.01918632       0.16918644      -0.00285308 </v>
+   <v>      -0.01850122       0.29176689       0.04972311 </v>
+   <v>       0.02739606      -0.21813486      -0.11550582 </v>
+   <v>       0.00547797      -0.19736820      -0.02297853 </v>
+   <v>      -0.01106074       0.25110850       0.07592920 </v>
+   <v>      -0.05149083       0.16727862      -0.05607346 </v>
+   <v>      -0.01182914      -0.19799133       0.15803659 </v>
+   <v>       0.03067737      -0.23681427       0.07848857 </v>
+   <v>       0.03966070       0.09320709       0.02872848 </v>
+   <v>       0.06409676       0.21456259      -0.00956975 </v>
+   <v>       0.01190030      -0.18155670      -0.06128014 </v>
+   <v>       0.02255242      -0.18461284      -0.08302362 </v>
+   <v>      -0.02379535       0.13293752       0.09131218 </v>
+   <v>       0.03679452       0.22285114      -0.05504409 </v>
+   <v>      -0.01831893      -0.19731871       0.02338532 </v>
+   <v>       0.01318955      -0.17357285       0.09085547 </v>
+   <v>       0.01386361       0.21516435       0.05626406 </v>
+   <v>      -0.00352944       0.12181801      -0.13497928 </v>
+   <v>      -0.04715036      -0.18972924      -0.05669673 </v>
+   <v>       0.02041141      -0.18170428       0.10159628 </v>
+   <v>      -0.00511453       0.16045379      -0.01014289 </v>
+   <v>       0.01793145       0.26165009       0.01889421 </v>
+   <v>      -0.03071790      -0.21713283      -0.01082776 </v>
+   <v>       0.00077096      -0.19453905      -0.03003541 </v>
+   <v>      -0.01097206       0.19757472      -0.06022880 </v>
+  </varray>
+  <varray name="stress" >
+   <v>    -153.56936677      -0.03258476       0.00865641 </v>
+   <v>      -0.03258475       3.21310302       0.00096504 </v>
+   <v>       0.00865649       0.00096507      -2.86657981 </v>
+  </varray>
+  <energy>
+   <i name="e_fr_energy">   -253.13907769 </i>
+   <i name="e_wo_entrp">   -253.07529117 </i>
+   <i name="e_0_energy">   -253.11781552 </i>
+   <i name="kinetic">      1.98424597 </i>
+   <i name="lattice kinetic">      0.00000000 </i>
+   <i name="nosepot">      0.00000000 </i>
+   <i name="nosekinetic">      0.00000000 </i>
+   <i name="total">   -251.15483172 </i>
+  </energy>
+  <time name="totalsc">    6.20    6.25</time>
+ </calculation>
+ <calculation>
+  <scstep>
+   <time name="dav">    0.35    0.35</time>
+   <time name="total">    0.39    0.40</time>
+   <energy>
+    <i name="alphaZ">    650.40088722 </i>
+    <i name="ewald">  -4112.50694631 </i>
+    <i name="hartreedc">   -113.29863721 </i>
+    <i name="XCdc">  -1172.37389273 </i>
+    <i name="pawpsdc">   8428.87611959 </i>
+    <i name="pawaedc">  -7140.15347159 </i>
+    <i name="eentropy">     -0.06035856 </i>
+    <i name="bandstr">    172.67072594 </i>
+    <i name="atom">   3033.34488495 </i>
+    <i name="e_fr_energy">   -253.10068870 </i>
+    <i name="e_wo_entrp">   -253.04033014 </i>
+    <i name="e_0_energy">   -253.08056918 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.55    0.55</time>
+   <time name="total">    0.60    0.60</time>
+   <energy>
+    <i name="e_fr_energy">   -253.10089437 </i>
+    <i name="e_wo_entrp">   -253.04075612 </i>
+    <i name="e_0_energy">   -253.08084828 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.36    0.36</time>
+   <time name="total">    0.40    0.41</time>
+   <energy>
+    <i name="e_fr_energy">   -253.10069793 </i>
+    <i name="e_wo_entrp">   -253.04058361 </i>
+    <i name="e_0_energy">   -253.08065983 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.53    0.53</time>
+   <time name="total">    0.58    0.59</time>
+   <energy>
+    <i name="e_fr_energy">   -253.10069848 </i>
+    <i name="e_wo_entrp">   -253.04058791 </i>
+    <i name="e_0_energy">   -253.08066162 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.54    0.54</time>
+   <time name="total">    0.58    0.58</time>
+   <energy>
+    <i name="e_fr_energy">   -253.10069476 </i>
+    <i name="e_wo_entrp">   -253.04059280 </i>
+    <i name="e_0_energy">   -253.08066078 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.35    0.35</time>
+   <time name="total">    0.39    0.40</time>
+   <energy>
+    <i name="e_fr_energy">   -253.10069823 </i>
+    <i name="e_wo_entrp">   -253.04061545 </i>
+    <i name="e_0_energy">   -253.08067064 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.54    0.54</time>
+   <time name="total">    0.59    0.59</time>
+   <energy>
+    <i name="e_fr_energy">   -253.10069523 </i>
+    <i name="e_wo_entrp">   -253.04061527 </i>
+    <i name="e_0_energy">   -253.08066858 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.40    0.40</time>
+   <time name="total">    0.43    0.43</time>
+   <energy>
+    <i name="alphaZ">    650.40088722 </i>
+    <i name="ewald">  -4112.50694631 </i>
+    <i name="hartreedc">   -113.34449098 </i>
+    <i name="XCdc">  -1172.37782650 </i>
+    <i name="pawpsdc">   8430.64651710 </i>
+    <i name="pawaedc">  -7141.92752147 </i>
+    <i name="eentropy">     -0.06008122 </i>
+    <i name="bandstr">    172.72388201 </i>
+    <i name="atom">   3033.34488495 </i>
+    <i name="e_fr_energy">   -253.10069520 </i>
+    <i name="e_wo_entrp">   -253.04061398 </i>
+    <i name="e_0_energy">   -253.08066812 </i>
+   </energy>
+  </scstep>
+  <structure>
+   <crystal>
+    <varray name="basis" >
+     <v>       5.87198220       0.00000000       0.00000000 </v>
+     <v>       0.00000000      10.16561149       0.00000000 </v>
+     <v>       0.00000000       0.00000000       9.29538000 </v>
+    </varray>
+    <i name="volume">    554.86251651 </i>
+    <varray name="rec_basis" >
+     <v>       0.17030024       0.00000000       0.00000000 </v>
+     <v>       0.00000000       0.09837087       0.00000000 </v>
+     <v>       0.00000000       0.00000000       0.10758032 </v>
+    </varray>
+   </crystal>
+   <varray name="positions" >
+    <v>       0.04051223       0.04984576       0.12302890 </v>
+    <v>       0.04439045       0.38515679       0.37517792 </v>
+    <v>       0.29282423       0.13464721       0.37292321 </v>
+    <v>       0.29149620       0.30095174       0.12378475 </v>
+    <v>       0.04391474       0.05026482       0.62429800 </v>
+    <v>       0.03924778       0.38424845       0.87453170 </v>
+    <v>       0.29337424       0.13466937       0.87605267 </v>
+    <v>       0.29353250       0.30187527       0.62414521 </v>
+    <v>       0.04432377       0.54914901       0.12316059 </v>
+    <v>       0.04067906       0.88535780       0.37620719 </v>
+    <v>       0.29159205       0.63415067       0.37466872 </v>
+    <v>       0.29317580       0.79887166       0.12214986 </v>
+    <v>       0.04456230       0.55202265       0.62526499 </v>
+    <v>       0.04507390       0.88465238       0.87040355 </v>
+    <v>       0.29135076       0.63574825       0.87184098 </v>
+    <v>       0.29020188       0.80463360       0.62283125 </v>
+    <v>       0.53822667       0.05003259       0.12461636 </v>
+    <v>       0.54191045       0.38451055       0.37528787 </v>
+    <v>       0.79080943       0.13420377       0.37509813 </v>
+    <v>       0.79293888       0.30213831       0.12224069 </v>
+    <v>       0.54086642       0.05083260       0.62559960 </v>
+    <v>       0.54202294       0.38498238       0.87399650 </v>
+    <v>       0.79160764       0.13415317       0.87266213 </v>
+    <v>       0.79138277       0.30113693       0.62272166 </v>
+    <v>       0.54216080       0.55276865       0.12704381 </v>
+    <v>       0.54430461       0.88443812       0.37522538 </v>
+    <v>       0.79270722       0.63366452       0.37259957 </v>
+    <v>       0.79531895       0.80072827       0.12382649 </v>
+    <v>       0.54301686       0.55008927       0.62440074 </v>
+    <v>       0.54471401       0.88499338       0.87361788 </v>
+    <v>       0.79170336       0.63508747       0.87407981 </v>
+    <v>       0.79065498       0.80255846       0.62505260 </v>
+   </varray>
+  </structure>
+  <varray name="forces" >
+   <v>      -0.03264729       0.25434374       0.04186176 </v>
+   <v>      -0.03409805      -0.24221952      -0.04042135 </v>
+   <v>      -0.04715632      -0.25601528       0.18553056 </v>
+   <v>       0.02867971       0.20979682      -0.01322831 </v>
+   <v>      -0.05445530       0.37948865      -0.02897862 </v>
+   <v>       0.07435600      -0.19199973      -0.09146378 </v>
+   <v>      -0.04165724      -0.20626298      -0.18314615 </v>
+   <v>      -0.03699994       0.13885237      -0.00598465 </v>
+   <v>      -0.03705920       0.38402406       0.09944757 </v>
+   <v>       0.05388101      -0.23745263      -0.23034653 </v>
+   <v>       0.01248970      -0.19510627      -0.04244495 </v>
+   <v>      -0.02335985       0.30363248       0.14543103 </v>
+   <v>      -0.10173139       0.13414102      -0.11148236 </v>
+   <v>      -0.02122560      -0.19715479       0.31926357 </v>
+   <v>       0.06194289      -0.27123221       0.15484934 </v>
+   <v>       0.07804577      -0.01561969       0.05425571 </v>
+   <v>       0.12763638       0.22868875      -0.02025924 </v>
+   <v>       0.02325220      -0.16165797      -0.12064997 </v>
+   <v>       0.04478842      -0.17011603      -0.16257289 </v>
+   <v>      -0.04862535       0.06751076       0.17863589 </v>
+   <v>       0.07379085       0.24571384      -0.11154224 </v>
+   <v>      -0.03672728      -0.19626653       0.04582924 </v>
+   <v>       0.02721063      -0.14651831       0.18032902 </v>
+   <v>       0.02829693       0.22915932       0.11251904 </v>
+   <v>      -0.00605505       0.04317356      -0.26705850 </v>
+   <v>      -0.09350812      -0.18045374      -0.11070969 </v>
+   <v>       0.04238591      -0.16370817       0.20013428 </v>
+   <v>      -0.01448661       0.12050619      -0.01986997 </v>
+   <v>       0.03654295       0.32066835       0.03837613 </v>
+   <v>      -0.06086442      -0.23519389      -0.01739654 </v>
+   <v>       0.00297790      -0.18791833      -0.06058856 </v>
+   <v>      -0.02528060       0.19471036      -0.11913781 </v>
+  </varray>
+  <varray name="stress" >
+   <v>    -153.35852691      -0.08218484       0.03546365 </v>
+   <v>      -0.08218485       3.50696113      -0.00074952 </v>
+   <v>       0.03546372      -0.00074935      -2.62906023 </v>
+  </varray>
+  <energy>
+   <i name="e_fr_energy">   -253.10069520 </i>
+   <i name="e_wo_entrp">   -253.04061398 </i>
+   <i name="e_0_energy">   -253.08066812 </i>
+   <i name="kinetic">      1.94593517 </i>
+   <i name="lattice kinetic">      0.00000000 </i>
+   <i name="nosepot">      0.00000000 </i>
+   <i name="nosekinetic">      0.00000000 </i>
+   <i name="total">   -251.15476003 </i>
+  </energy>
+  <time name="totalsc">    4.69    4.74</time>
+ </calculation>
+ <calculation>
+  <scstep>
+   <time name="dav">    0.46    0.46</time>
+   <time name="total">    0.50    0.50</time>
+   <energy>
+    <i name="alphaZ">    650.40088722 </i>
+    <i name="ewald">  -4112.06599501 </i>
+    <i name="hartreedc">   -113.70501544 </i>
+    <i name="XCdc">  -1172.37982119 </i>
+    <i name="pawpsdc">   8435.21078648 </i>
+    <i name="pawaedc">  -7146.50560449 </i>
+    <i name="eentropy">     -0.05552531 </i>
+    <i name="bandstr">    172.71381326 </i>
+    <i name="atom">   3033.34488495 </i>
+    <i name="e_fr_energy">   -253.04158952 </i>
+    <i name="e_wo_entrp">   -252.98606422 </i>
+    <i name="e_0_energy">   -253.02308109 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.45    0.45</time>
+   <time name="total">    0.50    0.50</time>
+   <energy>
+    <i name="e_fr_energy">   -253.04153707 </i>
+    <i name="e_wo_entrp">   -252.98596496 </i>
+    <i name="e_0_energy">   -253.02301304 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.53    0.53</time>
+   <time name="total">    0.57    0.58</time>
+   <energy>
+    <i name="e_fr_energy">   -253.04153199 </i>
+    <i name="e_wo_entrp">   -252.98594036 </i>
+    <i name="e_0_energy">   -253.02300145 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.21    0.21</time>
+   <time name="total">    0.26    0.26</time>
+   <energy>
+    <i name="e_fr_energy">   -253.04153205 </i>
+    <i name="e_wo_entrp">   -252.98593789 </i>
+    <i name="e_0_energy">   -253.02300066 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.41    0.41</time>
+   <time name="total">    0.46    0.46</time>
+   <energy>
+    <i name="e_fr_energy">   -253.04153210 </i>
+    <i name="e_wo_entrp">   -252.98593851 </i>
+    <i name="e_0_energy">   -253.02300090 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.21    0.21</time>
+   <time name="total">    0.24    0.24</time>
+   <energy>
+    <i name="alphaZ">    650.40088722 </i>
+    <i name="ewald">  -4112.06599501 </i>
+    <i name="hartreedc">   -113.70205702 </i>
+    <i name="XCdc">  -1172.37964996 </i>
+    <i name="pawpsdc">   8434.94316058 </i>
+    <i name="pawaedc">  -7146.23834627 </i>
+    <i name="eentropy">     -0.05559634 </i>
+    <i name="bandstr">    172.71117941 </i>
+    <i name="atom">   3033.34488495 </i>
+    <i name="e_fr_energy">   -253.04153245 </i>
+    <i name="e_wo_entrp">   -252.98593610 </i>
+    <i name="e_0_energy">   -253.02300033 </i>
+   </energy>
+  </scstep>
+  <structure>
+   <crystal>
+    <varray name="basis" >
+     <v>       5.87198220       0.00000000       0.00000000 </v>
+     <v>       0.00000000      10.16561149       0.00000000 </v>
+     <v>       0.00000000       0.00000000       9.29538000 </v>
+    </varray>
+    <i name="volume">    554.86251651 </i>
+    <varray name="rec_basis" >
+     <v>       0.17030024       0.00000000       0.00000000 </v>
+     <v>       0.00000000       0.09837087       0.00000000 </v>
+     <v>       0.00000000       0.00000000       0.10758032 </v>
+    </varray>
+   </crystal>
+   <varray name="positions" >
+    <v>       0.03960066       0.04917204       0.12253882 </v>
+    <v>       0.04541092       0.38544011       0.37575469 </v>
+    <v>       0.29306223       0.13467485       0.37239691 </v>
+    <v>       0.29108376       0.30082656       0.12366693 </v>
+    <v>       0.04470075       0.04981299       0.62443478 </v>
+    <v>       0.03771560       0.38408264       0.87477988 </v>
+    <v>       0.29388820       0.13471302       0.87705111 </v>
+    <v>       0.29412693       0.30220480       0.62420841 </v>
+    <v>       0.04531723       0.54813978       0.12274257 </v>
+    <v>       0.03985903       0.88574217       0.37727802 </v>
+    <v>       0.29122413       0.63393612       0.37499040 </v>
+    <v>       0.29359432       0.79771569       0.12123192 </v>
+    <v>       0.04566388       0.55242549       0.62587629 </v>
+    <v>       0.04643828       0.88468802       0.86863208 </v>
+    <v>       0.29087071       0.63632488       0.87077030 </v>
+    <v>       0.28915084       0.80632704       0.62224405 </v>
+    <v>       0.53619984       0.04944978       0.12491326 </v>
+    <v>       0.54170084       0.38447876       0.37591090 </v>
+    <v>       0.79005581       0.13401826       0.37562149 </v>
+    <v>       0.79323459       0.30259227       0.12137171 </v>
+    <v>       0.54015022       0.05065147       0.62637824 </v>
+    <v>       0.54185927       0.38518313       0.87399196 </v>
+    <v>       0.79125006       0.13394466       0.87200477 </v>
+    <v>       0.79091357       0.30110627       0.62208592 </v>
+    <v>       0.54207805       0.55353547       0.12852760 </v>
+    <v>       0.54527200       0.88436829       0.37581824 </v>
+    <v>       0.79290201       0.63321000       0.37191311 </v>
+    <v>       0.79681066       0.80048250       0.12372880 </v>
+    <v>       0.54336947       0.54954395       0.62459616 </v>
+    <v>       0.54589171       0.88519575       0.87341706 </v>
+    <v>       0.79138946       0.63534199       0.87410515 </v>
+    <v>       0.78981283       0.80323514       0.62555719 </v>
+   </varray>
+  </structure>
+  <varray name="forces" >
+   <v>      -0.04771950       0.28259484       0.06037263 </v>
+   <v>      -0.04953402      -0.26063399      -0.05928865 </v>
+   <v>      -0.07086994      -0.28189022       0.27791240 </v>
+   <v>       0.04437839       0.21404926      -0.02042101 </v>
+   <v>      -0.08368034       0.47358237      -0.04445791 </v>
+   <v>       0.11096373      -0.19005201      -0.13760806 </v>
+   <v>      -0.06269110      -0.20783297      -0.27149067 </v>
+   <v>      -0.05356854       0.10842865      -0.00907332 </v>
+   <v>      -0.05592057       0.47545227       0.14776458 </v>
+   <v>       0.07829080      -0.25849278      -0.34364277 </v>
+   <v>       0.02066675      -0.19324616      -0.05817130 </v>
+   <v>      -0.03698767       0.35868456       0.20744335 </v>
+   <v>      -0.15097604       0.10156124      -0.16511886 </v>
+   <v>      -0.02870390      -0.19798330       0.48259030 </v>
+   <v>       0.09352497      -0.30347320       0.22841446 </v>
+   <v>       0.11553596      -0.12571393       0.07705232 </v>
+   <v>       0.18992793       0.24224394      -0.03285123 </v>
+   <v>       0.03384455      -0.14161349      -0.17816372 </v>
+   <v>       0.06620205      -0.15740646      -0.23816136 </v>
+   <v>      -0.07424114       0.00546606       0.26115229 </v>
+   <v>       0.10981216       0.26858105      -0.16903254 </v>
+   <v>      -0.05558700      -0.19738682       0.06784089 </v>
+   <v>       0.04140149      -0.12024822       0.26781447 </v>
+   <v>       0.04307055       0.24225645       0.16825673 </v>
+   <v>      -0.00624346      -0.03440700      -0.39552683 </v>
+   <v>      -0.13793324      -0.17198318      -0.16171984 </v>
+   <v>       0.06578601      -0.14574578       0.29489681 </v>
+   <v>      -0.02811844       0.08088304      -0.02907708 </v>
+   <v>       0.05565333       0.37832750       0.05810814 </v>
+   <v>      -0.09030303      -0.25401738      -0.01917338 </v>
+   <v>       0.00699091      -0.18004529      -0.09115087 </v>
+   <v>      -0.04238438       0.19071489      -0.17649118 </v>
+  </varray>
+  <varray name="stress" >
+   <v>    -153.09625833      -0.15198775       0.08126662 </v>
+   <v>      -0.15198772       3.94356847      -0.00955321 </v>
+   <v>       0.08126662      -0.00955322      -2.27047581 </v>
+  </varray>
+  <energy>
+   <i name="e_fr_energy">   -253.04153245 </i>
+   <i name="e_wo_entrp">   -252.98593610 </i>
+   <i name="e_0_energy">   -253.02300033 </i>
+   <i name="kinetic">      1.88688103 </i>
+   <i name="lattice kinetic">      0.00000000 </i>
+   <i name="nosepot">      0.00000000 </i>
+   <i name="nosekinetic">      0.00000000 </i>
+   <i name="total">   -251.15465142 </i>
+  </energy>
+  <time name="totalsc">    3.26    3.30</time>
+ </calculation>
+ <calculation>
+  <scstep>
+   <time name="dav">    0.47    0.47</time>
+   <time name="total">    0.51    0.51</time>
+   <energy>
+    <i name="alphaZ">    650.40088722 </i>
+    <i name="ewald">  -4111.46625827 </i>
+    <i name="hartreedc">   -114.19498465 </i>
+    <i name="XCdc">  -1172.38312967 </i>
+    <i name="pawpsdc">   8440.87320308 </i>
+    <i name="pawaedc">  -7152.18845031 </i>
+    <i name="eentropy">     -0.05031028 </i>
+    <i name="bandstr">    172.70076825 </i>
+    <i name="atom">   3033.34488495 </i>
+    <i name="e_fr_energy">   -252.96338967 </i>
+    <i name="e_wo_entrp">   -252.91307939 </i>
+    <i name="e_0_energy">   -252.94661958 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.45    0.45</time>
+   <time name="total">    0.50    0.51</time>
+   <energy>
+    <i name="e_fr_energy">   -252.96334112 </i>
+    <i name="e_wo_entrp">   -252.91289978 </i>
+    <i name="e_0_energy">   -252.94652734 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.35    0.35</time>
+   <time name="total">    0.39    0.40</time>
+   <energy>
+    <i name="e_fr_energy">   -252.96333416 </i>
+    <i name="e_wo_entrp">   -252.91291133 </i>
+    <i name="e_0_energy">   -252.94652655 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.45    0.46</time>
+   <time name="total">    0.51    0.51</time>
+   <energy>
+    <i name="e_fr_energy">   -252.96333408 </i>
+    <i name="e_wo_entrp">   -252.91290472 </i>
+    <i name="e_0_energy">   -252.94652430 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.21    0.21</time>
+   <time name="total">    0.26    0.26</time>
+   <energy>
+    <i name="e_fr_energy">   -252.96333386 </i>
+    <i name="e_wo_entrp">   -252.91290802 </i>
+    <i name="e_0_energy">   -252.94652525 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.40    0.40</time>
+   <time name="total">    0.43    0.43</time>
+   <energy>
+    <i name="alphaZ">    650.40088722 </i>
+    <i name="ewald">  -4111.46625827 </i>
+    <i name="hartreedc">   -114.18620042 </i>
+    <i name="XCdc">  -1172.38230061 </i>
+    <i name="pawpsdc">   8440.71789971 </i>
+    <i name="pawaedc">  -7152.03097672 </i>
+    <i name="eentropy">     -0.05043386 </i>
+    <i name="bandstr">    172.68916407 </i>
+    <i name="atom">   3033.34488495 </i>
+    <i name="e_fr_energy">   -252.96333393 </i>
+    <i name="e_wo_entrp">   -252.91290007 </i>
+    <i name="e_0_energy">   -252.94652265 </i>
+   </energy>
+  </scstep>
+  <structure>
+   <crystal>
+    <varray name="basis" >
+     <v>       5.87198220       0.00000000       0.00000000 </v>
+     <v>       0.00000000      10.16561149       0.00000000 </v>
+     <v>       0.00000000       0.00000000       9.29538000 </v>
+    </varray>
+    <i name="volume">    554.86251651 </i>
+    <varray name="rec_basis" >
+     <v>       0.17030024       0.00000000       0.00000000 </v>
+     <v>       0.00000000       0.09837087       0.00000000 </v>
+     <v>       0.00000000       0.00000000       0.10758032 </v>
+    </varray>
+   </crystal>
+   <varray name="positions" >
+    <v>       0.03868254       0.04852072       0.12205397 </v>
+    <v>       0.04642460       0.38570275       0.37632633 </v>
+    <v>       0.29329051       0.13468013       0.37189472 </v>
+    <v>       0.29067742       0.30071834       0.12354735 </v>
+    <v>       0.04547528       0.04939872       0.62456771 </v>
+    <v>       0.03619865       0.38390176       0.87501613 </v>
+    <v>       0.29439355       0.13474018       0.87802602 </v>
+    <v>       0.29471401       0.30254292       0.62427081 </v>
+    <v>       0.04630300       0.54716824       0.12233736 </v>
+    <v>       0.03904974       0.88610604       0.37831906 </v>
+    <v>       0.29085905       0.63370623       0.37530703 </v>
+    <v>       0.29400775       0.79658817       0.12033197 </v>
+    <v>       0.04674472       0.55283638       0.62647327 </v>
+    <v>       0.04779872       0.88470797       0.86690247 </v>
+    <v>       0.29040350       0.63687744       0.86971942 </v>
+    <v>       0.28811566       0.80801050       0.62166354 </v>
+    <v>       0.53419909       0.04888617       0.12520732 </v>
+    <v>       0.54149587       0.38443573       0.37651849 </v>
+    <v>       0.78931127       0.13382026       0.37612420 </v>
+    <v>       0.79352011       0.30304666       0.12052539 </v>
+    <v>       0.53944908       0.05049164       0.62714222 </v>
+    <v>       0.54168796       0.38536823       0.87399331 </v>
+    <v>       0.79089817       0.13372662       0.87137063 </v>
+    <v>       0.79045028       0.30109482       0.62146477 </v>
+    <v>       0.54199444       0.55429956       0.12997709 </v>
+    <v>       0.54622046       0.88428483       0.37639707 </v>
+    <v>       0.79310583       0.63274392       0.37125222 </v>
+    <v>       0.79829851       0.80024313       0.12362859 </v>
+    <v>       0.54372971       0.54902863       0.62479661 </v>
+    <v>       0.54705701       0.88537798       0.87321459 </v>
+    <v>       0.79107652       0.63558224       0.87412259 </v>
+    <v>       0.78896486       0.80392694       0.62604648 </v>
+   </varray>
+  </structure>
+  <varray name="forces" >
+   <v>      -0.06142946       0.31069270       0.07707720 </v>
+   <v>      -0.06412609      -0.27771867      -0.07795514 </v>
+   <v>      -0.09481808      -0.30584810       0.36802500 </v>
+   <v>       0.06042669       0.21855796      -0.02813942 </v>
+   <v>      -0.11453089       0.56981430      -0.05952876 </v>
+   <v>       0.14677742      -0.18924534      -0.18265506 </v>
+   <v>      -0.08380729      -0.20836150      -0.35647765 </v>
+   <v>      -0.06869938       0.07842074      -0.01162639 </v>
+   <v>      -0.07399442       0.56428894       0.19374923 </v>
+   <v>       0.10138852      -0.28088373      -0.45481901 </v>
+   <v>       0.02985140      -0.19162084      -0.07033115 </v>
+   <v>      -0.05247135       0.41581361       0.26202789 </v>
+   <v>      -0.19808849       0.07006169      -0.21605458 </v>
+   <v>      -0.03428479      -0.19985113       0.64656424 </v>
+   <v>       0.12534420      -0.33370578       0.29877869 </v>
+   <v>       0.15240960      -0.23793486       0.09727727 </v>
+   <v>       0.25002810       0.25454441      -0.04815011 </v>
+   <v>       0.04347144      -0.12162565      -0.23331904 </v>
+   <v>       0.08700304      -0.14623080      -0.30908837 </v>
+   <v>      -0.10052031      -0.05296370       0.33815654 </v>
+   <v>       0.14521636       0.29192073      -0.22640820 </v>
+   <v>      -0.07446781      -0.20052126       0.08927143 </v>
+   <v>       0.05578742      -0.09481438       0.35259417 </v>
+   <v>       0.05817549       0.25399613       0.22331422 </v>
+   <v>      -0.00504669      -0.11026193      -0.51960115 </v>
+   <v>      -0.18103951      -0.16506180      -0.20988905 </v>
+   <v>       0.09005546      -0.12838681       0.38496600 </v>
+   <v>      -0.04599524       0.04297006      -0.03816336 </v>
+   <v>       0.07400929       0.43456029       0.07783037 </v>
+   <v>      -0.11830591      -0.27351022      -0.01577241 </v>
+   <v>       0.01273613      -0.17146981      -0.12127161 </v>
+   <v>      -0.06171143       0.18566953      -0.23124461 </v>
+  </varray>
+  <varray name="stress" >
+   <v>    -152.75599881      -0.23766986       0.14806514 </v>
+   <v>      -0.23766983       4.52127528      -0.02472804 </v>
+   <v>       0.14806522      -0.02472809      -1.77524362 </v>
+  </varray>
+  <energy>
+   <i name="e_fr_energy">   -252.96333393 </i>
+   <i name="e_wo_entrp">   -252.91290007 </i>
+   <i name="e_0_energy">   -252.94652265 </i>
+   <i name="kinetic">      1.80882661 </i>
+   <i name="lattice kinetic">      0.00000000 </i>
+   <i name="nosepot">      0.00000000 </i>
+   <i name="nosekinetic">      0.00000000 </i>
+   <i name="total">   -251.15450732 </i>
+  </energy>
+  <time name="totalsc">    3.33    3.35</time>
+ </calculation>
+ <calculation>
+  <scstep>
+   <time name="dav">    0.46    0.46</time>
+   <time name="total">    0.50    0.50</time>
+   <energy>
+    <i name="alphaZ">    650.40088722 </i>
+    <i name="ewald">  -4110.72448206 </i>
+    <i name="hartreedc">   -114.79281351 </i>
+    <i name="XCdc">  -1172.38657185 </i>
+    <i name="pawpsdc">   8448.02852681 </i>
+    <i name="pawaedc">  -7159.36397443 </i>
+    <i name="eentropy">     -0.04458833 </i>
+    <i name="bandstr">    172.66961155 </i>
+    <i name="atom">   3033.34488495 </i>
+    <i name="e_fr_energy">   -252.86851966 </i>
+    <i name="e_wo_entrp">   -252.82393133 </i>
+    <i name="e_0_energy">   -252.85365688 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.54    0.54</time>
+   <time name="total">    0.58    0.59</time>
+   <energy>
+    <i name="e_fr_energy">   -252.86848669 </i>
+    <i name="e_wo_entrp">   -252.82379820 </i>
+    <i name="e_0_energy">   -252.85359052 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.35    0.35</time>
+   <time name="total">    0.40    0.41</time>
+   <energy>
+    <i name="e_fr_energy">   -252.86846673 </i>
+    <i name="e_wo_entrp">   -252.82375414 </i>
+    <i name="e_0_energy">   -252.85356253 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.46    0.46</time>
+   <time name="total">    0.50    0.51</time>
+   <energy>
+    <i name="e_fr_energy">   -252.86846645 </i>
+    <i name="e_wo_entrp">   -252.82374750 </i>
+    <i name="e_0_energy">   -252.85356014 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.21    0.21</time>
+   <time name="total">    0.26    0.26</time>
+   <energy>
+    <i name="e_fr_energy">   -252.86846619 </i>
+    <i name="e_wo_entrp">   -252.82374808 </i>
+    <i name="e_0_energy">   -252.85356015 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.46    0.46</time>
+   <time name="total">    0.48    0.49</time>
+   <energy>
+    <i name="alphaZ">    650.40088722 </i>
+    <i name="ewald">  -4110.72448206 </i>
+    <i name="hartreedc">   -114.78470614 </i>
+    <i name="XCdc">  -1172.38586705 </i>
+    <i name="pawpsdc">   8447.81409479 </i>
+    <i name="pawaedc">  -7159.14811636 </i>
+    <i name="eentropy">     -0.04472277 </i>
+    <i name="bandstr">    172.65956121 </i>
+    <i name="atom">   3033.34488495 </i>
+    <i name="e_fr_energy">   -252.86846620 </i>
+    <i name="e_wo_entrp">   -252.82374343 </i>
+    <i name="e_0_energy">   -252.85355861 </i>
+   </energy>
+  </scstep>
+  <structure>
+   <crystal>
+    <varray name="basis" >
+     <v>       5.87198220       0.00000000       0.00000000 </v>
+     <v>       0.00000000      10.16561149       0.00000000 </v>
+     <v>       0.00000000       0.00000000       9.29538000 </v>
+    </varray>
+    <i name="volume">    554.86251651 </i>
+    <varray name="rec_basis" >
+     <v>       0.17030024       0.00000000       0.00000000 </v>
+     <v>       0.00000000       0.09837087       0.00000000 </v>
+     <v>       0.00000000       0.00000000       0.10758032 </v>
+    </varray>
+   </crystal>
+   <varray name="positions" >
+    <v>       0.03775599       0.04789404       0.12157581 </v>
+    <v>       0.04742948       0.38594338       0.37689120 </v>
+    <v>       0.29350576       0.13466116       0.37142444 </v>
+    <v>       0.29027936       0.30062746       0.12342532 </v>
+    <v>       0.04623408       0.04902962       0.62469548 </v>
+    <v>       0.03470185       0.38370588       0.87523654 </v>
+    <v>       0.29488740       0.13475082       0.87897001 </v>
+    <v>       0.29529167       0.30288726       0.62433222 </v>
+    <v>       0.04727862       0.54624145       0.12194895 </v>
+    <v>       0.03825437       0.88644763       0.37932066 </v>
+    <v>       0.29049806       0.63346116       0.37561757 </v>
+    <v>       0.29441399       0.79549362       0.11945475 </v>
+    <v>       0.04779838       0.55325282       0.62705152 </v>
+    <v>       0.04915446       0.88471207       0.86522892 </v>
+    <v>       0.28995350       0.63740355       0.86869446 </v>
+    <v>       0.28710140       0.80967510       0.62109147 </v>
+    <v>       0.53223267       0.04834274       0.12549721 </v>
+    <v>       0.54129687       0.38438305       0.37710585 </v>
+    <v>       0.78857868       0.13361066       0.37660011 </v>
+    <v>       0.79379184       0.30349685       0.11970838 </v>
+    <v>       0.53876788       0.05035494       0.62788658 </v>
+    <v>       0.54150644       0.38553742       0.87400240 </v>
+    <v>       0.79055393       0.13350105       0.87076707 </v>
+    <v>       0.78999498       0.30110351       0.62086299 </v>
+    <v>       0.54191014       0.55505491       0.13138153 </v>
+    <v>       0.54714407       0.88418827       0.37695771 </v>
+    <v>       0.79332201       0.63226766       0.37062472 </v>
+    <v>       0.79978006       0.80000718       0.12352507 </v>
+    <v>       0.54410012       0.54854776       0.62500382 </v>
+    <v>       0.54820607       0.88553852       0.87301074 </v>
+    <v>       0.79076533       0.63580889       0.87412952 </v>
+    <v>       0.78810841       0.80463346       0.62651571 </v>
+   </varray>
+  </structure>
+  <varray name="forces" >
+   <v>      -0.07297021       0.33784027       0.09287182 </v>
+   <v>      -0.07818635      -0.29353131      -0.09599732 </v>
+   <v>      -0.11832843      -0.32808691       0.45525902 </v>
+   <v>       0.07677623       0.22307507      -0.03532688 </v>
+   <v>      -0.14660282       0.66733874      -0.07443152 </v>
+   <v>       0.18231116      -0.18909372      -0.22620256 </v>
+   <v>      -0.10452974      -0.20835424      -0.43796384 </v>
+   <v>      -0.08245994       0.04843048      -0.01423707 </v>
+   <v>      -0.09177866       0.64934905       0.23734572 </v>
+   <v>       0.12303814      -0.30418193      -0.56229637 </v>
+   <v>       0.03980857      -0.18948209      -0.07846113 </v>
+   <v>      -0.06975587       0.47524666       0.30990924 </v>
+   <v>      -0.24320326       0.03986628      -0.26412942 </v>
+   <v>      -0.03775139      -0.20283643       0.80863940 </v>
+   <v>       0.15715574      -0.36177445       0.36469824 </v>
+   <v>       0.18894350      -0.35098045       0.11403965 </v>
+   <v>       0.30809308       0.26547662      -0.06532261 </v>
+   <v>       0.05227019      -0.10221154      -0.28525323 </v>
+   <v>       0.10659057      -0.13692272      -0.37422822 </v>
+   <v>      -0.12730291      -0.10690940       0.40999296 </v>
+   <v>       0.17904152       0.31576341      -0.28381346 </v>
+   <v>      -0.09328771      -0.20528500       0.10955144 </v>
+   <v>       0.06977342      -0.07118935       0.43264382 </v>
+   <v>       0.07337907       0.26428623       0.27646151 </v>
+   <v>      -0.00200140      -0.18381399      -0.63764651 </v>
+   <v>      -0.22165746      -0.15900884      -0.25464901 </v>
+   <v>       0.11491757      -0.11129651       0.47024856 </v>
+   <v>      -0.06725857       0.00683241      -0.04616849 </v>
+   <v>       0.09171645       0.48926047       0.09622101 </v>
+   <v>      -0.14506884      -0.29309714      -0.00721836 </v>
+   <v>       0.02031330      -0.16229662      -0.15093034 </v>
+   <v>      -0.08230862       0.17860716      -0.28402077 </v>
+  </varray>
+  <varray name="stress" >
+   <v>    -152.34231104      -0.33660745       0.23416941 </v>
+   <v>      -0.33660752       5.20450026      -0.05115656 </v>
+   <v>       0.23416941      -0.05115643      -1.16798236 </v>
+  </varray>
+  <energy>
+   <i name="e_fr_energy">   -252.86846620 </i>
+   <i name="e_wo_entrp">   -252.82374343 </i>
+   <i name="e_0_energy">   -252.85355861 </i>
+   <i name="kinetic">      1.71412777 </i>
+   <i name="lattice kinetic">      0.00000000 </i>
+   <i name="nosepot">      0.00000000 </i>
+   <i name="nosekinetic">      0.00000000 </i>
+   <i name="total">   -251.15433843 </i>
+  </energy>
+  <time name="totalsc">    3.47    3.51</time>
+ </calculation>
+ <calculation>
+  <scstep>
+   <time name="dav">    0.46    0.46</time>
+   <time name="total">    0.50    0.50</time>
+   <energy>
+    <i name="alphaZ">    650.40088722 </i>
+    <i name="ewald">  -4109.86128375 </i>
+    <i name="hartreedc">   -115.49023149 </i>
+    <i name="XCdc">  -1172.39109664 </i>
+    <i name="pawpsdc">   8456.25899315 </i>
+    <i name="pawaedc">  -7167.61823198 </i>
+    <i name="eentropy">     -0.03852243 </i>
+    <i name="bandstr">    172.63473426 </i>
+    <i name="atom">   3033.34488495 </i>
+    <i name="e_fr_energy">   -252.75986672 </i>
+    <i name="e_wo_entrp">   -252.72134429 </i>
+    <i name="e_0_energy">   -252.74702591 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.53    0.53</time>
+   <time name="total">    0.59    0.60</time>
+   <energy>
+    <i name="e_fr_energy">   -252.75983373 </i>
+    <i name="e_wo_entrp">   -252.72113519 </i>
+    <i name="e_0_energy">   -252.74693422 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.35    0.35</time>
+   <time name="total">    0.39    0.39</time>
+   <energy>
+    <i name="e_fr_energy">   -252.75981640 </i>
+    <i name="e_wo_entrp">   -252.72113758 </i>
+    <i name="e_0_energy">   -252.74692346 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.53    0.53</time>
+   <time name="total">    0.58    0.58</time>
+   <energy>
+    <i name="e_fr_energy">   -252.75981623 </i>
+    <i name="e_wo_entrp">   -252.72113777 </i>
+    <i name="e_0_energy">   -252.74692341 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.40    0.40</time>
+   <time name="total">    0.45    0.45</time>
+   <energy>
+    <i name="e_fr_energy">   -252.75981595 </i>
+    <i name="e_wo_entrp">   -252.72113430 </i>
+    <i name="e_0_energy">   -252.74692207 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.29    0.29</time>
+   <time name="total">    0.32    0.32</time>
+   <energy>
+    <i name="alphaZ">    650.40088722 </i>
+    <i name="ewald">  -4109.86128375 </i>
+    <i name="hartreedc">   -115.48074944 </i>
+    <i name="XCdc">  -1172.39025867 </i>
+    <i name="pawpsdc">   8456.04175518 </i>
+    <i name="pawaedc">  -7167.39938213 </i>
+    <i name="eentropy">     -0.03868800 </i>
+    <i name="bandstr">    172.62301859 </i>
+    <i name="atom">   3033.34488495 </i>
+    <i name="e_fr_energy">   -252.75981604 </i>
+    <i name="e_wo_entrp">   -252.72112804 </i>
+    <i name="e_0_energy">   -252.74692004 </i>
+   </energy>
+  </scstep>
+  <structure>
+   <crystal>
+    <varray name="basis" >
+     <v>       5.87198220       0.00000000       0.00000000 </v>
+     <v>       0.00000000      10.16561149       0.00000000 </v>
+     <v>       0.00000000       0.00000000       9.29538000 </v>
+    </varray>
+    <i name="volume">    554.86251651 </i>
+    <varray name="rec_basis" >
+     <v>       0.17030024       0.00000000       0.00000000 </v>
+     <v>       0.00000000       0.09837087       0.00000000 </v>
+     <v>       0.00000000       0.00000000       0.10758032 </v>
+    </varray>
+   </crystal>
+   <varray name="positions" >
+    <v>       0.03681943       0.04729415       0.12110571 </v>
+    <v>       0.04842362       0.38616072       0.37744776 </v>
+    <v>       0.29370478       0.13461617       0.37099364 </v>
+    <v>       0.28989185       0.30055426       0.12330023 </v>
+    <v>       0.04697276       0.04871344       0.62481679 </v>
+    <v>       0.03323008       0.38349500       0.87543733 </v>
+    <v>       0.29536690       0.13474494       0.87987602 </v>
+    <v>       0.29585800       0.30323544       0.62439239 </v>
+    <v>       0.04824165       0.54536614       0.12158113 </v>
+    <v>       0.03747589       0.88676510       0.38027349 </v>
+    <v>       0.29014254       0.63320105       0.37592131 </v>
+    <v>       0.29481065       0.79443674       0.11860440 </v>
+    <v>       0.04881866       0.55367242       0.62760687 </v>
+    <v>       0.05050502       0.88470008       0.86362550 </v>
+    <v>       0.28952507       0.63790096       0.86770112 </v>
+    <v>       0.28611308       0.81131186       0.62052928 </v>
+    <v>       0.53030853       0.04782036       0.12578143 </v>
+    <v>       0.54110505       0.38432227       0.37766847 </v>
+    <v>       0.78786072       0.13339020       0.37704357 </v>
+    <v>       0.79404609       0.30393856       0.11892694 </v>
+    <v>       0.53811126       0.05024328       0.62860632 </v>
+    <v>       0.54131211       0.38569033       0.87402099 </v>
+    <v>       0.79021928       0.13326983       0.87020103 </v>
+    <v>       0.78954975       0.30113315       0.62028519 </v>
+    <v>       0.54182557       0.55579568       0.13273068 </v>
+    <v>       0.54803725       0.88407910       0.37749626 </v>
+    <v>       0.79355397       0.63178257       0.37003800 </v>
+    <v>       0.80125237       0.79977176       0.12341755 </v>
+    <v>       0.54448311       0.54810569       0.62521937 </v>
+    <v>       0.54933522       0.88567582       0.87280628 </v>
+    <v>       0.79045694       0.63602267       0.87412336 </v>
+    <v>       0.78724068       0.80535413       0.62696032 </v>
+   </varray>
+  </structure>
+  <varray name="forces" >
+   <v>      -0.08260888       0.36355201       0.10776211 </v>
+   <v>      -0.09216659      -0.30819380      -0.11407470 </v>
+   <v>      -0.14141057      -0.34798833       0.53804445 </v>
+   <v>       0.09314435       0.22801515      -0.04212694 </v>
+   <v>      -0.18020915       0.76501384      -0.08827678 </v>
+   <v>       0.21652907      -0.18908053      -0.26715444 </v>
+   <v>      -0.12461322      -0.20765526      -0.51486265 </v>
+   <v>      -0.09515921       0.01900047      -0.01637146 </v>
+   <v>      -0.10893488       0.72950253       0.27733284 </v>
+   <v>       0.14287950      -0.32801108      -0.66548177 </v>
+   <v>       0.05023568      -0.18697211      -0.08313742 </v>
+   <v>      -0.08841674       0.53637506       0.35116862 </v>
+   <v>      -0.28601963       0.01152247      -0.30860380 </v>
+   <v>      -0.04027199      -0.20637162       0.96740782 </v>
+   <v>       0.18852913      -0.38790531       0.42606992 </v>
+   <v>       0.22521270      -0.46447070       0.12830216 </v>
+   <v>       0.36379469       0.27481637      -0.08480670 </v>
+   <v>       0.06047077      -0.08371485      -0.33396950 </v>
+   <v>       0.12517472      -0.12871152      -0.43384000 </v>
+   <v>      -0.15434579      -0.15614713       0.47601498 </v>
+   <v>       0.21131508       0.33976711      -0.34034453 </v>
+   <v>      -0.11155990      -0.21154991       0.12873481 </v>
+   <v>       0.08331044      -0.04903266       0.50788325 </v>
+   <v>       0.08863844       0.27304691       0.32761573 </v>
+   <v>       0.00290176      -0.25415791      -0.74869968 </v>
+   <v>      -0.25995613      -0.15429965      -0.29661808 </v>
+   <v>       0.13978819      -0.09485536       0.54970423 </v>
+   <v>      -0.09164240      -0.02693902      -0.05362340 </v>
+   <v>       0.10823137       0.54271181       0.11296592 </v>
+   <v>      -0.16994944      -0.31276693       0.00639493 </v>
+   <v>       0.02966465      -0.15292814      -0.17933354 </v>
+   <v>      -0.10331167       0.16944974      -0.33409485 </v>
+  </varray>
+  <varray name="stress" >
+   <v>    -151.86505328      -0.44613597       0.34003496 </v>
+   <v>      -0.44613597       5.96938020      -0.08841790 </v>
+   <v>       0.34003498      -0.08841794      -0.47713540 </v>
+  </varray>
+  <energy>
+   <i name="e_fr_energy">   -252.75981604 </i>
+   <i name="e_wo_entrp">   -252.72112804 </i>
+   <i name="e_0_energy">   -252.74692004 </i>
+   <i name="kinetic">      1.60567410 </i>
+   <i name="lattice kinetic">      0.00000000 </i>
+   <i name="nosepot">      0.00000000 </i>
+   <i name="nosekinetic">      0.00000000 </i>
+   <i name="total">   -251.15414194 </i>
+  </energy>
+  <time name="totalsc">    3.57    3.60</time>
+ </calculation>
+ <calculation>
+  <scstep>
+   <time name="dav">    0.54    0.54</time>
+   <time name="total">    0.58    0.58</time>
+   <energy>
+    <i name="alphaZ">    650.40088722 </i>
+    <i name="ewald">  -4108.90057732 </i>
+    <i name="hartreedc">   -116.26371790 </i>
+    <i name="XCdc">  -1172.39613204 </i>
+    <i name="pawpsdc">   8465.40447560 </i>
+    <i name="pawaedc">  -7176.78926505 </i>
+    <i name="eentropy">     -0.03239786 </i>
+    <i name="bandstr">    172.59106529 </i>
+    <i name="atom">   3033.34488495 </i>
+    <i name="e_fr_energy">   -252.64077712 </i>
+    <i name="e_wo_entrp">   -252.60837926 </i>
+    <i name="e_0_energy">   -252.62997783 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.54    0.54</time>
+   <time name="total">    0.59    0.59</time>
+   <energy>
+    <i name="e_fr_energy">   -252.64075504 </i>
+    <i name="e_wo_entrp">   -252.60825237 </i>
+    <i name="e_0_energy">   -252.62992081 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.54    0.54</time>
+   <time name="total">    0.59    0.59</time>
+   <energy>
+    <i name="e_fr_energy">   -252.64072956 </i>
+    <i name="e_wo_entrp">   -252.60818929 </i>
+    <i name="e_0_energy">   -252.62988280 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.56    0.56</time>
+   <time name="total">    0.60    0.61</time>
+   <energy>
+    <i name="e_fr_energy">   -252.64072928 </i>
+    <i name="e_wo_entrp">   -252.60818718 </i>
+    <i name="e_0_energy">   -252.62988192 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.29    0.29</time>
+   <time name="total">    0.34    0.34</time>
+   <energy>
+    <i name="e_fr_energy">   -252.64072903 </i>
+    <i name="e_wo_entrp">   -252.60818578 </i>
+    <i name="e_0_energy">   -252.62988128 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.16    0.16</time>
+   <time name="total">    0.18    0.19</time>
+   <energy>
+    <i name="alphaZ">    650.40088722 </i>
+    <i name="ewald">  -4108.90057732 </i>
+    <i name="hartreedc">   -116.25475445 </i>
+    <i name="XCdc">  -1172.39534482 </i>
+    <i name="pawpsdc">   8465.21744847 </i>
+    <i name="pawaedc">  -7176.60045050 </i>
+    <i name="eentropy">     -0.03254568 </i>
+    <i name="bandstr">    172.57972308 </i>
+    <i name="atom">   3033.34488495 </i>
+    <i name="e_fr_energy">   -252.64072907 </i>
+    <i name="e_wo_entrp">   -252.60818338 </i>
+    <i name="e_0_energy">   -252.62988051 </i>
+   </energy>
+  </scstep>
+  <structure>
+   <crystal>
+    <varray name="basis" >
+     <v>       5.87198220       0.00000000       0.00000000 </v>
+     <v>       0.00000000      10.16561149       0.00000000 </v>
+     <v>       0.00000000       0.00000000       9.29538000 </v>
+    </varray>
+    <i name="volume">    554.86251651 </i>
+    <varray name="rec_basis" >
+     <v>       0.17030024       0.00000000       0.00000000 </v>
+     <v>       0.00000000       0.09837087       0.00000000 </v>
+     <v>       0.00000000       0.00000000       0.10758032 </v>
+    </varray>
+   </crystal>
+   <varray name="positions" >
+    <v>       0.03587153       0.04672307       0.12064495 </v>
+    <v>       0.04940512       0.38635363       0.37799442 </v>
+    <v>       0.29388439       0.13454359       0.37060950 </v>
+    <v>       0.28951713       0.30049913       0.12317149 </v>
+    <v>       0.04768670       0.04845791       0.62493045 </v>
+    <v>       0.03178803       0.38326912       0.87561497 </v>
+    <v>       0.29582930       0.13472259       0.88073739 </v>
+    <v>       0.29641127       0.30358512       0.62445114 </v>
+    <v>       0.04918972       0.54454868       0.12123735 </v>
+    <v>       0.03671703       0.88705656       0.38116863 </v>
+    <v>       0.28979392       0.63292612       0.37621784 </v>
+    <v>       0.29519518       0.79342240       0.11778450 </v>
+    <v>       0.04979968       0.55409294       0.62813545 </v>
+    <v>       0.05185005       0.88467172       0.86210597 </v>
+    <v>       0.28912253       0.63836761       0.86674473 </v>
+    <v>       0.28515568       0.81291179       0.61997823 </v>
+    <v>       0.52843434       0.04731976       0.12605830 </v>
+    <v>       0.54092154       0.38425485       0.37820213 </v>
+    <v>       0.78715995       0.13315954       0.37744941 </v>
+    <v>       0.79427916       0.30436788       0.11818677 </v>
+    <v>       0.53748365       0.05015856       0.62929655 </v>
+    <v>       0.54110247       0.38582647       0.87405074 </v>
+    <v>       0.78989606       0.13303473       0.86967903 </v>
+    <v>       0.78911669       0.30118444       0.61973579 </v>
+    <v>       0.54174140       0.55651629       0.13401490 </v>
+    <v>       0.54889474       0.88395769       0.37800909 </v>
+    <v>       0.79380512       0.63128995       0.36949894 </v>
+    <v>       0.80271210       0.79953421       0.12330538 </v>
+    <v>       0.54488097       0.54770664       0.62544472 </v>
+    <v>       0.55044105       0.88578831       0.87260236 </v>
+    <v>       0.79015261       0.63622431       0.87410165 </v>
+    <v>       0.78635876       0.80608825       0.62737596 </v>
+   </varray>
+  </structure>
+  <varray name="forces" >
+   <v>      -0.08971818       0.38728932       0.12178789 </v>
+   <v>      -0.10617926      -0.32210150      -0.13199746 </v>
+   <v>      -0.16372111      -0.36620877       0.61506565 </v>
+   <v>       0.10928790       0.23291597      -0.04829970 </v>
+   <v>      -0.21453972       0.86119836      -0.10083830 </v>
+   <v>       0.25010591      -0.18851174      -0.30470854 </v>
+   <v>      -0.14407986      -0.20687725      -0.58663887 </v>
+   <v>      -0.10632999      -0.00994565      -0.01827429 </v>
+   <v>      -0.12562677       0.80369886       0.31354395 </v>
+   <v>       0.16140752      -0.35168421      -0.76299730 </v>
+   <v>       0.06118201      -0.18319571      -0.08500155 </v>
+   <v>      -0.10855482       0.59859048       0.38611702 </v>
+   <v>      -0.32601433      -0.01478418      -0.34899731 </v>
+   <v>      -0.04166080      -0.21002754       1.12028713 </v>
+   <v>       0.21907302      -0.41158442       0.48211691 </v>
+   <v>       0.26099253      -0.57681156       0.14021789 </v>
+   <v>       0.41664611       0.28244881      -0.10628184 </v>
+   <v>       0.06803752      -0.06648162      -0.37926028 </v>
+   <v>       0.14230922      -0.12207638      -0.48711299 </v>
+   <v>      -0.18134157      -0.20032914       0.53639130 </v>
+   <v>       0.24130523       0.36418021      -0.39557353 </v>
+   <v>      -0.12935871      -0.21887187       0.14670765 </v>
+   <v>       0.09625777      -0.02915670       0.57751172 </v>
+   <v>       0.10405171       0.28014591       0.37618100 </v>
+   <v>       0.00948385      -0.32053054      -0.85143157 </v>
+   <v>      -0.29574413      -0.15034517      -0.33583515 </v>
+   <v>       0.16411884      -0.07905894       0.62283294 </v>
+   <v>      -0.11881325      -0.05779778      -0.06007865 </v>
+   <v>       0.12280788       0.59446614       0.12757306 </v>
+   <v>      -0.19300400      -0.33163183       0.02479507 </v>
+   <v>       0.04076292      -0.14344527      -0.20590495 </v>
+   <v>      -0.12378592       0.15817539      -0.38128446 </v>
+  </varray>
+  <varray name="stress" >
+   <v>    -151.33014317      -0.56103922       0.46369416 </v>
+   <v>      -0.56103928       6.78998838      -0.14070764 </v>
+   <v>       0.46369416      -0.14070756       0.27694433 </v>
+  </varray>
+  <energy>
+   <i name="e_fr_energy">   -252.64072907 </i>
+   <i name="e_wo_entrp">   -252.60818338 </i>
+   <i name="e_0_energy">   -252.62988051 </i>
+   <i name="kinetic">      1.48680809 </i>
+   <i name="lattice kinetic">      0.00000000 </i>
+   <i name="nosepot">      0.00000000 </i>
+   <i name="nosekinetic">      0.00000000 </i>
+   <i name="total">   -251.15392097 </i>
+  </energy>
+  <time name="totalsc">    3.60    3.64</time>
+ </calculation>
+ <calculation>
+  <scstep>
+   <time name="dav">    0.64    0.64</time>
+   <time name="total">    0.68    0.68</time>
+   <energy>
+    <i name="alphaZ">    650.40088722 </i>
+    <i name="ewald">  -4107.86883161 </i>
+    <i name="hartreedc">   -117.09444841 </i>
+    <i name="XCdc">  -1172.40186028 </i>
+    <i name="pawpsdc">   8475.25523235 </i>
+    <i name="pawaedc">  -7186.66622942 </i>
+    <i name="eentropy">     -0.02639137 </i>
+    <i name="bandstr">    172.54180558 </i>
+    <i name="atom">   3033.34488495 </i>
+    <i name="e_fr_energy">   -252.51495099 </i>
+    <i name="e_wo_entrp">   -252.48855963 </i>
+    <i name="e_0_energy">   -252.50615387 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.54    0.54</time>
+   <time name="total">    0.58    0.59</time>
+   <energy>
+    <i name="e_fr_energy">   -252.51492683 </i>
+    <i name="e_wo_entrp">   -252.48836050 </i>
+    <i name="e_0_energy">   -252.50607139 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.53    0.53</time>
+   <time name="total">    0.58    0.58</time>
+   <energy>
+    <i name="e_fr_energy">   -252.51490665 </i>
+    <i name="e_wo_entrp">   -252.48834642 </i>
+    <i name="e_0_energy">   -252.50605324 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.53    0.53</time>
+   <time name="total">    0.58    0.58</time>
+   <energy>
+    <i name="e_fr_energy">   -252.51490632 </i>
+    <i name="e_wo_entrp">   -252.48835385 </i>
+    <i name="e_0_energy">   -252.50605549 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.16    0.16</time>
+   <time name="total">    0.21    0.21</time>
+   <energy>
+    <i name="e_fr_energy">   -252.51490608 </i>
+    <i name="e_wo_entrp">   -252.48834748 </i>
+    <i name="e_0_energy">   -252.50605321 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.29    0.29</time>
+   <time name="total">    0.31    0.32</time>
+   <energy>
+    <i name="alphaZ">    650.40088722 </i>
+    <i name="ewald">  -4107.86883161 </i>
+    <i name="hartreedc">   -117.08568601 </i>
+    <i name="XCdc">  -1172.40114926 </i>
+    <i name="pawpsdc">   8475.03261388 </i>
+    <i name="pawaedc">  -7186.44197500 </i>
+    <i name="eentropy">     -0.02656263 </i>
+    <i name="bandstr">    172.53091234 </i>
+    <i name="atom">   3033.34488495 </i>
+    <i name="e_fr_energy">   -252.51490613 </i>
+    <i name="e_wo_entrp">   -252.48834349 </i>
+    <i name="e_0_energy">   -252.50605192 </i>
+   </energy>
+  </scstep>
+  <structure>
+   <crystal>
+    <varray name="basis" >
+     <v>       5.87198220       0.00000000       0.00000000 </v>
+     <v>       0.00000000      10.16561149       0.00000000 </v>
+     <v>       0.00000000       0.00000000       9.29538000 </v>
+    </varray>
+    <i name="volume">    554.86251651 </i>
+    <varray name="rec_basis" >
+     <v>       0.17030024       0.00000000       0.00000000 </v>
+     <v>       0.00000000       0.09837087       0.00000000 </v>
+     <v>       0.00000000       0.00000000       0.10758032 </v>
+    </varray>
+   </crystal>
+   <varray name="positions" >
+    <v>       0.03491131       0.04618271       0.12019475 </v>
+    <v>       0.05037205       0.38652099       0.37852963 </v>
+    <v>       0.29404153       0.13444196       0.37027869 </v>
+    <v>       0.28915742       0.30046247       0.12303856 </v>
+    <v>       0.04837120       0.04827067       0.62503537 </v>
+    <v>       0.03038032       0.38302829       0.87576617 </v>
+    <v>       0.29627192       0.13468383       0.88154789 </v>
+    <v>       0.29694995       0.30393401       0.62450830 </v>
+    <v>       0.05012055       0.54379494       0.12092077 </v>
+    <v>       0.03598033       0.88732013       0.38199759 </v>
+    <v>       0.28945371       0.63263665       0.37650699 </v>
+    <v>       0.29556481       0.79245551       0.11699809 </v>
+    <v>       0.05073595       0.55451227       0.62863377 </v>
+    <v>       0.05318936       0.88462671       0.86068358 </v>
+    <v>       0.28875006       0.63880163       0.86583015 </v>
+    <v>       0.28423411       0.81446598       0.61943933 </v>
+    <v>       0.52661735       0.04684156       0.12632595 </v>
+    <v>       0.54074736       0.38418215       0.37870290 </v>
+    <v>       0.78647871       0.13291919       0.37781300 </v>
+    <v>       0.79448733       0.30478132       0.11749311 </v>
+    <v>       0.53688917       0.05010272       0.62995247 </v>
+    <v>       0.54087507       0.38594524       0.87409322 </v>
+    <v>       0.78958606       0.13279731       0.86920711 </v>
+    <v>       0.78869793       0.30125794       0.61921901 </v>
+    <v>       0.54165853       0.55721148       0.13522529 </v>
+    <v>       0.54971165       0.88382436       0.37849280 </v>
+    <v>       0.79407881       0.63079107       0.36901390 </v>
+    <v>       0.80415553       0.79929206       0.12318800 </v>
+    <v>       0.54529568       0.54735473       0.62568113 </v>
+    <v>       0.55152038       0.88587451       0.87240060 </v>
+    <v>       0.78985389       0.63641458       0.87406208 </v>
+    <v>       0.78545985       0.80683490       0.62775853 </v>
+   </varray>
+  </structure>
+  <varray name="forces" >
+   <v>      -0.09429106       0.40929710       0.13520068 </v>
+   <v>      -0.12008141      -0.33502975      -0.15002647 </v>
+   <v>      -0.18508170      -0.38201733       0.68523253 </v>
+   <v>       0.12468129       0.23776478      -0.05361085 </v>
+   <v>      -0.24938914       0.95435484      -0.11165159 </v>
+   <v>       0.28230444      -0.18696903      -0.33824950 </v>
+   <v>      -0.16217140      -0.20552011      -0.65265247 </v>
+   <v>      -0.11632082      -0.03778990      -0.01969139 </v>
+   <v>      -0.14212670       0.87099082       0.34535958 </v>
+   <v>       0.17820332      -0.37500034      -0.85383634 </v>
+   <v>       0.07233604      -0.17849264      -0.08444743 </v>
+   <v>      -0.12941543       0.66083509       0.41570835 </v>
+   <v>      -0.36323022      -0.03907175      -0.38496968 </v>
+   <v>      -0.04350890      -0.21340233       1.26517893 </v>
+   <v>       0.24856599      -0.43371534       0.53243278 </v>
+   <v>       0.29635627      -0.68727950       0.14992878 </v>
+   <v>       0.46613724       0.28840552      -0.12964295 </v>
+   <v>       0.07518312      -0.05078826      -0.42070377 </v>
+   <v>       0.15797414      -0.11629920      -0.53411259 </v>
+   <v>      -0.20783528      -0.23949133       0.59095346 </v>
+   <v>       0.26902578       0.38846856      -0.44873858 </v>
+   <v>      -0.14626299      -0.22741874       0.16275529 </v>
+   <v>       0.10822949      -0.01121215       0.64039930 </v>
+   <v>       0.11913882       0.28564169       0.42182302 </v>
+   <v>       0.01785432      -0.38248923      -0.94548416 </v>
+   <v>      -0.32862272      -0.14763451      -0.37203037 </v>
+   <v>       0.18766215      -0.06401939       0.68908677 </v>
+   <v>      -0.14829053      -0.08602046      -0.06573598 </v>
+   <v>       0.13539402       0.64425852       0.13943350 </v>
+   <v>      -0.21351472      -0.34983297       0.04720188 </v>
+   <v>       0.05351477      -0.13405592      -0.23034786 </v>
+   <v>      -0.14283132       0.14519007      -0.42518277 </v>
+  </varray>
+  <varray name="stress" >
+   <v>    -150.75910115      -0.68051066       0.60179423 </v>
+   <v>      -0.68051067       7.63115747      -0.20223447 </v>
+   <v>       0.60179424      -0.20223437       1.06721039 </v>
+  </varray>
+  <energy>
+   <i name="e_fr_energy">   -252.51490613 </i>
+   <i name="e_wo_entrp">   -252.48834349 </i>
+   <i name="e_0_energy">   -252.50605192 </i>
+   <i name="kinetic">      1.36122328 </i>
+   <i name="lattice kinetic">      0.00000000 </i>
+   <i name="nosepot">      0.00000000 </i>
+   <i name="nosekinetic">      0.00000000 </i>
+   <i name="total">   -251.15368284 </i>
+  </energy>
+  <time name="totalsc">    3.68    3.71</time>
+ </calculation>
+ <calculation>
+  <scstep>
+   <time name="dav">    0.64    0.64</time>
+   <time name="total">    0.68    0.68</time>
+   <energy>
+    <i name="alphaZ">    650.40088722 </i>
+    <i name="ewald">  -4106.79424254 </i>
+    <i name="hartreedc">   -117.95882574 </i>
+    <i name="XCdc">  -1172.40823702 </i>
+    <i name="pawpsdc">   8485.44716935 </i>
+    <i name="pawaedc">  -7196.88440144 </i>
+    <i name="eentropy">     -0.02080829 </i>
+    <i name="bandstr">    172.48727095 </i>
+    <i name="atom">   3033.34488495 </i>
+    <i name="e_fr_energy">   -252.38630258 </i>
+    <i name="e_wo_entrp">   -252.36549429 </i>
+    <i name="e_0_energy">   -252.37936648 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.53    0.53</time>
+   <time name="total">    0.57    0.58</time>
+   <energy>
+    <i name="e_fr_energy">   -252.38628059 </i>
+    <i name="e_wo_entrp">   -252.36535349 </i>
+    <i name="e_0_energy">   -252.37930489 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.53    0.53</time>
+   <time name="total">    0.61    0.61</time>
+   <energy>
+    <i name="e_fr_energy">   -252.38626304 </i>
+    <i name="e_wo_entrp">   -252.36530631 </i>
+    <i name="e_0_energy">   -252.37927747 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.46    0.46</time>
+   <time name="total">    0.51    0.51</time>
+   <energy>
+    <i name="e_fr_energy">   -252.38626286 </i>
+    <i name="e_wo_entrp">   -252.36530703 </i>
+    <i name="e_0_energy">   -252.37927758 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.16    0.16</time>
+   <time name="total">    0.20    0.21</time>
+   <energy>
+    <i name="e_fr_energy">   -252.38626263 </i>
+    <i name="e_wo_entrp">   -252.36530464 </i>
+    <i name="e_0_energy">   -252.37927663 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.30    0.30</time>
+   <time name="total">    0.32    0.33</time>
+   <energy>
+    <i name="alphaZ">    650.40088722 </i>
+    <i name="ewald">  -4106.79424254 </i>
+    <i name="hartreedc">   -117.95092048 </i>
+    <i name="XCdc">  -1172.40754065 </i>
+    <i name="pawpsdc">   8485.30069765 </i>
+    <i name="pawaedc">  -7196.73616052 </i>
+    <i name="eentropy">     -0.02095868 </i>
+    <i name="bandstr">    172.47709042 </i>
+    <i name="atom">   3033.34488495 </i>
+    <i name="e_fr_energy">   -252.38626263 </i>
+    <i name="e_wo_entrp">   -252.36530395 </i>
+    <i name="e_0_energy">   -252.37927641 </i>
+   </energy>
+  </scstep>
+  <structure>
+   <crystal>
+    <varray name="basis" >
+     <v>       5.87198220       0.00000000       0.00000000 </v>
+     <v>       0.00000000      10.16561149       0.00000000 </v>
+     <v>       0.00000000       0.00000000       9.29538000 </v>
+    </varray>
+    <i name="volume">    554.86251651 </i>
+    <varray name="rec_basis" >
+     <v>       0.17030024       0.00000000       0.00000000 </v>
+     <v>       0.00000000       0.09837087       0.00000000 </v>
+     <v>       0.00000000       0.00000000       0.10758032 </v>
+    </varray>
+   </crystal>
+   <varray name="positions" >
+    <v>       0.03393815       0.04567479       0.11975627 </v>
+    <v>       0.05132249       0.38666179       0.37905184 </v>
+    <v>       0.29417326       0.13431004       0.37000731 </v>
+    <v>       0.28881482       0.30044466       0.12290098 </v>
+    <v>       0.04902147       0.04815909       0.62513060 </v>
+    <v>       0.02901137       0.38277263       0.87588805 </v>
+    <v>       0.29669228       0.13462877       0.88230179 </v>
+    <v>       0.29747267       0.30427990       0.62456376 </v>
+    <v>       0.05103188       0.54311026       0.12063413 </v>
+    <v>       0.03526809       0.88755396       0.38275252 </v>
+    <v>       0.28912342       0.63233303       0.37678883 </v>
+    <v>       0.29591667       0.79154102       0.11624772 </v>
+    <v>       0.05162235       0.55492851       0.62909870 </v>
+    <v>       0.05452270       0.88456477       0.85937091 </v>
+    <v>       0.28841171       0.63920125       0.86496174 </v>
+    <v>       0.28335322       0.81596567       0.61891343 </v>
+    <v>       0.52486434       0.04638623       0.12658236 </v>
+    <v>       0.54058351       0.38410542       0.37916720 </v>
+    <v>       0.78581917       0.13266961       0.37813028 </v>
+    <v>       0.79466698       0.30517576       0.11685070 </v>
+    <v>       0.53633162       0.05007767       0.63056949 </v>
+    <v>       0.54062760       0.38604598       0.87414981 </v>
+    <v>       0.78929092       0.13255899       0.86879072 </v>
+    <v>       0.78829551       0.30135408       0.61873881 </v>
+    <v>       0.54157812       0.55787635       0.13635369 </v>
+    <v>       0.55048344       0.88367932       0.37894425 </v>
+    <v>       0.79437825       0.63028710       0.36858861 </v>
+    <v>       0.80557860       0.79904310       0.12306492 </v>
+    <v>       0.54572899       0.54705390       0.62592963 </v>
+    <v>       0.55257040       0.88593296       0.87220293 </v>
+    <v>       0.78956251       0.63659422       0.87400254 </v>
+    <v>       0.78454134       0.80759306       0.62810423 </v>
+   </varray>
+  </structure>
+  <varray name="forces" >
+   <v>      -0.09617041       0.42898756       0.14820321 </v>
+   <v>      -0.13482457      -0.34753415      -0.16824791 </v>
+   <v>      -0.20525081      -0.39600592       0.74760353 </v>
+   <v>       0.13920307       0.24224533      -0.05792695 </v>
+   <v>      -0.28443005       1.04229618      -0.12027330 </v>
+   <v>       0.31316803      -0.18405679      -0.36716426 </v>
+   <v>      -0.17933645      -0.20448599      -0.71240116 </v>
+   <v>      -0.12507697      -0.06423837      -0.02055062 </v>
+   <v>      -0.15851866       0.93132918       0.37274970 </v>
+   <v>       0.19361712      -0.39713770      -0.93682652 </v>
+   <v>       0.08385470      -0.17219262      -0.08247438 </v>
+   <v>      -0.15087272       0.72175222       0.44036996 </v>
+   <v>      -0.39748733      -0.06116241      -0.41636378 </v>
+   <v>      -0.04541726      -0.21619041       1.40006129 </v>
+   <v>       0.27649567      -0.45323432       0.57727674 </v>
+   <v>       0.33069410      -0.79410693       0.15849055 </v>
+   <v>       0.51275752       0.29294727      -0.15425045 </v>
+   <v>       0.08234472      -0.03687877      -0.45797167 </v>
+   <v>       0.17198995      -0.11147255      -0.57435805 </v>
+   <v>      -0.23348869      -0.27354162       0.63983212 </v>
+   <v>       0.29422398       0.41296909      -0.49914587 </v>
+   <v>      -0.16202371      -0.23654908       0.17680323 </v>
+   <v>       0.11914119       0.00440923       0.69633554 </v>
+   <v>       0.13385808       0.28938584       0.46415662 </v>
+   <v>       0.02780730      -0.43933309      -1.02952608 </v>
+   <v>      -0.35875194      -0.14562345      -0.40584682 </v>
+   <v>       0.20954732      -0.04981379       0.74776266 </v>
+   <v>      -0.17911686      -0.11127563      -0.07044799 </v>
+   <v>       0.14568717       0.69151893       0.14833877 </v>
+   <v>      -0.23207050      -0.36691314       0.07308230 </v>
+   <v>       0.06786776      -0.12505271      -0.25207480 </v>
+   <v>      -0.15935303       0.13072693      -0.46523408 </v>
+  </varray>
+  <varray name="stress" >
+   <v>    -150.15310495      -0.79978778       0.75046395 </v>
+   <v>      -0.79978772       8.47953302      -0.27542733 </v>
+   <v>       0.75046398      -0.27542728       1.85891868 </v>
+  </varray>
+  <energy>
+   <i name="e_fr_energy">   -252.38626263 </i>
+   <i name="e_wo_entrp">   -252.36530395 </i>
+   <i name="e_0_energy">   -252.37927641 </i>
+   <i name="kinetic">      1.23282418 </i>
+   <i name="lattice kinetic">      0.00000000 </i>
+   <i name="nosepot">      0.00000000 </i>
+   <i name="nosekinetic">      0.00000000 </i>
+   <i name="total">   -251.15343845 </i>
+  </energy>
+  <dos>
+   <i name="efermi">      3.07830407 </i>
+   <total>
+    <array>
+     <dimension dim="1">gridpoints</dimension>
+     <dimension dim="2">spin</dimension>
+     <field>energy</field>
+     <field>total</field>
+     <field>integrated</field>
+     <set>
+      <set comment="spin 1">
+       <r>    -5.0415     0.0000     0.0000 </r>
+       <r>    -5.0004     0.0000     0.0000 </r>
+       <r>    -4.9593     0.0000     0.0000 </r>
+       <r>    -4.9182     0.0000     0.0000 </r>
+       <r>    -4.8771     0.0000     0.0000 </r>
+       <r>    -4.8360     0.0000     0.0000 </r>
+       <r>    -4.7949     0.0000     0.0000 </r>
+       <r>    -4.7538     0.0000     0.0000 </r>
+       <r>    -4.7127     0.0000     0.0000 </r>
+       <r>    -4.6716    -0.0000    -0.0000 </r>
+       <r>    -4.6305    -0.0000    -0.0000 </r>
+       <r>    -4.5894    -0.0000    -0.0000 </r>
+       <r>    -4.5483    -0.0000    -0.0000 </r>
+       <r>    -4.5072    -0.0000    -0.0000 </r>
+       <r>    -4.4661    -0.0000    -0.0000 </r>
+       <r>    -4.4250    -0.0000    -0.0000 </r>
+       <r>    -4.3839    -0.0000    -0.0000 </r>
+       <r>    -4.3428    -0.0000    -0.0000 </r>
+       <r>    -4.3017    -0.0000    -0.0000 </r>
+       <r>    -4.2606    -0.0000    -0.0000 </r>
+       <r>    -4.2195    -0.0000    -0.0000 </r>
+       <r>    -4.1784    -0.0000    -0.0000 </r>
+       <r>    -4.1373    -0.0000    -0.0000 </r>
+       <r>    -4.0962    -0.0000    -0.0000 </r>
+       <r>    -4.0551    -0.0000    -0.0000 </r>
+       <r>    -4.0140    -0.0000    -0.0000 </r>
+       <r>    -3.9729    -0.0000    -0.0000 </r>
+       <r>    -3.9318    -0.0000    -0.0000 </r>
+       <r>    -3.8906    -0.0000    -0.0000 </r>
+       <r>    -3.8495    -0.0000    -0.0000 </r>
+       <r>    -3.8084    -0.0002    -0.0000 </r>
+       <r>    -3.7673    -0.0007    -0.0000 </r>
+       <r>    -3.7262    -0.0027    -0.0001 </r>
+       <r>    -3.6851    -0.0095    -0.0005 </r>
+       <r>    -3.6440    -0.0303    -0.0018 </r>
+       <r>    -3.6029    -0.0879    -0.0054 </r>
+       <r>    -3.5618    -0.2302    -0.0149 </r>
+       <r>    -3.5207    -0.5418    -0.0372 </r>
+       <r>    -3.4796    -1.1377    -0.0839 </r>
+       <r>    -3.4385    -2.1062    -0.1706 </r>
+       <r>    -3.3974    -3.3624    -0.3089 </r>
+       <r>    -3.3563    -4.4143    -0.4904 </r>
+       <r>    -3.3152    -4.1403    -0.6607 </r>
+       <r>    -3.2741    -0.8017    -0.6937 </r>
+       <r>    -3.2330     7.4612    -0.3868 </r>
+       <r>    -3.1919    21.6135     0.5022 </r>
+       <r>    -3.1508    40.5883     2.1715 </r>
+       <r>    -3.1097    60.7944     4.6720 </r>
+       <r>    -3.0686    76.9306     7.8360 </r>
+       <r>    -3.0275    84.0327    11.2922 </r>
+       <r>    -2.9864    79.7534    14.5724 </r>
+       <r>    -2.9453    65.5181    17.2671 </r>
+       <r>    -2.9042    45.8179    19.1515 </r>
+       <r>    -2.8631    26.0950    20.2247 </r>
+       <r>    -2.8220    10.5115    20.6571 </r>
+       <r>    -2.7808     0.7755    20.6890 </r>
+       <r>    -2.7397    -3.6572    20.5385 </r>
+       <r>    -2.6986    -4.5301    20.3522 </r>
+       <r>    -2.6575    -3.6824    20.2008 </r>
+       <r>    -2.6164    -2.4097    20.1016 </r>
+       <r>    -2.5753    -1.3483    20.0462 </r>
+       <r>    -2.5342    -0.6621    20.0190 </r>
+       <r>    -2.4931    -0.2894    20.0071 </r>
+       <r>    -2.4520    -0.1135    20.0024 </r>
+       <r>    -2.4109    -0.0402    20.0007 </r>
+       <r>    -2.3698    -0.0129    20.0002 </r>
+       <r>    -2.3287    -0.0038    20.0001 </r>
+       <r>    -2.2876    -0.0010    20.0000 </r>
+       <r>    -2.2465    -0.0004    20.0000 </r>
+       <r>    -2.2054    -0.0006    20.0000 </r>
+       <r>    -2.1643    -0.0024    19.9999 </r>
+       <r>    -2.1232    -0.0087    19.9995 </r>
+       <r>    -2.0821    -0.0292    19.9983 </r>
+       <r>    -2.0410    -0.0895    19.9946 </r>
+       <r>    -1.9999    -0.2485    19.9844 </r>
+       <r>    -1.9588    -0.6229    19.9588 </r>
+       <r>    -1.9177    -1.4020    19.9011 </r>
+       <r>    -1.8766    -2.8096    19.7856 </r>
+       <r>    -1.8355    -4.9429    19.5823 </r>
+       <r>    -1.7944    -7.4330    19.2766 </r>
+       <r>    -1.7533    -8.9852    18.9070 </r>
+       <r>    -1.7122    -7.0748    18.6160 </r>
+       <r>    -1.6711     1.7375    18.6875 </r>
+       <r>    -1.6299    20.5075    19.5309 </r>
+       <r>    -1.5888    49.8655    21.5819 </r>
+       <r>    -1.5477    86.3351    25.1328 </r>
+       <r>    -1.5066   122.5412    30.1728 </r>
+       <r>    -1.4655   150.0518    36.3444 </r>
+       <r>    -1.4244   163.7276    43.0784 </r>
+       <r>    -1.3833   164.8059    49.8567 </r>
+       <r>    -1.3422   160.1810    56.4448 </r>
+       <r>    -1.3011   157.8067    62.9353 </r>
+       <r>    -1.2600   161.1642    69.5638 </r>
+       <r>    -1.2189   166.7495    76.4220 </r>
+       <r>    -1.1778   166.4655    83.2686 </r>
+       <r>    -1.1367   153.1842    89.5688 </r>
+       <r>    -1.0956   125.5084    94.7308 </r>
+       <r>    -1.0545    88.6351    98.3762 </r>
+       <r>    -1.0134    51.2576   100.4843 </r>
+       <r>    -0.9723    21.0645   101.3506 </r>
+       <r>    -0.9312     1.7356   101.4220 </r>
+       <r>    -0.8901    -7.3259   101.1207 </r>
+       <r>    -0.8490    -9.2640   100.7396 </r>
+       <r>    -0.8079    -7.6378   100.4255 </r>
+       <r>    -0.7668    -5.0604   100.2174 </r>
+       <r>    -0.7257    -2.8675   100.0995 </r>
+       <r>    -0.6846    -1.4395   100.0403 </r>
+       <r>    -0.6435    -0.6906   100.0119 </r>
+       <r>    -0.6024    -0.4415    99.9937 </r>
+       <r>    -0.5613    -0.6214    99.9681 </r>
+       <r>    -0.5202    -1.3545    99.9124 </r>
+       <r>    -0.4790    -2.9695    99.7903 </r>
+       <r>    -0.4379    -5.8828    99.5483 </r>
+       <r>    -0.3968   -10.2277    99.1277 </r>
+       <r>    -0.3557   -15.1230    98.5057 </r>
+       <r>    -0.3146   -17.7126    97.7772 </r>
+       <r>    -0.2735   -12.5620    97.2605 </r>
+       <r>    -0.2324     7.6238    97.5741 </r>
+       <r>    -0.1913    49.2201    99.5985 </r>
+       <r>    -0.1502   113.3008   104.2585 </r>
+       <r>    -0.1091   191.8469   112.1491 </r>
+       <r>    -0.0680   267.5903   123.1550 </r>
+       <r>    -0.0269   319.1606   136.2818 </r>
+       <r>     0.0142   329.8625   149.8488 </r>
+       <r>     0.0553   295.4112   161.9987 </r>
+       <r>     0.0964   225.9910   171.2934 </r>
+       <r>     0.1375   141.5000   177.1130 </r>
+       <r>     0.1786    63.2294   179.7134 </r>
+       <r>     0.2197     7.0925   180.0050 </r>
+       <r>     0.2608   -18.3960   179.2483 </r>
+       <r>     0.3019   -10.0331   178.8356 </r>
+       <r>     0.3430    32.8851   180.1882 </r>
+       <r>     0.3841   108.9030   184.6672 </r>
+       <r>     0.4252   211.7777   193.3775 </r>
+       <r>     0.4663   327.5941   206.8511 </r>
+       <r>     0.5074   435.6256   224.7681 </r>
+       <r>     0.5485   514.8498   245.9434 </r>
+       <r>     0.5896   553.4497   268.7064 </r>
+       <r>     0.6308   555.0292   291.5343 </r>
+       <r>     0.6719   536.3073   313.5922 </r>
+       <r>     0.7130   516.8943   334.8516 </r>
+       <r>     0.7541   507.9276   355.7422 </r>
+       <r>     0.7952   507.3897   376.6106 </r>
+       <r>     0.8363   504.7647   397.3710 </r>
+       <r>     0.8774   490.7739   417.5558 </r>
+       <r>     0.9185   464.9366   436.6780 </r>
+       <r>     0.9596   436.2977   454.6223 </r>
+       <r>     1.0007   417.8766   471.8090 </r>
+       <r>     1.0418   419.0859   489.0456 </r>
+       <r>     1.0829   440.7152   507.1718 </r>
+       <r>     1.1240   474.7926   526.6998 </r>
+       <r>     1.1651   508.6193   547.6190 </r>
+       <r>     1.2062   530.2123   569.4263 </r>
+       <r>     1.2473   532.2415   591.3170 </r>
+       <r>     1.2884   513.0262   612.4172 </r>
+       <r>     1.3295   475.0652   631.9561 </r>
+       <r>     1.3706   422.6569   649.3395 </r>
+       <r>     1.4117   360.1277   664.1511 </r>
+       <r>     1.4528   291.4733   676.1391 </r>
+       <r>     1.4939   221.3327   685.2422 </r>
+       <r>     1.5350   156.3922   691.6744 </r>
+       <r>     1.5761   105.8206   696.0265 </r>
+       <r>     1.6172    79.5858   699.2996 </r>
+       <r>     1.6583    84.6498   702.7810 </r>
+       <r>     1.6994   120.5866   707.7405 </r>
+       <r>     1.7405   177.1375   715.0259 </r>
+       <r>     1.7817   235.8129   724.7247 </r>
+       <r>     1.8228   275.8343   736.0695 </r>
+       <r>     1.8639   282.3458   747.6822 </r>
+       <r>     1.9050   253.2782   758.0993 </r>
+       <r>     1.9461   201.5207   766.3876 </r>
+       <r>     1.9872   151.0657   772.6006 </r>
+       <r>     2.0283   128.4126   777.8819 </r>
+       <r>     2.0694   152.4257   784.1508 </r>
+       <r>     2.1105   226.4731   793.4652 </r>
+       <r>     2.1516   336.1582   807.2910 </r>
+       <r>     2.1927   454.4188   825.9807 </r>
+       <r>     2.2338   552.9906   848.7246 </r>
+       <r>     2.2749   615.6044   874.0437 </r>
+       <r>     2.3160   645.8382   900.6063 </r>
+       <r>     2.3571   664.0315   927.9173 </r>
+       <r>     2.3982   693.7385   956.4502 </r>
+       <r>     2.4393   745.4105   987.1087 </r>
+       <r>     2.4804   807.7283  1020.3306 </r>
+       <r>     2.5215   852.4165  1055.3907 </r>
+       <r>     2.5626   849.4821  1090.3300 </r>
+       <r>     2.6037   783.3462  1122.5490 </r>
+       <r>     2.6448   660.8149  1149.7278 </r>
+       <r>     2.6859   507.9690  1170.6197 </r>
+       <r>     2.7270   359.4805  1185.4041 </r>
+       <r>     2.7681   246.3538  1195.5355 </r>
+       <r>     2.8092   186.6752  1203.2125 </r>
+       <r>     2.8503   181.4810  1210.6760 </r>
+       <r>     2.8915   216.3511  1219.5740 </r>
+       <r>     2.9326   268.2548  1230.6070 </r>
+       <r>     2.9737   315.2797  1243.5743 </r>
+       <r>     3.0148   344.7711  1257.7545 </r>
+       <r>     3.0559   355.5122  1272.3766 </r>
+       <r>     3.0970   353.1659  1286.9021 </r>
+       <r>     3.1381   343.0703  1301.0123 </r>
+       <r>     3.1792   326.4165  1314.4375 </r>
+       <r>     3.2203   302.7063  1326.8873 </r>
+       <r>     3.2614   275.6528  1338.2242 </r>
+       <r>     3.3025   256.3764  1348.7682 </r>
+       <r>     3.3436   259.8788  1359.4561 </r>
+       <r>     3.3847   296.5977  1371.6543 </r>
+       <r>     3.4258   365.4558  1386.6848 </r>
+       <r>     3.4669   454.2518  1405.3677 </r>
+       <r>     3.5080   547.7017  1427.8942 </r>
+       <r>     3.5491   637.1660  1454.1004 </r>
+       <r>     3.5902   724.2339  1483.8878 </r>
+       <r>     3.6313   814.8389  1517.4020 </r>
+       <r>     3.6724   908.2710  1554.7591 </r>
+       <r>     3.7135   990.1218  1595.4828 </r>
+       <r>     3.7546  1035.7215  1638.0819 </r>
+       <r>     3.7957  1022.7298  1680.1463 </r>
+       <r>     3.8368   944.5691  1718.9955 </r>
+       <r>     3.8779   815.8551  1752.5503 </r>
+       <r>     3.9190   666.9040  1779.9785 </r>
+       <r>     3.9601   531.6363  1801.8432 </r>
+       <r>     4.0012   436.2885  1819.7864 </r>
+       <r>     4.0424   393.9560  1835.9888 </r>
+       <r>     4.0835   405.2230  1852.6549 </r>
+       <r>     4.1246   461.9801  1871.6556 </r>
+       <r>     4.1657   551.4353  1894.3358 </r>
+       <r>     4.2068   658.8780  1921.4352 </r>
+       <r>     4.2479   769.0900  1953.0678 </r>
+       <r>     4.2890   866.9250  1988.7246 </r>
+       <r>     4.3301   938.0114  2027.3053 </r>
+       <r>     4.3712   970.7322  2067.2317 </r>
+       <r>     4.4123   959.8318  2106.7097 </r>
+       <r>     4.4534   910.1368  2144.1433 </r>
+       <r>     4.4945   837.4455  2178.5869 </r>
+       <r>     4.5356   764.4391  2210.0276 </r>
+       <r>     4.5767   712.4318  2239.3293 </r>
+       <r>     4.6178   692.7234  2267.8205 </r>
+       <r>     4.6589   701.9572  2296.6916 </r>
+       <r>     4.7000   723.8720  2326.4640 </r>
+       <r>     4.7411   736.6687  2356.7626 </r>
+       <r>     4.7822   722.6333  2386.4835 </r>
+       <r>     4.8233   675.5984  2414.2696 </r>
+       <r>     4.8644   602.6665  2439.0558 </r>
+       <r>     4.9055   519.3757  2460.4164 </r>
+       <r>     4.9466   441.1278  2478.5588 </r>
+       <r>     4.9877   376.0049  2494.0230 </r>
+       <r>     5.0288   323.0966  2507.3112 </r>
+       <r>     5.0699   276.5448  2518.6847 </r>
+       <r>     5.1110   231.6033  2528.2098 </r>
+       <r>     5.1521   188.1357  2535.9471 </r>
+       <r>     5.1933   149.5978  2542.0993 </r>
+       <r>     5.2344   119.2596  2547.0039 </r>
+       <r>     5.2755    97.1718  2551.0001 </r>
+       <r>     5.3166    80.1334  2554.2958 </r>
+       <r>     5.3577    64.1649  2556.9347 </r>
+       <r>     5.3988    47.1751  2558.8750 </r>
+       <r>     5.4399    29.8528  2560.1029 </r>
+       <r>     5.4810    14.5526  2560.7015 </r>
+       <r>     5.5221     3.4166  2560.8420 </r>
+       <r>     5.5632    -2.8603  2560.7244 </r>
+       <r>     5.6043    -5.0818  2560.5154 </r>
+       <r>     5.6454    -4.8038  2560.3178 </r>
+       <r>     5.6865    -3.5088  2560.1735 </r>
+       <r>     5.7276    -2.1563  2560.0848 </r>
+       <r>     5.7687    -1.1534  2560.0374 </r>
+       <r>     5.8098    -0.5463  2560.0149 </r>
+       <r>     5.8509    -0.2314  2560.0054 </r>
+       <r>     5.8920    -0.0882  2560.0018 </r>
+       <r>     5.9331    -0.0304  2560.0005 </r>
+       <r>     5.9742    -0.0095  2560.0001 </r>
+       <r>     6.0153    -0.0027  2560.0000 </r>
+       <r>     6.0564    -0.0007  2560.0000 </r>
+       <r>     6.0975    -0.0002  2560.0000 </r>
+       <r>     6.1386    -0.0000  2560.0000 </r>
+       <r>     6.1797    -0.0000  2560.0000 </r>
+       <r>     6.2208    -0.0000  2560.0000 </r>
+       <r>     6.2619    -0.0000  2560.0000 </r>
+       <r>     6.3031    -0.0000  2560.0000 </r>
+       <r>     6.3442    -0.0000  2560.0000 </r>
+       <r>     6.3853    -0.0000  2560.0000 </r>
+       <r>     6.4264    -0.0000  2560.0000 </r>
+       <r>     6.4675    -0.0000  2560.0000 </r>
+       <r>     6.5086    -0.0000  2560.0000 </r>
+       <r>     6.5497    -0.0000  2560.0000 </r>
+       <r>     6.5908     0.0000  2560.0000 </r>
+       <r>     6.6319     0.0000  2560.0000 </r>
+       <r>     6.6730     0.0000  2560.0000 </r>
+       <r>     6.7141     0.0000  2560.0000 </r>
+       <r>     6.7552     0.0000  2560.0000 </r>
+       <r>     6.7963     0.0000  2560.0000 </r>
+       <r>     6.8374     0.0000  2560.0000 </r>
+       <r>     6.8785     0.0000  2560.0000 </r>
+       <r>     6.9196     0.0000  2560.0000 </r>
+       <r>     6.9607     0.0000  2560.0000 </r>
+       <r>     7.0018     0.0000  2560.0000 </r>
+       <r>     7.0429     0.0000  2560.0000 </r>
+       <r>     7.0840     0.0000  2560.0000 </r>
+       <r>     7.1251     0.0000  2560.0000 </r>
+       <r>     7.1662     0.0000  2560.0000 </r>
+       <r>     7.2073     0.0000  2560.0000 </r>
+       <r>     7.2484     0.0000  2560.0000 </r>
+       <r>     7.2895     0.0000  2560.0000 </r>
+      </set>
+     </set>
+    </array>
+   </total>
+  </dos>
+  <time name="totalsc">    3.68    3.73</time>
+  <eigenvalues>
+   <array>
+    <dimension dim="1">band</dimension>
+    <dimension dim="2">kpoint</dimension>
+    <dimension dim="3">spin</dimension>
+    <field>eigene</field>
+    <field>occ</field>
+    <set>
+     <set comment="spin 1">
+      <set comment="kpoint 1">
+       <r>   -3.0404    1.0000 </r>
+       <r>   -1.4776    1.0000 </r>
+       <r>   -1.4213    1.0000 </r>
+       <r>   -1.1895    1.0000 </r>
+       <r>   -1.1802    1.0000 </r>
+       <r>   -0.0443    1.0000 </r>
+       <r>   -0.0344    1.0000 </r>
+       <r>    0.0056    1.0000 </r>
+       <r>    0.0185    1.0000 </r>
+       <r>    0.4245    1.0000 </r>
+       <r>    0.5296    1.0000 </r>
+       <r>    0.5437    1.0000 </r>
+       <r>    0.5629    1.0000 </r>
+       <r>    0.5719    1.0000 </r>
+       <r>    0.5735    1.0000 </r>
+       <r>    0.5914    1.0000 </r>
+       <r>    0.7647    1.0000 </r>
+       <r>    0.7804    1.0000 </r>
+       <r>    0.7825    1.0000 </r>
+       <r>    0.8063    1.0000 </r>
+       <r>    0.8287    1.0000 </r>
+       <r>    0.9166    1.0000 </r>
+       <r>    0.9370    1.0000 </r>
+       <r>    0.9506    1.0000 </r>
+       <r>    1.0833    1.0000 </r>
+       <r>    1.0904    1.0000 </r>
+       <r>    1.1283    1.0000 </r>
+       <r>    1.1589    1.0000 </r>
+       <r>    1.2306    1.0000 </r>
+       <r>    1.2521    1.0000 </r>
+       <r>    1.2793    1.0000 </r>
+       <r>    1.3093    1.0000 </r>
+       <r>    1.3625    1.0000 </r>
+       <r>    1.4308    1.0000 </r>
+       <r>    1.5231    1.0000 </r>
+       <r>    1.7576    1.0000 </r>
+       <r>    1.8086    1.0000 </r>
+       <r>    1.8532    1.0000 </r>
+       <r>    1.8935    1.0000 </r>
+       <r>    2.1103    1.0000 </r>
+       <r>    2.1731    1.0000 </r>
+       <r>    2.2078    1.0000 </r>
+       <r>    2.2315    1.0000 </r>
+       <r>    2.2539    1.0000 </r>
+       <r>    2.2770    1.0000 </r>
+       <r>    2.2800    1.0000 </r>
+       <r>    2.2956    1.0000 </r>
+       <r>    2.3904    1.0000 </r>
+       <r>    2.4166    1.0000 </r>
+       <r>    2.4639    1.0001 </r>
+       <r>    2.4811    1.0001 </r>
+       <r>    2.5028    1.0002 </r>
+       <r>    2.5189    1.0003 </r>
+       <r>    2.5288    1.0004 </r>
+       <r>    2.5554    1.0007 </r>
+       <r>    2.5971    1.0017 </r>
+       <r>    2.6099    1.0023 </r>
+       <r>    2.6537    1.0052 </r>
+       <r>    2.6732    1.0073 </r>
+       <r>    2.7572    1.0228 </r>
+       <r>    2.9083    1.0020 </r>
+       <r>    2.9567    0.9241 </r>
+       <r>    2.9653    0.9043 </r>
+       <r>    3.0111    0.7681 </r>
+       <r>    3.1530    0.2077 </r>
+       <r>    3.1728    0.1461 </r>
+       <r>    3.1949    0.0884 </r>
+       <r>    3.2600   -0.0126 </r>
+       <r>    3.3897   -0.0251 </r>
+       <r>    3.3996   -0.0228 </r>
+       <r>    3.4918   -0.0064 </r>
+       <r>    3.5042   -0.0052 </r>
+       <r>    3.5232   -0.0036 </r>
+       <r>    3.5417   -0.0025 </r>
+       <r>    3.5448   -0.0024 </r>
+       <r>    3.6176   -0.0005 </r>
+       <r>    3.6392   -0.0003 </r>
+       <r>    3.6852   -0.0001 </r>
+       <r>    3.6950   -0.0001 </r>
+       <r>    3.7160   -0.0000 </r>
+       <r>    3.7381   -0.0000 </r>
+       <r>    3.7538   -0.0000 </r>
+       <r>    3.7635   -0.0000 </r>
+       <r>    3.7837   -0.0000 </r>
+       <r>    3.8154   -0.0000 </r>
+       <r>    3.8289   -0.0000 </r>
+       <r>    3.8367   -0.0000 </r>
+       <r>    3.8496   -0.0000 </r>
+       <r>    3.8789   -0.0000 </r>
+       <r>    3.9297   -0.0000 </r>
+       <r>    3.9535   -0.0000 </r>
+       <r>    4.0128   -0.0000 </r>
+       <r>    4.0751   -0.0000 </r>
+       <r>    4.1329   -0.0000 </r>
+       <r>    4.1605   -0.0000 </r>
+       <r>    4.2155   -0.0000 </r>
+       <r>    4.2181   -0.0000 </r>
+       <r>    4.2388   -0.0000 </r>
+       <r>    4.2540   -0.0000 </r>
+       <r>    4.2782   -0.0000 </r>
+       <r>    4.3036   -0.0000 </r>
+       <r>    4.3459   -0.0000 </r>
+       <r>    4.3664   -0.0000 </r>
+       <r>    4.3903   -0.0000 </r>
+       <r>    4.4003   -0.0000 </r>
+       <r>    4.4204   -0.0000 </r>
+       <r>    4.4474   -0.0000 </r>
+       <r>    4.4753   -0.0000 </r>
+       <r>    4.4974   -0.0000 </r>
+       <r>    4.5274   -0.0000 </r>
+       <r>    4.5606   -0.0000 </r>
+       <r>    4.5798   -0.0000 </r>
+       <r>    4.6156   -0.0000 </r>
+       <r>    4.6682   -0.0000 </r>
+       <r>    4.7018   -0.0000 </r>
+       <r>    4.7143   -0.0000 </r>
+       <r>    4.7613   -0.0000 </r>
+       <r>    4.7737   -0.0000 </r>
+       <r>    4.7944   -0.0000 </r>
+       <r>    4.8059   -0.0000 </r>
+       <r>    4.8449   -0.0000 </r>
+       <r>    4.8645   -0.0000 </r>
+       <r>    4.8854   -0.0000 </r>
+       <r>    4.9699   -0.0000 </r>
+       <r>    5.0298   -0.0000 </r>
+       <r>    5.0597   -0.0000 </r>
+       <r>    5.1343   -0.0000 </r>
+       <r>    5.2913   -0.0000 </r>
+      </set>
+     </set>
+    </set>
+   </array>
+  </eigenvalues>
+  <separator name="orbital magnetization" >
+   <v name="MAGDIPOLOUT">      0.00000000      0.00000000      0.00000000</v>
+  </separator>
+  <dos>
+   <i name="efermi">      3.07851177 </i>
+   <total>
+    <array>
+     <dimension dim="1">gridpoints</dimension>
+     <dimension dim="2">spin</dimension>
+     <field>energy</field>
+     <field>total</field>
+     <field>integrated</field>
+     <set>
+      <set comment="spin 1">
+       <r>    -5.0404     0.0000     0.0000 </r>
+       <r>    -4.9993     0.0000     0.0000 </r>
+       <r>    -4.9582     0.0000     0.0000 </r>
+       <r>    -4.9171     0.0000     0.0000 </r>
+       <r>    -4.8760     0.0000     0.0000 </r>
+       <r>    -4.8349     0.0000     0.0000 </r>
+       <r>    -4.7938     0.0000     0.0000 </r>
+       <r>    -4.7527     0.0000     0.0000 </r>
+       <r>    -4.7116     0.0000     0.0000 </r>
+       <r>    -4.6705    -0.0000    -0.0000 </r>
+       <r>    -4.6294    -0.0000    -0.0000 </r>
+       <r>    -4.5883    -0.0000    -0.0000 </r>
+       <r>    -4.5472    -0.0000    -0.0000 </r>
+       <r>    -4.5061    -0.0000    -0.0000 </r>
+       <r>    -4.4650    -0.0000    -0.0000 </r>
+       <r>    -4.4238    -0.0000    -0.0000 </r>
+       <r>    -4.3827    -0.0000    -0.0000 </r>
+       <r>    -4.3416    -0.0000    -0.0000 </r>
+       <r>    -4.3005    -0.0000    -0.0000 </r>
+       <r>    -4.2594    -0.0000    -0.0000 </r>
+       <r>    -4.2183    -0.0000    -0.0000 </r>
+       <r>    -4.1772    -0.0000    -0.0000 </r>
+       <r>    -4.1361    -0.0000    -0.0000 </r>
+       <r>    -4.0950    -0.0000    -0.0000 </r>
+       <r>    -4.0539    -0.0000    -0.0000 </r>
+       <r>    -4.0128    -0.0000    -0.0000 </r>
+       <r>    -3.9717    -0.0000    -0.0000 </r>
+       <r>    -3.9306    -0.0000    -0.0000 </r>
+       <r>    -3.8895    -0.0000    -0.0000 </r>
+       <r>    -3.8484    -0.0000    -0.0000 </r>
+       <r>    -3.8073    -0.0000    -0.0000 </r>
+       <r>    -3.7662    -0.0001    -0.0000 </r>
+       <r>    -3.7250    -0.0003    -0.0000 </r>
+       <r>    -3.6839    -0.0009    -0.0001 </r>
+       <r>    -3.6428    -0.0030    -0.0002 </r>
+       <r>    -3.6017    -0.0086    -0.0005 </r>
+       <r>    -3.5606    -0.0226    -0.0015 </r>
+       <r>    -3.5195    -0.0533    -0.0036 </r>
+       <r>    -3.4784    -0.1121    -0.0083 </r>
+       <r>    -3.4373    -0.2081    -0.0168 </r>
+       <r>    -3.3962    -0.3334    -0.0305 </r>
+       <r>    -3.3551    -0.4400    -0.0486 </r>
+       <r>    -3.3140    -0.4175    -0.0658 </r>
+       <r>    -3.2729    -0.0935    -0.0696 </r>
+       <r>    -3.2318     0.7185    -0.0401 </r>
+       <r>    -3.1907     2.1185     0.0470 </r>
+       <r>    -3.1496     4.0062     0.2117 </r>
+       <r>    -3.1085     6.0291     0.4595 </r>
+       <r>    -3.0674     7.6601     0.7744 </r>
+       <r>    -3.0263     8.3993     1.1197 </r>
+       <r>    -2.9851     8.0030     1.4486 </r>
+       <r>    -2.9440     6.6031     1.7200 </r>
+       <r>    -2.9029     4.6419     1.9108 </r>
+       <r>    -2.8618     2.6635     2.0203 </r>
+       <r>    -2.8207     1.0897     2.0651 </r>
+       <r>    -2.7796     0.0986     2.0692 </r>
+       <r>    -2.7385    -0.3585     2.0544 </r>
+       <r>    -2.6974    -0.4539     2.0358 </r>
+       <r>    -2.6563    -0.3722     2.0205 </r>
+       <r>    -2.6152    -0.2450     2.0104 </r>
+       <r>    -2.5741    -0.1378     2.0048 </r>
+       <r>    -2.5330    -0.0680     2.0020 </r>
+       <r>    -2.4919    -0.0298     2.0007 </r>
+       <r>    -2.4508    -0.0118     2.0002 </r>
+       <r>    -2.4097    -0.0042     2.0001 </r>
+       <r>    -2.3686    -0.0013     2.0000 </r>
+       <r>    -2.3275    -0.0004     2.0000 </r>
+       <r>    -2.2864    -0.0001     2.0000 </r>
+       <r>    -2.2452    -0.0000     2.0000 </r>
+       <r>    -2.2041    -0.0001     2.0000 </r>
+       <r>    -2.1630    -0.0003     2.0000 </r>
+       <r>    -2.1219    -0.0011     1.9999 </r>
+       <r>    -2.0808    -0.0035     1.9998 </r>
+       <r>    -2.0397    -0.0104     1.9994 </r>
+       <r>    -1.9986    -0.0280     1.9982 </r>
+       <r>    -1.9575    -0.0682     1.9954 </r>
+       <r>    -1.9164    -0.1494     1.9893 </r>
+       <r>    -1.8753    -0.2915     1.9773 </r>
+       <r>    -1.8342    -0.4988     1.9568 </r>
+       <r>    -1.7931    -0.7269     1.9269 </r>
+       <r>    -1.7520    -0.8415     1.8923 </r>
+       <r>    -1.7109    -0.5952     1.8679 </r>
+       <r>    -1.6698     0.3343     1.8816 </r>
+       <r>    -1.6287     2.2178     1.9728 </r>
+       <r>    -1.5876     5.0878     2.1819 </r>
+       <r>    -1.5464     8.5940     2.5352 </r>
+       <r>    -1.5053    12.0370     3.0300 </r>
+       <r>    -1.4642    14.6380     3.6317 </r>
+       <r>    -1.4231    15.9378     4.2868 </r>
+       <r>    -1.3820    16.0725     4.9475 </r>
+       <r>    -1.3409    15.7011     5.5929 </r>
+       <r>    -1.2998    15.5752     6.2331 </r>
+       <r>    -1.2587    16.0187     6.8916 </r>
+       <r>    -1.2176    16.6836     7.5773 </r>
+       <r>    -1.1765    16.7687     8.2666 </r>
+       <r>    -1.1354    15.5526     8.9059 </r>
+       <r>    -1.0943    12.8671     9.4348 </r>
+       <r>    -1.0532     9.2036     9.8132 </r>
+       <r>    -1.0121     5.4252    10.0362 </r>
+       <r>    -0.9710     2.3213    10.1316 </r>
+       <r>    -0.9299     0.2936    10.1437 </r>
+       <r>    -0.8888    -0.6890    10.1153 </r>
+       <r>    -0.8477    -0.9289    10.0772 </r>
+       <r>    -0.8065    -0.7848    10.0449 </r>
+       <r>    -0.7654    -0.5284    10.0232 </r>
+       <r>    -0.7243    -0.3034    10.0107 </r>
+       <r>    -0.6832    -0.1542    10.0044 </r>
+       <r>    -0.6421    -0.0751    10.0013 </r>
+       <r>    -0.6010    -0.0489     9.9993 </r>
+       <r>    -0.5599    -0.0683     9.9965 </r>
+       <r>    -0.5188    -0.1454     9.9905 </r>
+       <r>    -0.4777    -0.3113     9.9777 </r>
+       <r>    -0.4366    -0.6030     9.9529 </r>
+       <r>    -0.3955    -1.0246     9.9108 </r>
+       <r>    -0.3544    -1.4768     9.8501 </r>
+       <r>    -0.3133    -1.6690     9.7815 </r>
+       <r>    -0.2722    -1.0718     9.7374 </r>
+       <r>    -0.2311     1.0031     9.7787 </r>
+       <r>    -0.1900     5.1346     9.9897 </r>
+       <r>    -0.1489    11.3880    10.4578 </r>
+       <r>    -0.1078    18.9775    11.2379 </r>
+       <r>    -0.0666    26.2667    12.3176 </r>
+       <r>    -0.0255    31.2479    13.6021 </r>
+       <r>     0.0156    32.3462    14.9317 </r>
+       <r>     0.0567    29.1301    16.1291 </r>
+       <r>     0.0978    22.5193    17.0548 </r>
+       <r>     0.1389    14.3758    17.6457 </r>
+       <r>     0.1800     6.7564    17.9234 </r>
+       <r>     0.2211     1.2740    17.9758 </r>
+       <r>     0.2622    -1.1354    17.9291 </r>
+       <r>     0.3033    -0.0813    17.9258 </r>
+       <r>     0.3444     4.4942    18.1105 </r>
+       <r>     0.3855    12.3329    18.6175 </r>
+       <r>     0.4266    22.6451    19.5483 </r>
+       <r>     0.4677    33.9130    20.9423 </r>
+       <r>     0.5088    44.0630    22.7536 </r>
+       <r>     0.5499    51.1447    24.8559 </r>
+       <r>     0.5910    54.2251    27.0849 </r>
+       <r>     0.6322    53.9005    29.3005 </r>
+       <r>     0.6733    51.9692    31.4367 </r>
+       <r>     0.7144    50.3799    33.5076 </r>
+       <r>     0.7555    50.1323    35.5683 </r>
+       <r>     0.7966    50.8690    37.6593 </r>
+       <r>     0.8377    51.3811    39.7714 </r>
+       <r>     0.8788    50.5923    41.8510 </r>
+       <r>     0.9199    48.3183    43.8372 </r>
+       <r>     0.9610    45.3587    45.7017 </r>
+       <r>     1.0021    42.9845    47.4686 </r>
+       <r>     1.0432    42.2284    49.2044 </r>
+       <r>     1.0843    43.3991    50.9884 </r>
+       <r>     1.1254    46.0098    52.8796 </r>
+       <r>     1.1665    49.0469    54.8957 </r>
+       <r>     1.2076    51.3702    57.0074 </r>
+       <r>     1.2487    52.0564    59.1472 </r>
+       <r>     1.2898    50.6021    61.2272 </r>
+       <r>     1.3309    46.9812    63.1584 </r>
+       <r>     1.3721    41.5795    64.8675 </r>
+       <r>     1.4132    35.0401    66.3079 </r>
+       <r>     1.4543    28.0868    67.4624 </r>
+       <r>     1.4954    21.4169    68.3428 </r>
+       <r>     1.5365    15.7026    68.9882 </r>
+       <r>     1.5776    11.6347    69.4665 </r>
+       <r>     1.6187     9.8707    69.8722 </r>
+       <r>     1.6598    10.8056    70.3164 </r>
+       <r>     1.7009    14.2459    70.9020 </r>
+       <r>     1.7420    19.2093    71.6916 </r>
+       <r>     1.7831    24.0716    72.6811 </r>
+       <r>     1.8242    27.1019    73.7951 </r>
+       <r>     1.8653    27.1886    74.9127 </r>
+       <r>     1.9064    24.4078    75.9160 </r>
+       <r>     1.9475    20.1277    76.7434 </r>
+       <r>     1.9886    16.5578    77.4240 </r>
+       <r>     2.0297    15.9141    78.0782 </r>
+       <r>     2.0709    19.5401    78.8814 </r>
+       <r>     2.1120    27.3433    80.0054 </r>
+       <r>     2.1531    37.7863    81.5586 </r>
+       <r>     2.1942    48.4731    83.5511 </r>
+       <r>     2.2353    57.1274    85.8994 </r>
+       <r>     2.2764    62.5473    88.4704 </r>
+       <r>     2.3175    65.0524    91.1444 </r>
+       <r>     2.3586    66.1438    93.8633 </r>
+       <r>     2.3997    67.5240    96.6389 </r>
+       <r>     2.4408    70.0323    99.5177 </r>
+       <r>     2.4819    73.1207   102.5233 </r>
+       <r>     2.5230    75.1541   105.6126 </r>
+       <r>     2.5641    74.3072   108.6670 </r>
+       <r>     2.6052    69.5161   111.5246 </r>
+       <r>     2.6463    61.0064   114.0323 </r>
+       <r>     2.6874    50.2343   116.0972 </r>
+       <r>     2.7285    39.3691   117.7155 </r>
+       <r>     2.7696    30.5685   118.9720 </r>
+       <r>     2.8108    25.2920   120.0117 </r>
+       <r>     2.8519    23.8618   120.9925 </r>
+       <r>     2.8930    25.4399   122.0382 </r>
+       <r>     2.9341    28.4713   123.2086 </r>
+       <r>     2.9752    31.4105   124.4997 </r>
+       <r>     3.0163    33.3474   125.8705 </r>
+       <r>     3.0574    34.1767   127.2753 </r>
+       <r>     3.0985    34.2655   128.6838 </r>
+       <r>     3.1396    33.9461   130.0792 </r>
+       <r>     3.1807    33.2733   131.4469 </r>
+       <r>     3.2218    32.2197   132.7713 </r>
+       <r>     3.2629    31.0731   134.0486 </r>
+       <r>     3.3040    30.6128   135.3070 </r>
+       <r>     3.3451    31.8383   136.6157 </r>
+       <r>     3.3862    35.4154   138.0715 </r>
+       <r>     3.4273    41.2535   139.7672 </r>
+       <r>     3.4684    48.5425   141.7626 </r>
+       <r>     3.5095    56.2382   144.0743 </r>
+       <r>     3.5507    63.6535   146.6908 </r>
+       <r>     3.5918    70.7254   149.5981 </r>
+       <r>     3.6329    77.7511   152.7941 </r>
+       <r>     3.6740    84.7755   156.2788 </r>
+       <r>     3.7151    91.0845   160.0229 </r>
+       <r>     3.7562    95.2139   163.9367 </r>
+       <r>     3.7973    95.5343   167.8637 </r>
+       <r>     3.8384    91.0897   171.6080 </r>
+       <r>     3.8795    82.2070   174.9872 </r>
+       <r>     3.9206    70.5549   177.8874 </r>
+       <r>     3.9617    58.6533   180.2984 </r>
+       <r>     4.0028    49.0968   182.3166 </r>
+       <r>     4.0439    43.8176   184.1177 </r>
+       <r>     4.0850    43.6210   185.9108 </r>
+       <r>     4.1261    48.0832   187.8873 </r>
+       <r>     4.1672    55.7946   190.1808 </r>
+       <r>     4.2083    64.8488   192.8464 </r>
+       <r>     4.2495    73.4063   195.8638 </r>
+       <r>     4.2906    80.1269   199.1575 </r>
+       <r>     4.3317    84.3268   202.6238 </r>
+       <r>     4.3728    85.8744   206.1537 </r>
+       <r>     4.4139    84.9861   209.6471 </r>
+       <r>     4.4550    82.1025   213.0220 </r>
+       <r>     4.4961    77.8993   216.2241 </r>
+       <r>     4.5372    73.3255   219.2382 </r>
+       <r>     4.5783    69.5028   222.0952 </r>
+       <r>     4.6194    67.4109   224.8662 </r>
+       <r>     4.6605    67.4571   227.6390 </r>
+       <r>     4.7016    69.1699   230.4823 </r>
+       <r>     4.7427    71.2517   233.4111 </r>
+       <r>     4.7838    72.0591   236.3732 </r>
+       <r>     4.8249    70.3140   239.2635 </r>
+       <r>     4.8660    65.6735   241.9630 </r>
+       <r>     4.9071    58.8270   244.3812 </r>
+       <r>     4.9482    51.0694   246.4804 </r>
+       <r>     4.9894    43.6297   248.2738 </r>
+       <r>     5.0305    37.1709   249.8018 </r>
+       <r>     5.0716    31.7229   251.1058 </r>
+       <r>     5.1127    26.9822   252.2149 </r>
+       <r>     5.1538    22.6819   253.1472 </r>
+       <r>     5.1949    18.7596   253.9184 </r>
+       <r>     5.2360    15.2756   254.5463 </r>
+       <r>     5.2771    12.2432   255.0495 </r>
+       <r>     5.3182     9.5609   255.4425 </r>
+       <r>     5.3593     7.0929   255.7341 </r>
+       <r>     5.4004     4.7964   255.9313 </r>
+       <r>     5.4415     2.7664   256.0450 </r>
+       <r>     5.4826     1.1642   256.0928 </r>
+       <r>     5.5237     0.0986   256.0969 </r>
+       <r>     5.5648    -0.4459   256.0786 </r>
+       <r>     5.6059    -0.5958   256.0541 </r>
+       <r>     5.6470    -0.5211   256.0326 </r>
+       <r>     5.6881    -0.3667   256.0176 </r>
+       <r>     5.7293    -0.2206   256.0085 </r>
+       <r>     5.7704    -0.1164   256.0037 </r>
+       <r>     5.8115    -0.0546   256.0015 </r>
+       <r>     5.8526    -0.0230   256.0005 </r>
+       <r>     5.8937    -0.0087   256.0002 </r>
+       <r>     5.9348    -0.0030   256.0001 </r>
+       <r>     5.9759    -0.0009   256.0000 </r>
+       <r>     6.0170    -0.0003   256.0000 </r>
+       <r>     6.0581    -0.0001   256.0000 </r>
+       <r>     6.0992    -0.0000   256.0000 </r>
+       <r>     6.1403    -0.0000   256.0000 </r>
+       <r>     6.1814    -0.0000   256.0000 </r>
+       <r>     6.2225    -0.0000   256.0000 </r>
+       <r>     6.2636    -0.0000   256.0000 </r>
+       <r>     6.3047    -0.0000   256.0000 </r>
+       <r>     6.3458    -0.0000   256.0000 </r>
+       <r>     6.3869    -0.0000   256.0000 </r>
+       <r>     6.4281    -0.0000   256.0000 </r>
+       <r>     6.4692    -0.0000   256.0000 </r>
+       <r>     6.5103    -0.0000   256.0000 </r>
+       <r>     6.5514    -0.0000   256.0000 </r>
+       <r>     6.5925     0.0000   256.0000 </r>
+       <r>     6.6336     0.0000   256.0000 </r>
+       <r>     6.6747     0.0000   256.0000 </r>
+       <r>     6.7158     0.0000   256.0000 </r>
+       <r>     6.7569     0.0000   256.0000 </r>
+       <r>     6.7980     0.0000   256.0000 </r>
+       <r>     6.8391     0.0000   256.0000 </r>
+       <r>     6.8802     0.0000   256.0000 </r>
+       <r>     6.9213     0.0000   256.0000 </r>
+       <r>     6.9624     0.0000   256.0000 </r>
+       <r>     7.0035     0.0000   256.0000 </r>
+       <r>     7.0446     0.0000   256.0000 </r>
+       <r>     7.0857     0.0000   256.0000 </r>
+       <r>     7.1268     0.0000   256.0000 </r>
+       <r>     7.1680     0.0000   256.0000 </r>
+       <r>     7.2091     0.0000   256.0000 </r>
+       <r>     7.2502     0.0000   256.0000 </r>
+       <r>     7.2913     0.0000   256.0000 </r>
+      </set>
+     </set>
+    </array>
+   </total>
+  </dos>
+ </calculation>
+ <structure name="finalpos" >
+  <crystal>
+   <varray name="basis" >
+    <v>       5.87198220       0.00000000       0.00000000 </v>
+    <v>       0.00000000      10.16561149       0.00000000 </v>
+    <v>       0.00000000       0.00000000       9.29538000 </v>
+   </varray>
+   <i name="volume">    554.86251651 </i>
+   <varray name="rec_basis" >
+    <v>       0.17030024       0.00000000       0.00000000 </v>
+    <v>       0.00000000       0.09837087       0.00000000 </v>
+    <v>       0.00000000       0.00000000       0.10758032 </v>
+   </varray>
+  </crystal>
+  <varray name="positions" >
+   <v>       0.03295180       0.04520089       0.11933065 </v>
+   <v>       0.05225442       0.38677502       0.37955945 </v>
+   <v>       0.29427682       0.13414671       0.36980075 </v>
+   <v>       0.28849133       0.30044605       0.12275838 </v>
+   <v>       0.04963269       0.04813016       0.62521541 </v>
+   <v>       0.02768540       0.38250238       0.87597808 </v>
+   <v>       0.29708803       0.13455750       0.88299391 </v>
+   <v>       0.29797821       0.30462069       0.62461743 </v>
+   <v>       0.05192144       0.54249942       0.12037981 </v>
+   <v>       0.03458243       0.88775630       0.38342620 </v>
+   <v>       0.28880464       0.63201576       0.37706351 </v>
+   <v>       0.29624783       0.79068376       0.11553554 </v>
+   <v>       0.05245420       0.55533989       0.62952754 </v>
+   <v>       0.05584981       0.88448569       0.85817964 </v>
+   <v>       0.28811132       0.63956492       0.86414339 </v>
+   <v>       0.28251773       0.81740239       0.61840127 </v>
+   <v>       0.52318173       0.04595411       0.12682539 </v>
+   <v>       0.54043096       0.38402576       0.37959177 </v>
+   <v>       0.78518323       0.13241119       0.37839776 </v>
+   <v>       0.79481457       0.30554850       0.11626377 </v>
+   <v>       0.53581446       0.05008536       0.63114322 </v>
+   <v>       0.54035789       0.38612796       0.87422173 </v>
+   <v>       0.78901213       0.13232102       0.86843472 </v>
+   <v>       0.78791147       0.30147316       0.61829887 </v>
+   <v>       0.54150152       0.55850637       0.13739281 </v>
+   <v>       0.55120599       0.88352273       0.37936051 </v>
+   <v>       0.79470646       0.62977918       0.36822816 </v>
+   <v>       0.80697709       0.79878530       0.12293573 </v>
+   <v>       0.54618229       0.54680790       0.62619100 </v>
+   <v>       0.55358857       0.88596231       0.87201160 </v>
+   <v>       0.78928045       0.63676393       0.87392114 </v>
+   <v>       0.78360095       0.80836158       0.62840959 </v>
+  </varray>
+  <varray name="velocities" >
+   <v>      -0.00098636      -0.00047391      -0.00042562 </v>
+   <v>       0.00093193       0.00011323       0.00050762 </v>
+   <v>       0.00010356      -0.00016333      -0.00020656 </v>
+   <v>      -0.00032349       0.00000139      -0.00014260 </v>
+   <v>       0.00061122      -0.00002893       0.00008480 </v>
+   <v>      -0.00132597      -0.00027026       0.00009004 </v>
+   <v>       0.00039574      -0.00007128       0.00069212 </v>
+   <v>       0.00050555       0.00034079       0.00005368 </v>
+   <v>       0.00088956      -0.00061084      -0.00025431 </v>
+   <v>      -0.00068566       0.00020234       0.00067369 </v>
+   <v>      -0.00031878      -0.00031728       0.00027468 </v>
+   <v>       0.00033115      -0.00085727      -0.00071218 </v>
+   <v>       0.00083184       0.00041138       0.00042883 </v>
+   <v>       0.00132711      -0.00007908      -0.00119127 </v>
+   <v>      -0.00030039       0.00036368      -0.00081835 </v>
+   <v>      -0.00083549       0.00143672      -0.00051215 </v>
+   <v>      -0.00168262      -0.00043211       0.00024303 </v>
+   <v>      -0.00015255      -0.00007966       0.00042458 </v>
+   <v>      -0.00063594      -0.00025842       0.00026748 </v>
+   <v>       0.00014760       0.00037275      -0.00058693 </v>
+   <v>      -0.00051716       0.00000769       0.00057373 </v>
+   <v>      -0.00026971       0.00008198       0.00007192 </v>
+   <v>      -0.00027879      -0.00023797      -0.00035600 </v>
+   <v>      -0.00038404       0.00011909      -0.00043995 </v>
+   <v>      -0.00007660       0.00063002       0.00103912 </v>
+   <v>       0.00072255      -0.00015659       0.00041626 </v>
+   <v>       0.00032821      -0.00050792      -0.00036045 </v>
+   <v>       0.00139848      -0.00025780      -0.00012919 </v>
+   <v>       0.00045330      -0.00024600       0.00026137 </v>
+   <v>       0.00101817       0.00002935      -0.00019133 </v>
+   <v>      -0.00028206       0.00016972      -0.00008140 </v>
+   <v>      -0.00094039       0.00076852       0.00030536 </v>
+  </varray>
+ </structure>
+</modeling>

--- a/tests/test_vasp_outcar.py
+++ b/tests/test_vasp_outcar.py
@@ -115,5 +115,22 @@ class TestVaspOUTCARML(unittest.TestCase):
         self.assertEqual(len(system2["energies"]), 4)
 
 
+class TestVaspOUTCARNWRITE0(unittest.TestCase):
+    def test(self):
+        # only the first and last frames that have forces are read
+        ss = dpdata.LabeledSystem("poscars/Ti-aimd-nwrite0/OUTCAR")
+        self.assertEqual(ss.get_nframes(), 2)
+
+
+class TestVaspAtomNamesV6(unittest.TestCase):
+    def test(self):
+        # in vasp v6, the key TITEL is removed. check if the atom names
+        # are correctly parsed.
+        ss = dpdata.LabeledSystem("poscars/Ti-O-Ti-v6/OUTCAR")
+        self.assertEqual(ss.get_atom_names(), ["Ti", "O"])
+        self.assertEqual(ss.get_atom_numbs(), [6, 2])
+        np.testing.assert_equal(ss.get_atom_types(), [0, 0, 0, 1, 1, 0, 0, 0])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_vasp_xml.py
+++ b/tests/test_vasp_xml.py
@@ -71,5 +71,21 @@ class TestVaspXmlNoVirial(unittest.TestCase, CompSys, IsPBC):
         self.system_2 = xml_sys.sub_system([-1])
 
 
+class TestVaspOUTCARNWRITE0(unittest.TestCase):
+    def test(self):
+        # all frames are written to vasprun.xml that have forces are read
+        # even though the nwrite parameter is set to 0
+        ss = dpdata.LabeledSystem("poscars/Ti-aimd-nwrite0/vasprun.xml")
+        self.assertEqual(ss.get_nframes(), 10)
+
+
+class TestVaspAtomNamesV6(unittest.TestCase):
+    def test(self):
+        ss = dpdata.LabeledSystem("poscars/Ti-O-Ti-v6/vasprun.xml")
+        self.assertEqual(ss.get_atom_names(), ["Ti", "O"])
+        self.assertEqual(ss.get_atom_numbs(), [6, 2])
+        np.testing.assert_equal(ss.get_atom_types(), [0, 0, 0, 1, 1, 0, 0, 0])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
- fix #822 . now can handle nwrite = 0
- fix #836 . when the key TITEL is missing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved extraction of atom names from VASP output files, enhancing compatibility with VASP version 6 files.
  * Added support for reading the NWRITE parameter from OUTCAR files.
  * Enhanced validation to ensure coordinates, cell, and forces are present in parsed frames.

* **Bug Fixes**
  * Improved handling of OUTCAR files lacking TITEL lines for atom names.

* **Tests**
  * Added new tests to verify correct frame extraction and atom name parsing from both OUTCAR and XML files, including cases with NWRITE=0 and VASP 6 output formats.

* **Chores**
  * Included new sample OUTCAR and vasprun.xml files for expanded test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->