### PR TITLE
CI(benchmark): run benchmark on codspeed-macro for wall time

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -6,7 +6,8 @@ on:
 
 jobs:
   benchmark:
-    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'deepmodeling' }}
+    runs-on: codspeed-macro
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python


### PR DESCRIPTION
The previous results are not reliable, due to https://github.com/CodSpeedHQ/pytest-codspeed/issues/37. The new method is good.

See
https://docs.codspeed.io/instruments/walltime/#usage-with-github-actions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the benchmark workflow to run only for the "deepmodeling" repository owner and switched the runner environment to a custom setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->