### PR TITLE
fix: skip datatype registration warning for duplicate types

### DIFF
--- a/dpdata/data_type.py
+++ b/dpdata/data_type.py
@@ -64,6 +64,43 @@ class DataType:
         self.required = required
         self.deepmd_name = name if deepmd_name is None else deepmd_name
 
+    def __eq__(self, other) -> bool:
+        """Check if two DataType instances are equal.
+
+        Parameters
+        ----------
+        other : object
+            object to compare with
+
+        Returns
+        -------
+        bool
+            True if equal, False otherwise
+        """
+        if not isinstance(other, DataType):
+            return False
+        return (
+            self.name == other.name
+            and self.dtype == other.dtype
+            and self.shape == other.shape
+            and self.required == other.required
+            and self.deepmd_name == other.deepmd_name
+        )
+
+    def __repr__(self) -> str:
+        """Return string representation of DataType.
+
+        Returns
+        -------
+        str
+            string representation
+        """
+        return (
+            f"DataType(name='{self.name}', dtype={self.dtype.__name__}, "
+            f"shape={self.shape}, required={self.required}, "
+            f"deepmd_name='{self.deepmd_name}')"
+        )
+
     def real_shape(self, system: System) -> tuple[int]:
         """Returns expected real shape of a system."""
         assert self.shape is not None

--- a/dpdata/system.py
+++ b/dpdata/system.py
@@ -1102,12 +1102,11 @@ class System:
         all_dtypes = cls.DTYPES + tuple(data_type)
         dtypes_dict = {}
         for dt in all_dtypes:
-            if dt.name in dtypes_dict:
-                if dt != dtypes_dict[dt.name]:
-                    warnings.warn(
-                        f"Data type {dt.name} is registered twice with different definitions; only the newly registered one will be used.",
-                        UserWarning,
-                    )
+            if dt.name in dtypes_dict and dt != dtypes_dict[dt.name]:
+                warnings.warn(
+                    f"Data type {dt.name} is registered twice with different definitions; only the newly registered one will be used.",
+                    UserWarning,
+                )
             dtypes_dict[dt.name] = dt
         cls.DTYPES = tuple(dtypes_dict.values())
 

--- a/dpdata/system.py
+++ b/dpdata/system.py
@@ -1103,10 +1103,11 @@ class System:
         dtypes_dict = {}
         for dt in all_dtypes:
             if dt.name in dtypes_dict:
-                warnings.warn(
-                    f"Data type {dt.name} is registered twice; only the newly registered one will be used.",
-                    UserWarning,
-                )
+                if dt != dtypes_dict[dt.name]:
+                    warnings.warn(
+                        f"Data type {dt.name} is registered twice with different definitions; only the newly registered one will be used.",
+                        UserWarning,
+                    )
             dtypes_dict[dt.name] = dt
         cls.DTYPES = tuple(dtypes_dict.values())
 

--- a/tests/test_custom_data_type.py
+++ b/tests/test_custom_data_type.py
@@ -51,7 +51,9 @@ class TestDataType(unittest.TestCase):
     def test_register_different_data_type_with_warning(self):
         """Test registering different DataType instances with same name should warn."""
         dt1 = DataType("test_diff", np.ndarray, shape=(Axis.NFRAMES, 3))
-        dt2 = DataType("test_diff", list, shape=(Axis.NFRAMES, 4))  # Different dtype and shape
+        dt2 = DataType(
+            "test_diff", list, shape=(Axis.NFRAMES, 4)
+        )  # Different dtype and shape
 
         # Register first time
         dpdata.System.register_data_type(dt1)
@@ -63,7 +65,9 @@ class TestDataType(unittest.TestCase):
             # Check warning was issued
             self.assertEqual(len(w), 1)
             self.assertTrue(issubclass(w[-1].category, UserWarning))
-            self.assertIn("registered twice with different definitions", str(w[-1].message))
+            self.assertIn(
+                "registered twice with different definitions", str(w[-1].message)
+            )
 
 
 class DeepmdLoadDumpCompTest:

--- a/tests/test_custom_data_type.py
+++ b/tests/test_custom_data_type.py
@@ -1,12 +1,69 @@
 from __future__ import annotations
 
 import unittest
+import warnings
 
 import h5py  # noqa: TID253
 import numpy as np
 
 import dpdata
 from dpdata.data_type import Axis, DataType
+
+
+class TestDataType(unittest.TestCase):
+    """Test DataType class methods."""
+
+    def test_eq(self):
+        """Test equality method."""
+        dt1 = DataType("test", np.ndarray, shape=(Axis.NFRAMES, 3))
+        dt2 = DataType("test", np.ndarray, shape=(Axis.NFRAMES, 3))
+        dt3 = DataType("other", np.ndarray, shape=(Axis.NFRAMES, 3))
+
+        self.assertTrue(dt1 == dt2)
+        self.assertFalse(dt1 == dt3)
+        self.assertFalse(dt1 == "not a DataType")
+
+    def test_repr(self):
+        """Test string representation."""
+        dt = DataType("test", np.ndarray, shape=(Axis.NFRAMES, 3))
+        expected = (
+            "DataType(name='test', dtype=ndarray, "
+            "shape=(<Axis.NFRAMES: 'nframes'>, 3), required=True, "
+            "deepmd_name='test')"
+        )
+        self.assertEqual(repr(dt), expected)
+
+    def test_register_same_data_type_no_warning(self):
+        """Test registering identical DataType instances should not warn."""
+        dt1 = DataType("test_same", np.ndarray, shape=(Axis.NFRAMES, 3))
+        dt2 = DataType("test_same", np.ndarray, shape=(Axis.NFRAMES, 3))
+
+        # Register first time
+        dpdata.System.register_data_type(dt1)
+
+        # Register same DataType again - should not warn
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            dpdata.System.register_data_type(dt2)
+            # Check no warnings were issued
+            self.assertEqual(len(w), 0)
+
+    def test_register_different_data_type_with_warning(self):
+        """Test registering different DataType instances with same name should warn."""
+        dt1 = DataType("test_diff", np.ndarray, shape=(Axis.NFRAMES, 3))
+        dt2 = DataType("test_diff", list, shape=(Axis.NFRAMES, 4))  # Different dtype and shape
+
+        # Register first time
+        dpdata.System.register_data_type(dt1)
+
+        # Register different DataType with same name - should warn
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            dpdata.System.register_data_type(dt2)
+            # Check warning was issued
+            self.assertEqual(len(w), 1)
+            self.assertTrue(issubclass(w[-1].category, UserWarning))
+            self.assertIn("registered twice with different definitions", str(w[-1].message))
 
 
 class DeepmdLoadDumpCompTest:
@@ -48,14 +105,6 @@ class DeepmdLoadDumpCompTest:
         self.system.to_deepmd_hdf5("data_foo.h5")
         x = self.cls("data_foo.h5", fmt="deepmd/hdf5")
         np.testing.assert_allclose(x.data["foo"], self.foo)
-
-    def test_duplicated_data_type(self):
-        dt = DataType("foo", np.ndarray, (Axis.NFRAMES, *self.shape), required=False)
-        n_dtypes_old = len(self.cls.DTYPES)
-        with self.assertWarns(UserWarning):
-            self.cls.register_data_type(dt)
-        n_dtypes_new = len(self.cls.DTYPES)
-        self.assertEqual(n_dtypes_old, n_dtypes_new)
 
     def test_to_deepmd_npy_mixed(self):
         ms = dpdata.MultiSystems(self.system)

--- a/tests/test_custom_data_type.py
+++ b/tests/test_custom_data_type.py
@@ -13,6 +13,14 @@ from dpdata.data_type import Axis, DataType
 class TestDataType(unittest.TestCase):
     """Test DataType class methods."""
 
+    def setUp(self):
+        # Store original DTYPES to restore later
+        self.original_dtypes = dpdata.System.DTYPES
+
+    def tearDown(self):
+        # Restore original DTYPES
+        dpdata.System.DTYPES = self.original_dtypes
+
     def test_eq(self):
         """Test equality method."""
         dt1 = DataType("test", np.ndarray, shape=(Axis.NFRAMES, 3))


### PR DESCRIPTION
Currently dpdata throws a warning if an existed data type is registered again, even if with the same definition. This PR adds a check to skip if the registered data types are identicle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved object comparison and display for data types, allowing equality checks and clearer string representations.

* **Bug Fixes**
  * Reduced unnecessary warnings when registering identical data types; warnings are now only shown if duplicate registrations differ.

* **Tests**
  * Added tests for data type comparison, representation, and registration behavior.
  * Removed outdated test for duplicate data type registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->