### PR TITLE
fix: raise runtime error when the vasp long ions per type bug is triggered

### DIFF
--- a/tests/poscars/outcar.longit/OUTCAR
+++ b/tests/poscars/outcar.longit/OUTCAR
@@ -1,0 +1,7442 @@
+ vasp.6.3.0 20Jan22 (build Oct 14 2024 11:24:38) complex                        
+  
+ executed on             LinuxIFC date 2025.08.06  11:35:31
+ running on   16 total cores
+ distrk:  each k-point on   16 cores,    1 groups
+ distr:  one band on NCORE=   4 cores,    4 groups
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+ INCAR:
+   ALGO = Fast
+   EDIFF = 5e-05
+   ENCUT = 520
+   IBRION = 2
+   ICHARGE = 2
+   ISART = 0
+   ISIF = 3
+   ISMEAR = 1
+   LASPH = .TRUE.
+   KPAR = 1
+   KSPACING = 0.5
+   LCHARGE = .False.
+   LREAL = AUTO
+   LWAVE = .False.
+   NELM = 500
+   NPAR = 4
+   NSW = 0
+   POTIM = 0.5
+   PREC = Accurate
+   SIGMA = 0.05
+
+ POTCAR:    PAW_PBE Cr_pv 02Aug2007               
+ POTCAR:    PAW_PBE Mn_pv 02Aug2007               
+ POTCAR:    PAW_PBE Fe_pv 02Aug2007               
+ POTCAR:    PAW_PBE Co 02Aug2007                  
+ POTCAR:    PAW_PBE Ni_pv 06Sep2000               
+ POTCAR:    PAW_PBE Cu_pv 06Sep2000               
+ POTCAR:    PAW_PBE Zn 06Sep2000                  
+ POTCAR:    PAW_PBE Y_sv 25May2007                
+ POTCAR:    PAW_PBE Zr_sv 04Jan2005               
+ POTCAR:    PAW_PBE Nb_pv 08Apr2002               
+ POTCAR:    PAW_PBE Mo_pv 04Feb2005               
+ POTCAR:    PAW_PBE Rh_pv 25Jan2005               
+ POTCAR:    PAW_PBE Pd 04Jan2005                  
+ POTCAR:   PAW_PBE W_pv 06Sep2000                 
+ POTCAR:    PAW_PBE Ir 06Sep2000                  
+ POTCAR:    PAW_PBE Pt 04Feb2005                  
+ POTCAR:    PAW_PBE Cr_pv 02Aug2007               
+   VRHFIN =Cr : p6d5s1                                                                              
+   LEXCH  = PE                                                                                      
+   EATOM  =  1647.9177 eV,  121.1185 Ry                                                             
+                                                                                                    
+   TITEL  = PAW_PBE Cr_pv 02Aug2007                                                                 
+   LULTRA =        F    use ultrasoft PP ?                                                          
+   IUNSCR =        1    unscreen: 0-lin 1-nonlin 2-no                                               
+   RPACOR =    2.080    partial core radius                                                         
+   POMASS =   51.996; ZVAL   =   12.000    mass and valenz                                          
+   RCORE  =    2.300    outmost cutoff radius                                                       
+   RWIGS  =    2.500; RWIGS  =    1.323    wigner-seitz radius (au A)                               
+   ENMAX  =  265.681; ENMIN  =  199.261 eV                                                          
+   ICORE  =        3    local potential                                                             
+   LCOR   =        T    correct aug charges                                                         
+   LPAW   =        T    paw PP                                                                      
+   EAUG   =  519.424                                                                                
+   DEXC   =    0.000                                                                                
+   RMAX   =    2.356    core radius for proj-oper                                                   
+   RAUG   =    1.300    factor for augmentation sphere                                              
+   RDEP   =    2.447    radius for radial grids                                                     
+   RDEPT  =    1.882    core radius for aug-charge                                                  
+                                                                                                    
+   Atomic configuration                                                                             
+    8 entries                                                                                       
+     n  l   j            E        occ.                                                              
+     1  0  0.50     -5880.4963   2.0000                                                             
+     2  0  0.50      -667.0865   2.0000                                                             
+     2  1  1.50      -560.6250   6.0000                                                             
+     3  0  0.50       -73.9860   2.0000                                                             
+     3  1  1.50       -45.4378   6.0000                                                             
+     3  2  2.50        -2.9137   5.0000                                                             
+     4  0  0.50        -4.0071   1.0000                                                             
+     4  3  2.50        -1.3606   0.0000                                                             
+   Description                                                                                      
+     l       E           TYP  RCUT    TYP  RCUT                                                     
+     1    -45.4377911     23  2.000                                                                 
+     1      1.3605826     23  2.000                                                                 
+     2     -2.9136672     23  2.300                                                                 
+     2     -4.2742498     23  2.300                                                                 
+     0     -4.0071320     23  2.300                                                                 
+     0      9.4498803     23  2.300                                                                 
+     3      2.7211652     23  2.300                                                                 
+  local pseudopotential read in
+  partial core-charges read in
+  partial kinetic energy density read in
+  atomic valenz-charges read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+  non local Contribution for L=           2  read in
+    real space projection operators read in
+  non local Contribution for L=           2  read in
+    real space projection operators read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+    PAW grid and wavefunctions read in
+ 
+   number of l-projection  operators is LMAX  =           6
+   number of lm-projection operators is LMMAX =          18
+ 
+ POTCAR:    PAW_PBE Mn_pv 02Aug2007               
+   VRHFIN =Mn: 3p4s3d                                                                               
+   LEXCH  = PE                                                                                      
+   EATOM  =  2025.2664 eV,  148.8529 Ry                                                             
+                                                                                                    
+   TITEL  = PAW_PBE Mn_pv 02Aug2007                                                                 
+   LULTRA =        F    use ultrasoft PP ?                                                          
+   IUNSCR =        1    unscreen: 0-lin 1-nonlin 2-no                                               
+   RPACOR =    2.080    partial core radius                                                         
+   POMASS =   54.938; ZVAL   =   13.000    mass and valenz                                          
+   RCORE  =    2.300    outmost cutoff radius                                                       
+   RWIGS  =    2.500; RWIGS  =    1.323    wigner-seitz radius (au A)                               
+   ENMAX  =  269.864; ENMIN  =  202.398 eV                                                          
+   ICORE  =        3    local potential                                                             
+   LCOR   =        T    correct aug charges                                                         
+   LPAW   =        T    paw PP                                                                      
+   EAUG   =  569.085                                                                                
+   DEXC   =    0.000                                                                                
+   RMAX   =    2.343    core radius for proj-oper                                                   
+   RAUG   =    1.300    factor for augmentation sphere                                              
+   RDEP   =    2.338    radius for radial grids                                                     
+   RDEPT  =    1.798    core radius for aug-charge                                                  
+                                                                                                    
+   Atomic configuration                                                                             
+    8 entries                                                                                       
+     n  l   j            E        occ.                                                              
+     1  0  0.50     -6424.8287   2.0000                                                             
+     2  0  0.50      -739.1154   2.0000                                                             
+     2  1  1.50      -625.3949   6.0000                                                             
+     3  0  0.50       -81.6100   2.0000                                                             
+     3  1  1.50       -50.4667   6.0000                                                             
+     3  2  2.50        -3.3745   6.0000                                                             
+     4  0  0.50        -4.1331   1.0000                                                             
+     4  3  2.50        -1.3606   0.0000                                                             
+   Description                                                                                      
+     l       E           TYP  RCUT    TYP  RCUT                                                     
+     1    -50.4666628     23  2.000                                                                 
+     1     -1.3605826     23  2.000                                                                 
+     2     -3.3744729     23  2.300                                                                 
+     2     -4.7350555     23  2.300                                                                 
+     0     -4.1331431     23  2.300                                                                 
+     0      7.6656591     23  2.300                                                                 
+     3      9.5240782     23  2.300                                                                 
+  local pseudopotential read in
+  partial core-charges read in
+  partial kinetic energy density read in
+  atomic valenz-charges read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+  non local Contribution for L=           2  read in
+    real space projection operators read in
+  non local Contribution for L=           2  read in
+    real space projection operators read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+    PAW grid and wavefunctions read in
+ 
+   number of l-projection  operators is LMAX  =           6
+   number of lm-projection operators is LMMAX =          18
+ 
+ POTCAR:    PAW_PBE Fe_pv 02Aug2007               
+   VRHFIN =Fe:  3pd7s1                                                                              
+   LEXCH  = PE                                                                                      
+   EATOM  =  2457.4239 eV,  180.6156 Ry                                                             
+                                                                                                    
+   TITEL  = PAW_PBE Fe_pv 02Aug2007                                                                 
+   LULTRA =        F    use ultrasoft PP ?                                                          
+   IUNSCR =        1    unscreen: 0-lin 1-nonlin 2-no                                               
+   RPACOR =    1.750    partial core radius                                                         
+   POMASS =   55.847; ZVAL   =   14.000    mass and valenz                                          
+   RCORE  =    2.200    outmost cutoff radius                                                       
+   RWIGS  =    2.200; RWIGS  =    1.164    wigner-seitz radius (au A)                               
+   ENMAX  =  293.238; ENMIN  =  219.928 eV                                                          
+   ICORE  =        3    local potential                                                             
+   LCOR   =        T    correct aug charges                                                         
+   LPAW   =        T    paw PP                                                                      
+   EAUG   =  578.342                                                                                
+   DEXC   =    0.000                                                                                
+   RMAX   =    2.249    core radius for proj-oper                                                   
+   RAUG   =    1.300    factor for augmentation sphere                                              
+   RDEP   =    2.296    radius for radial grids                                                     
+   RDEPT  =    1.766    core radius for aug-charge                                                  
+                                                                                                    
+   Atomic configuration                                                                             
+    8 entries                                                                                       
+     n  l   j            E        occ.                                                              
+     1  0  0.50     -6993.8440   2.0000                                                             
+     2  0  0.50      -814.6047   2.0000                                                             
+     2  1  1.50      -693.3689   6.0000                                                             
+     3  0  0.50       -89.4732   2.0000                                                             
+     3  1  1.50       -55.6373   6.0000                                                             
+     3  2  2.50        -3.8151   7.0000                                                             
+     4  0  0.50        -4.2551   1.0000                                                             
+     4  3  2.50        -1.3606   0.0000                                                             
+   Description                                                                                      
+     l       E           TYP  RCUT    TYP  RCUT                                                     
+     1    -55.6372668     23  2.000                                                                 
+     1     -5.4423304     23  2.000                                                                 
+     2     -3.8151096     23  2.200                                                                 
+     2     -5.1756922     23  2.200                                                                 
+     0     -4.2550951     23  2.200                                                                 
+     0     27.2116520     23  2.200                                                                 
+     3     -1.3605826     23  2.200                                                                 
+  local pseudopotential read in
+  partial core-charges read in
+  partial kinetic energy density read in
+  atomic valenz-charges read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+  non local Contribution for L=           2  read in
+    real space projection operators read in
+  non local Contribution for L=           2  read in
+    real space projection operators read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+    PAW grid and wavefunctions read in
+ 
+   number of l-projection  operators is LMAX  =           6
+   number of lm-projection operators is LMMAX =          18
+ 
+ POTCAR:    PAW_PBE Co 02Aug2007                  
+   VRHFIN =Co: d8 s1                                                                                
+   LEXCH  = PE                                                                                      
+   EATOM  =   813.3670 eV,   59.7808 Ry                                                             
+                                                                                                    
+   TITEL  = PAW_PBE Co 02Aug2007                                                                    
+   LULTRA =        F    use ultrasoft PP ?                                                          
+   IUNSCR =        1    unscreen: 0-lin 1-nonlin 2-no                                               
+   RPACOR =    2.000    partial core radius                                                         
+   POMASS =   58.933; ZVAL   =    9.000    mass and valenz                                          
+   RCORE  =    2.300    outmost cutoff radius                                                       
+   RWIGS  =    2.460; RWIGS  =    1.302    wigner-seitz radius (au A)                               
+   ENMAX  =  267.968; ENMIN  =  200.976 eV                                                          
+   RCLOC  =    1.203    cutoff for local pot                                                        
+   LCOR   =        T    correct aug charges                                                         
+   LPAW   =        T    paw PP                                                                      
+   EAUG   =  477.818                                                                                
+   DEXC   =    0.000                                                                                
+   RMAX   =    2.360    core radius for proj-oper                                                   
+   RAUG   =    1.300    factor for augmentation sphere                                              
+   RDEP   =    2.393    radius for radial grids                                                     
+   RDEPT  =    1.864    core radius for aug-charge                                                  
+                                                                                                    
+   Atomic configuration                                                                             
+    9 entries                                                                                       
+     n  l   j            E        occ.                                                              
+     1  0  0.50     -7587.6674   2.0000                                                             
+     2  0  0.50      -893.6084   2.0000                                                             
+     2  1  1.50      -764.5805   6.0000                                                             
+     3  0  0.50       -97.5973   2.0000                                                             
+     3  1  1.50       -60.9648   6.0000                                                             
+     3  2  2.50        -4.2382   8.0000                                                             
+     4  0  0.50        -4.3746   1.0000                                                             
+     4  1  1.50        -4.0817   0.0000                                                             
+     4  3  2.50        -1.3606   0.0000                                                             
+   Description                                                                                      
+     l       E           TYP  RCUT    TYP  RCUT                                                     
+     2     -4.2382362     23  2.300                                                                 
+     2     -5.5988188     23  2.300                                                                 
+     0     -4.3745797     23  2.300                                                                 
+     0      5.7660125     23  2.300                                                                 
+     1     -2.7211652     23  2.300                                                                 
+     1     16.9860234     23  2.300                                                                 
+  local pseudopotential read in
+  partial core-charges read in
+  partial kinetic energy density read in
+  atomic valenz-charges read in
+  non local Contribution for L=           2  read in
+    real space projection operators read in
+  non local Contribution for L=           2  read in
+    real space projection operators read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+    PAW grid and wavefunctions read in
+ 
+   number of l-projection  operators is LMAX  =           6
+   number of lm-projection operators is LMMAX =          18
+ 
+ POTCAR:    PAW_PBE Ni_pv 06Sep2000               
+   VRHFIN =Ni:                                                                                      
+   LEXCH  = PE                                                                                      
+   EATOM  =  3501.1230 eV,  257.3253 Ry                                                             
+                                                                                                    
+   TITEL  = PAW_PBE Ni_pv 06Sep2000                                                                 
+   LULTRA =        F    use ultrasoft PP ?                                                          
+   IUNSCR =        1    unscreen: 0-lin 1-nonlin 2-no                                               
+   RPACOR =    1.500    partial core radius                                                         
+   POMASS =   58.690; ZVAL   =   16.000    mass and valenz                                          
+   RCORE  =    2.000    outmost cutoff radius                                                       
+   RWIGS  =    2.000; RWIGS  =    1.058    wigner-seitz radius (au A)                               
+   ENMAX  =  367.986; ENMIN  =  275.989 eV                                                          
+   RCLOC  =    1.301    cutoff for local pot                                                        
+   LCOR   =        T    correct aug charges                                                         
+   LPAW   =        T    paw PP                                                                      
+   EAUG   =  703.443                                                                                
+   DEXC   =    0.000                                                                                
+   RMAX   =    2.041    core radius for proj-oper                                                   
+   RAUG   =    1.300    factor for augmentation sphere                                              
+   RDEP   =    2.103    radius for radial grids                                                     
+   RDEPT  =    1.618    core radius for aug-charge                                                  
+                                                                                                    
+   Atomic configuration                                                                             
+    8 entries                                                                                       
+     n  l   j            E        occ.                                                              
+     1  0  0.50     -8206.4253   2.0000                                                             
+     2  0  0.50      -976.1748   2.0000                                                             
+     2  1  1.50      -839.0571   6.0000                                                             
+     3  0  0.50      -105.9991   2.0000                                                             
+     3  1  1.50       -66.4603   6.0000                                                             
+     3  2  2.50        -4.6458   9.0000                                                             
+     4  0  0.50        -4.4926   1.0000                                                             
+     4  3  2.50        -1.3606   0.0000                                                             
+   Description                                                                                      
+     l       E           TYP  RCUT    TYP  RCUT                                                     
+     1    -66.4602962     23  1.700                                                                 
+     1     -1.3605826     23  1.700                                                                 
+     2     -4.6457867     23  2.000                                                                 
+     2     -6.0063693     23  2.000                                                                 
+     0     -4.4925576     23  1.900                                                                 
+     0     16.3626226     23  1.900                                                                 
+  local pseudopotential read in
+  partial core-charges read in
+  partial kinetic energy density read in
+  atomic valenz-charges read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+  non local Contribution for L=           2  read in
+    real space projection operators read in
+  non local Contribution for L=           2  read in
+    real space projection operators read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+    PAW grid and wavefunctions read in
+ 
+   number of l-projection  operators is LMAX  =           6
+   number of lm-projection operators is LMMAX =          18
+ 
+ POTCAR:    PAW_PBE Cu_pv 06Sep2000               
+   VRHFIN =Cu: d10 p1                                                                               
+   LEXCH  = PE                                                                                      
+   EATOM  =  4120.1201 eV,  302.8203 Ry                                                             
+                                                                                                    
+   TITEL  = PAW_PBE Cu_pv 06Sep2000                                                                 
+   LULTRA =        F    use ultrasoft PP ?                                                          
+   IUNSCR =        1    unscreen: 0-lin 1-nonlin 2-no                                               
+   RPACOR =    1.500    partial core radius                                                         
+   POMASS =   63.546; ZVAL   =   17.000    mass and valenz                                          
+   RCORE  =    2.000    outmost cutoff radius                                                       
+   RWIGS  =    2.000; RWIGS  =    1.058    wigner-seitz radius (au A)                               
+   ENMAX  =  368.648; ENMIN  =  276.486 eV                                                          
+   RCLOC  =    1.304    cutoff for local pot                                                        
+   LCOR   =        T    correct aug charges                                                         
+   LPAW   =        T    paw PP                                                                      
+   EAUG   =  758.233                                                                                
+   DEXC   =    0.000                                                                                
+   RMAX   =    2.046    core radius for proj-oper                                                   
+   RAUG   =    1.300    factor for augmentation sphere                                              
+   RDEP   =    2.025    radius for radial grids                                                     
+   RDEPT  =    1.558    core radius for aug-charge                                                  
+                                                                                                    
+   Atomic configuration                                                                             
+    8 entries                                                                                       
+     n  l   j            E        occ.                                                              
+     1  0  0.50     -8850.2467   2.0000                                                             
+     2  0  0.50     -1062.3498   2.0000                                                             
+     2  1  1.50      -916.8226   6.0000                                                             
+     3  0  0.50      -114.6929   2.0000                                                             
+     3  1  1.50       -72.1325   6.0000                                                             
+     3  2  2.50        -5.0394  10.0000                                                             
+     4  0  0.50        -4.6097   1.0000                                                             
+     4  3  2.50        -1.3606   0.0000                                                             
+   Description                                                                                      
+     l       E           TYP  RCUT    TYP  RCUT                                                     
+     1    -72.1324777     23  1.700                                                                 
+     1     -1.3605826     23  1.700                                                                 
+     2     -5.0393776     23  2.000                                                                 
+     2     -6.3999602     23  2.000                                                                 
+     0     -4.6097062     23  1.800                                                                 
+     0     14.1620818     23  1.800                                                                 
+  local pseudopotential read in
+  partial core-charges read in
+  partial kinetic energy density read in
+  atomic valenz-charges read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+  non local Contribution for L=           2  read in
+    real space projection operators read in
+  non local Contribution for L=           2  read in
+    real space projection operators read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+    PAW grid and wavefunctions read in
+ 
+   number of l-projection  operators is LMAX  =           6
+   number of lm-projection operators is LMMAX =          18
+ 
+ POTCAR:    PAW_PBE Zn 06Sep2000                  
+   VRHFIN =Zn: d10 p2                                                                               
+   LEXCH  = PE                                                                                      
+   EATOM  =  1748.8345 eV,  128.5357 Ry                                                             
+                                                                                                    
+   TITEL  = PAW_PBE Zn 06Sep2000                                                                    
+   LULTRA =        F    use ultrasoft PP ?                                                          
+   IUNSCR =        1    unscreen: 0-lin 1-nonlin 2-no                                               
+   RPACOR =    2.000    partial core radius                                                         
+   POMASS =   65.390; ZVAL   =   12.000    mass and valenz                                          
+   RCORE  =    2.300    outmost cutoff radius                                                       
+   RWIGS  =    2.400; RWIGS  =    1.270    wigner-seitz radius (au A)                               
+   ENMAX  =  276.723; ENMIN  =  207.542 eV                                                          
+   RCLOC  =    1.828    cutoff for local pot                                                        
+   LCOR   =        T    correct aug charges                                                         
+   LPAW   =        T    paw PP                                                                      
+   EAUG   =  575.892                                                                                
+   DEXC   =    0.000                                                                                
+   RMAX   =    2.347    core radius for proj-oper                                                   
+   RAUG   =    1.300    factor for augmentation sphere                                              
+   RDEP   =    2.324    radius for radial grids                                                     
+   RDEPT  =    1.788    core radius for aug-charge                                                  
+                                                                                                    
+   Atomic configuration                                                                             
+    9 entries                                                                                       
+     n  l   j            E        occ.                                                              
+     1  0  0.50     -9524.6913   2.0000                                                             
+     2  0  0.50     -1158.1882   2.0000                                                             
+     2  1  1.50     -1003.8506   6.0000                                                             
+     3  0  0.50      -129.2194   2.0000                                                             
+     3  1  1.50       -83.3890   6.0000                                                             
+     3  2  2.50       -10.1410  10.0000                                                             
+     4  0  0.50        -5.9785   2.0000                                                             
+     4  1  0.50        -4.0817   0.0000                                                             
+     4  3  2.50        -1.3606   0.0000                                                             
+   Description                                                                                      
+     l       E           TYP  RCUT    TYP  RCUT                                                     
+     2    -10.1410010     23  2.300                                                                 
+     2    -11.5015836     23  2.300                                                                 
+     0     -5.9785163     23  2.300                                                                 
+     0      1.1858015     23  2.300                                                                 
+     1     -2.7211652     23  2.300                                                                 
+     1     13.2444212     23  2.300                                                                 
+  local pseudopotential read in
+  partial core-charges read in
+  partial kinetic energy density read in
+  atomic valenz-charges read in
+  non local Contribution for L=           2  read in
+    real space projection operators read in
+  non local Contribution for L=           2  read in
+    real space projection operators read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+    PAW grid and wavefunctions read in
+ 
+   number of l-projection  operators is LMAX  =           6
+   number of lm-projection operators is LMMAX =          18
+ 
+ POTCAR:    PAW_PBE Y_sv 25May2007                
+   VRHFIN =Y: 4s4p5s4d                                                                              
+   LEXCH  = PE                                                                                      
+   EATOM  =  1046.9140 eV,   76.9460 Ry                                                             
+                                                                                                    
+   TITEL  = PAW_PBE Y_sv 25May2007                                                                  
+   LULTRA =        F    use ultrasoft PP ?                                                          
+   IUNSCR =        1    unscreen: 0-lin 1-nonlin 2-no                                               
+   RPACOR =    2.200    partial core radius                                                         
+   POMASS =   88.906; ZVAL   =   11.000    mass and valenz                                          
+   RCORE  =    2.800    outmost cutoff radius                                                       
+   RWIGS  =    3.430; RWIGS  =    1.815    wigner-seitz radius (au A)                               
+   ENMAX  =  202.626; ENMIN  =  151.970 eV                                                          
+   RCLOC  =    2.212    cutoff for local pot                                                        
+   LCOR   =        T    correct aug charges                                                         
+   LPAW   =        T    paw PP                                                                      
+   EAUG   =  470.889                                                                                
+   DEXC   =    0.000                                                                                
+   RMAX   =    2.863    core radius for proj-oper                                                   
+   RAUG   =    1.300    factor for augmentation sphere                                              
+   RDEP   =    2.926    radius for radial grids                                                     
+   RDEPT  =    2.280    core radius for aug-charge                                                  
+                                                                                                    
+   Atomic configuration                                                                             
+   11 entries                                                                                       
+     n  l   j            E        occ.                                                              
+     1  0  0.50    -16863.0720   2.0000                                                             
+     2  0  0.50     -2309.2881   2.0000                                                             
+     2  1  1.50     -2055.5536   6.0000                                                             
+     3  0  0.50      -367.1837   2.0000                                                             
+     3  1  1.50      -284.8912   6.0000                                                             
+     3  2  2.50      -149.4324  10.0000                                                             
+     4  0  0.50       -46.3345   2.0000                                                             
+     5  0  0.50        -3.6387   1.0000                                                             
+     4  1  1.50       -26.3769   6.0000                                                             
+     4  2  2.50        -1.6291   2.0000                                                             
+     4  3  2.50        -1.3606   0.0000                                                             
+   Description                                                                                      
+     l       E           TYP  RCUT    TYP  RCUT                                                     
+     0    -46.3344714     23  2.600                                                                 
+     0     -3.6387002     23  2.700                                                                 
+     1    -26.3769044     23  2.600                                                                 
+     1    -27.7374870     23  2.600                                                                 
+     2     -1.6291019     23  2.600                                                                 
+     2      0.1354037     23  2.600                                                                 
+     3     -1.3605826     23  2.800                                                                 
+  local pseudopotential read in
+  partial core-charges read in
+  partial kinetic energy density read in
+  atomic valenz-charges read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+  non local Contribution for L=           2  read in
+    real space projection operators read in
+  non local Contribution for L=           2  read in
+    real space projection operators read in
+  non local Contribution for L=           3  read in
+    real space projection operators read in
+    PAW grid and wavefunctions read in
+ 
+   number of l-projection  operators is LMAX  =           7
+   number of lm-projection operators is LMMAX =          25
+ 
+ POTCAR:    PAW_PBE Zr_sv 04Jan2005               
+   VRHFIN =Zr: 4s4p5s4d                                                                             
+   LEXCH  = PE                                                                                      
+   EATOM  =  1284.2219 eV,   94.3876 Ry                                                             
+                                                                                                    
+   TITEL  = PAW_PBE Zr_sv 04Jan2005                                                                 
+   LULTRA =        F    use ultrasoft PP ?                                                          
+   IUNSCR =        1    unscreen: 0-lin 1-nonlin 2-no                                               
+   RPACOR =    2.200    partial core radius                                                         
+   POMASS =   91.224; ZVAL   =   12.000    mass and valenz                                          
+   RCORE  =    2.500    outmost cutoff radius                                                       
+   RWIGS  =    3.070; RWIGS  =    1.625    wigner-seitz radius (au A)                               
+   ENMAX  =  229.898; ENMIN  =  172.424 eV                                                          
+   ICORE  =        3    local potential                                                             
+   LCOR   =        T    correct aug charges                                                         
+   LPAW   =        T    paw PP                                                                      
+   EAUG   =  461.257                                                                                
+   DEXC   =    0.000                                                                                
+   RMAX   =    2.561    core radius for proj-oper                                                   
+   RAUG   =    1.300    factor for augmentation sphere                                              
+   RDEP   =    2.597    radius for radial grids                                                     
+   RDEPT  =    2.007    core radius for aug-charge                                                  
+                                                                                                    
+   Atomic configuration                                                                             
+   11 entries                                                                                       
+     n  l   j            E        occ.                                                              
+     1  0  0.50    -17820.0161   2.0000                                                             
+     2  0  0.50     -2467.0882   2.0000                                                             
+     2  1  1.50     -2199.6095   6.0000                                                             
+     3  0  0.50      -402.4863   2.0000                                                             
+     3  1  1.50      -315.3675   6.0000                                                             
+     3  2  2.50      -172.4472  10.0000                                                             
+     4  0  0.50       -52.4146   2.0000                                                             
+     5  0  0.50        -3.8421   1.0000                                                             
+     4  1  1.50       -30.5054   6.0000                                                             
+     4  2  2.50        -2.3341   3.0000                                                             
+     4  3  2.50        -1.3606   0.0000                                                             
+   Description                                                                                      
+     l       E           TYP  RCUT    TYP  RCUT                                                     
+     0    -52.4145962     23  2.200                                                                 
+     0     -3.8421270     23  2.500                                                                 
+     1    -30.5053914     23  2.200                                                                 
+     1     20.4087390     23  2.200                                                                 
+     2     -2.3340816     23  2.500                                                                 
+     2     -0.6120942     23  2.500                                                                 
+     3     -4.0817478     23  2.500                                                                 
+  local pseudopotential read in
+  partial core-charges read in
+  partial kinetic energy density read in
+  atomic valenz-charges read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+  non local Contribution for L=           2  read in
+    real space projection operators read in
+  non local Contribution for L=           2  read in
+    real space projection operators read in
+    PAW grid and wavefunctions read in
+ 
+   number of l-projection  operators is LMAX  =           6
+   number of lm-projection operators is LMMAX =          18
+ 
+ POTCAR:    PAW_PBE Nb_pv 08Apr2002               
+   VRHFIN =Nb: 4p5s4d                                                                               
+   LEXCH  = PE                                                                                      
+   EATOM  =  1043.3917 eV,   76.6871 Ry                                                             
+                                                                                                    
+   TITEL  = PAW_PBE Nb_pv 08Apr2002                                                                 
+   LULTRA =        F    use ultrasoft PP ?                                                          
+   IUNSCR =        1    unscreen: 0-lin 1-nonlin 2-no                                               
+   RPACOR =    2.200    partial core radius                                                         
+   POMASS =   92.000; ZVAL   =   11.000    mass and valenz                                          
+   RCORE  =    2.750    outmost cutoff radius                                                       
+   RWIGS  =    2.840; RWIGS  =    1.503    wigner-seitz radius (au A)                               
+   ENMAX  =  208.608; ENMIN  =  156.456 eV                                                          
+   RCLOC  =    2.201    cutoff for local pot                                                        
+   LCOR   =        T    correct aug charges                                                         
+   LPAW   =        T    paw PP                                                                      
+   EAUG   =  355.067                                                                                
+   DEXC   =    0.000                                                                                
+   RMAX   =    2.804    core radius for proj-oper                                                   
+   RAUG   =    1.300    factor for augmentation sphere                                              
+   RDEP   =    2.776    radius for radial grids                                                     
+   RDEPT  =    2.198    core radius for aug-charge                                                  
+                                                                                                    
+   Atomic configuration                                                                             
+   11 entries                                                                                       
+     n  l   j            E        occ.                                                              
+     1  0  0.50    -18805.2456   2.0000                                                             
+     2  0  0.50     -2630.2869   2.0000                                                             
+     2  1  1.50     -2348.4045   6.0000                                                             
+     3  0  0.50      -438.8756   2.0000                                                             
+     3  1  1.50      -346.7587   6.0000                                                             
+     3  2  2.50      -196.2559  10.0000                                                             
+     4  0  0.50       -58.3859   2.0000                                                             
+     4  1  1.50       -34.5141   6.0000                                                             
+     4  2  2.50        -3.0408   4.0000                                                             
+     5  0  0.50        -3.9816   1.0000                                                             
+     4  3  2.50        -1.3606   0.0000                                                             
+   Description                                                                                      
+     l       E           TYP  RCUT    TYP  RCUT                                                     
+     1    -34.5140617     23  2.600                                                                 
+     1     -1.3605826     23  2.600                                                                 
+     2     -3.0407924     23  2.600                                                                 
+     2     -1.4463597     23  2.600                                                                 
+     0     -3.9816219     23  2.750                                                                 
+     0     20.4087390     23  2.750                                                                 
+  local pseudopotential read in
+  partial core-charges read in
+  partial kinetic energy density read in
+  atomic valenz-charges read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+  non local Contribution for L=           2  read in
+    real space projection operators read in
+  non local Contribution for L=           2  read in
+    real space projection operators read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+    PAW grid and wavefunctions read in
+ 
+   number of l-projection  operators is LMAX  =           6
+   number of lm-projection operators is LMMAX =          18
+ 
+ POTCAR:    PAW_PBE Mo_pv 04Feb2005               
+   VRHFIN =Mo: 4p5s4d                                                                               
+   LEXCH  = PE                                                                                      
+   EATOM  =  1284.3008 eV,   94.3934 Ry                                                             
+                                                                                                    
+   TITEL  = PAW_PBE Mo_pv 04Feb2005                                                                 
+   LULTRA =        F    use ultrasoft PP ?                                                          
+   IUNSCR =        1    unscreen: 0-lin 1-nonlin 2-no                                               
+   RPACOR =    2.200    partial core radius                                                         
+   POMASS =   95.940; ZVAL   =   12.000    mass and valenz                                          
+   RCORE  =    2.700    outmost cutoff radius                                                       
+   RWIGS  =    2.750; RWIGS  =    1.455    wigner-seitz radius (au A)                               
+   ENMAX  =  224.584; ENMIN  =  168.438 eV                                                          
+   ICORE  =        3    local potential                                                             
+   LCOR   =        T    correct aug charges                                                         
+   LPAW   =        T    paw PP                                                                      
+   EAUG   =  392.427                                                                                
+   DEXC   =    0.000                                                                                
+   RMAX   =    2.754    core radius for proj-oper                                                   
+   RAUG   =    1.300    factor for augmentation sphere                                              
+   RDEP   =    2.815    radius for radial grids                                                     
+   RDEPT  =    2.166    core radius for aug-charge                                                  
+                                                                                                    
+   Atomic configuration                                                                             
+   11 entries                                                                                       
+     n  l   j            E        occ.                                                              
+     1  0  0.50    -19819.0341   2.0000                                                             
+     2  0  0.50     -2799.0127   2.0000                                                             
+     2  1  1.50     -2502.0276   6.0000                                                             
+     3  0  0.50      -476.4449   2.0000                                                             
+     3  1  1.50      -379.1496   6.0000                                                             
+     3  2  2.50      -220.9367  10.0000                                                             
+     4  0  0.50       -64.3378   2.0000                                                             
+     4  1  1.50       -38.4773   6.0000                                                             
+     4  2  2.50        -3.7535   5.0000                                                             
+     5  0  0.50        -4.0862   1.0000                                                             
+     4  3  2.50        -1.3606   0.0000                                                             
+   Description                                                                                      
+     l       E           TYP  RCUT    TYP  RCUT                                                     
+     1    -38.4772993     23  2.500                                                                 
+     1     -2.7211652     23  2.500                                                                 
+     2     -3.7534941     23  2.500                                                                 
+     2     -5.1140767     23  2.500                                                                 
+     0     -4.0861640     23  2.700                                                                 
+     0     27.2116520     23  2.700                                                                 
+     3     -4.0817478     23  2.600                                                                 
+  local pseudopotential read in
+  partial core-charges read in
+  partial kinetic energy density read in
+  atomic valenz-charges read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+  non local Contribution for L=           2  read in
+    real space projection operators read in
+  non local Contribution for L=           2  read in
+    real space projection operators read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+    PAW grid and wavefunctions read in
+ 
+   number of l-projection  operators is LMAX  =           6
+   number of lm-projection operators is LMMAX =          18
+ 
+ POTCAR:    PAW_PBE Rh_pv 25Jan2005               
+   VRHFIN =Rh: 4p5s4d                                                                               
+   LEXCH  = PE                                                                                      
+   EATOM  =  2226.4782 eV,  163.6415 Ry                                                             
+                                                                                                    
+   TITEL  = PAW_PBE Rh_pv 25Jan2005                                                                 
+   LULTRA =        F    use ultrasoft PP ?                                                          
+   IUNSCR =        1    unscreen: 0-lin 1-nonlin 2-no                                               
+   RPACOR =    2.000    partial core radius                                                         
+   POMASS =  102.906; ZVAL   =   15.000    mass and valenz                                          
+   RCORE  =    2.400    outmost cutoff radius                                                       
+   RWIGS  =    2.650; RWIGS  =    1.402    wigner-seitz radius (au A)                               
+   ENMAX  =  247.408; ENMIN  =  185.556 eV                                                          
+   ICORE  =        3    local potential                                                             
+   LCOR   =        T    correct aug charges                                                         
+   LPAW   =        T    paw PP                                                                      
+   EAUG   =  425.654                                                                                
+   DEXC   =    0.000                                                                                
+   RMAX   =    2.461    core radius for proj-oper                                                   
+   RAUG   =    1.300    factor for augmentation sphere                                              
+   RDEP   =    2.536    radius for radial grids                                                     
+   RDEPT  =    1.975    core radius for aug-charge                                                  
+                                                                                                    
+   Atomic configuration                                                                             
+   11 entries                                                                                       
+     n  l   j            E        occ.                                                              
+     1  0  0.50    -23034.1986   2.0000                                                             
+     2  0  0.50     -3339.2387   2.0000                                                             
+     2  1  1.50     -2992.3290   6.0000                                                             
+     3  0  0.50      -596.7250   2.0000                                                             
+     3  1  1.50      -482.7183   6.0000                                                             
+     3  2  2.50      -300.5356  10.0000                                                             
+     4  0  0.50       -82.4809   2.0000                                                             
+     4  1  0.50       -50.4082   6.0000                                                             
+     4  2  2.50        -5.9408   8.0000                                                             
+     5  0  0.50        -4.2999   1.0000                                                             
+     4  3  2.50        -1.3606   0.0000                                                             
+   Description                                                                                      
+     l       E           TYP  RCUT    TYP  RCUT                                                     
+     1    -50.4082326     23  2.100                                                                 
+     1      4.0817478     23  2.100                                                                 
+     2     -5.9408148     23  2.400                                                                 
+     2     -7.3013974     23  2.400                                                                 
+     0     -4.2998579     23  2.400                                                                 
+     0     13.6058260     23  2.400                                                                 
+     3     -4.0817478     23  2.400                                                                 
+  local pseudopotential read in
+  partial core-charges read in
+  partial kinetic energy density read in
+  atomic valenz-charges read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+  non local Contribution for L=           2  read in
+    real space projection operators read in
+  non local Contribution for L=           2  read in
+    real space projection operators read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+    PAW grid and wavefunctions read in
+ 
+   number of l-projection  operators is LMAX  =           6
+   number of lm-projection operators is LMMAX =          18
+ 
+ POTCAR:    PAW_PBE Pd 04Jan2005                  
+   VRHFIN =Pd : s1 d9                                                                               
+   LEXCH  = PE                                                                                      
+   EATOM  =   809.7530 eV,   59.5152 Ry                                                             
+                                                                                                    
+   TITEL  = PAW_PBE Pd 04Jan2005                                                                    
+   LULTRA =        F    use ultrasoft PP ?                                                          
+   IUNSCR =        1    unscreen: 0-lin 1-nonlin 2-no                                               
+   RPACOR =    2.000    partial core radius                                                         
+   POMASS =  106.420; ZVAL   =   10.000    mass and valenz                                          
+   RCORE  =    2.600    outmost cutoff radius                                                       
+   RWIGS  =    2.710; RWIGS  =    1.434    wigner-seitz radius (au A)                               
+   ENMAX  =  250.925; ENMIN  =  188.194 eV                                                          
+   ICORE  =        3    local potential                                                             
+   LCOR   =        T    correct aug charges                                                         
+   LPAW   =        T    paw PP                                                                      
+   EAUG   =  416.230                                                                                
+   DEXC   =    0.000                                                                                
+   RMAX   =    2.653    core radius for proj-oper                                                   
+   RAUG   =    1.300    factor for augmentation sphere                                              
+   RDEP   =    2.734    radius for radial grids                                                     
+   RDEPT  =    2.103    core radius for aug-charge                                                  
+                                                                                                    
+   Atomic configuration                                                                             
+   12 entries                                                                                       
+     n  l   j            E        occ.                                                              
+     1  0  0.50    -24164.6631   2.0000                                                             
+     2  0  0.50     -3530.9218   2.0000                                                             
+     2  1  1.50     -3165.6822   6.0000                                                             
+     3  0  0.50      -639.4577   2.0000                                                             
+     3  1  1.50      -519.4532   6.0000                                                             
+     3  2  2.50      -328.9757  10.0000                                                             
+     4  0  0.50       -88.7014   2.0000                                                             
+     4  1  1.50       -54.4540   6.0000                                                             
+     4  2  2.50        -6.6878   9.0000                                                             
+     5  0  0.50        -4.3543   1.0000                                                             
+     5  1  0.50        -1.3606   0.0000                                                             
+     4  3  2.50        -1.3606   0.0000                                                             
+   Description                                                                                      
+     l       E           TYP  RCUT    TYP  RCUT                                                     
+     2     -6.6878251     23  2.400                                                                 
+     2     -8.0484077     23  2.400                                                                 
+     0     -4.3542939     23  2.400                                                                 
+     0      4.3406793     23  2.400                                                                 
+     1     -4.0817478     23  2.600                                                                 
+     1     15.8380318     23  2.600                                                                 
+     3     -4.0817478     23  2.400                                                                 
+  local pseudopotential read in
+  partial core-charges read in
+  partial kinetic energy density read in
+  atomic valenz-charges read in
+  non local Contribution for L=           2  read in
+    real space projection operators read in
+  non local Contribution for L=           2  read in
+    real space projection operators read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+    PAW grid and wavefunctions read in
+ 
+   number of l-projection  operators is LMAX  =           6
+   number of lm-projection operators is LMMAX =          18
+ 
+ POTCAR:   PAW_PBE W_pv 06Sep2000                 
+   VRHFIN =W : 5p6s5d                                                                               
+   LEXCH  = PE                                                                                      
+   EATOM  =  1260.0376 eV,   92.6101 Ry                                                             
+                                                                                                    
+   TITEL  = PAW_PBE W_pv 06Sep2000                                                                  
+   LULTRA =        F    use ultrasoft PP ?                                                          
+   IUNSCR =        1    unscreen: 0-lin 1-nonlin 2-no                                               
+   RPACOR =    2.330    partial core radius                                                         
+   POMASS =  183.850; ZVAL   =   12.000    mass and valenz                                          
+   RCORE  =    2.500    outmost cutoff radius                                                       
+   RWIGS  =    2.750; RWIGS  =    1.455    wigner-seitz radius (au A)                               
+   ENMAX  =  223.065; ENMIN  =  167.299 eV                                                          
+   RCLOC  =    2.147    cutoff for local pot                                                        
+   LCOR   =        T    correct aug charges                                                         
+   LPAW   =        T    paw PP                                                                      
+   EAUG   =  373.438                                                                                
+   DEXC   =    -.018                                                                                
+   RMAX   =    3.087    core radius for proj-oper                                                   
+   RAUG   =    1.300    factor for augmentation sphere                                              
+   RDEP   =    2.539    radius for radial grids                                                     
+   QCUT   =   -4.049; QGAM   =    8.098    optimization parameters                                  
+                                                                                                    
+   Description                                                                                      
+     l     E      TYP  RCUT    TYP  RCUT                                                            
+     1   .000     23  2.500                                                                         
+     1  -.200     23  2.500                                                                         
+     2   .000     23  2.500                                                                         
+     2   .000     23  2.500                                                                         
+     0   .000     23  2.500                                                                         
+     0   .000     23  2.500                                                                         
+     3   .000      7   .000                                                                         
+  local pseudopotential read in
+  partial core-charges read in
+  atomic valenz-charges read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+  non local Contribution for L=           2  read in
+    real space projection operators read in
+  non local Contribution for L=           2  read in
+    real space projection operators read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+    PAW grid and wavefunctions read in
+ 
+   number of l-projection  operators is LMAX  =           6
+   number of lm-projection operators is LMMAX =          18
+ 
+ POTCAR:    PAW_PBE Ir 06Sep2000                  
+   VRHFIN =Ir: s1d8                                                                                 
+   LEXCH  = PE                                                                                      
+   EATOM  =   560.1833 eV,   41.1723 Ry                                                             
+                                                                                                    
+   TITEL  = PAW_PBE Ir 06Sep2000                                                                    
+   LULTRA =        F    use ultrasoft PP ?                                                          
+   IUNSCR =        1    unscreen: 0-lin 1-nonlin 2-no                                               
+   RPACOR =    2.250    partial core radius                                                         
+   POMASS =  192.220; ZVAL   =    9.000    mass and valenz                                          
+   RCORE  =    2.600    outmost cutoff radius                                                       
+   RWIGS  =    2.690; RWIGS  =    1.423    wigner-seitz radius (au A)                               
+   ENMAX  =  210.864; ENMIN  =  158.148 eV                                                          
+   RCLOC  =    1.857    cutoff for local pot                                                        
+   LCOR   =        T    correct aug charges                                                         
+   LPAW   =        T    paw PP                                                                      
+   EAUG   =  318.962                                                                                
+   DEXC   =    0.000                                                                                
+   RMAX   =    2.667    core radius for proj-oper                                                   
+   RAUG   =    1.300    factor for augmentation sphere                                              
+   RDEP   =    2.748    radius for radial grids                                                     
+   RDEPT  =    2.300    core radius for aug-charge                                                  
+                                                                                                    
+   Atomic configuration                                                                             
+   16 entries                                                                                       
+     n  l   j            E        occ.                                                              
+     1  0  0.50    -76100.0449   2.0000                                                             
+     2  0  0.50    -13308.1683   2.0000                                                             
+     2  1  1.50    -11558.0021   6.0000                                                             
+     3  0  0.50     -3110.7274   2.0000                                                             
+     3  1  1.50     -2599.2109   6.0000                                                             
+     3  2  2.50     -2037.1515  10.0000                                                             
+     4  0  0.50      -661.6001   2.0000                                                             
+     4  1  1.50      -493.8981   6.0000                                                             
+     4  2  2.50      -288.1909  10.0000                                                             
+     4  3  3.50       -59.5718  14.0000                                                             
+     5  0  0.50       -95.3879   2.0000                                                             
+     5  1  1.50       -52.2747   6.0000                                                             
+     5  2  2.50        -5.4180   8.0000                                                             
+     6  0  0.50        -5.5479   1.0000                                                             
+     6  1  1.50        -6.8029   0.0000                                                             
+     5  3  2.50        -1.3606   0.0000                                                             
+   Description                                                                                      
+     l       E           TYP  RCUT    TYP  RCUT                                                     
+     2     -5.4179967     23  2.600                                                                 
+     2     -6.7785793     23  2.600                                                                 
+     0     -5.5478636     23  2.600                                                                 
+     0      2.2542272     23  2.600                                                                 
+     1     -2.7211652     23  2.600                                                                 
+     1     20.4087390     23  2.600                                                                 
+  local pseudopotential read in
+  partial core-charges read in
+  partial kinetic energy density read in
+  atomic valenz-charges read in
+  non local Contribution for L=           2  read in
+    real space projection operators read in
+  non local Contribution for L=           2  read in
+    real space projection operators read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+    PAW grid and wavefunctions read in
+ 
+   number of l-projection  operators is LMAX  =           6
+   number of lm-projection operators is LMMAX =          18
+ 
+ POTCAR:    PAW_PBE Pt 04Feb2005                  
+   VRHFIN =Pt: s1d9                                                                                 
+   LEXCH  = PE                                                                                      
+   EATOM  =   729.1176 eV,   53.5886 Ry                                                             
+                                                                                                    
+   TITEL  = PAW_PBE Pt 04Feb2005                                                                    
+   LULTRA =        F    use ultrasoft PP ?                                                          
+   IUNSCR =        1    unscreen: 0-lin 1-nonlin 2-no                                               
+   RPACOR =    2.330    partial core radius                                                         
+   POMASS =  195.080; ZVAL   =   10.000    mass and valenz                                          
+   RCORE  =    2.600    outmost cutoff radius                                                       
+   RWIGS  =    2.750; RWIGS  =    1.455    wigner-seitz radius (au A)                               
+   ENMAX  =  230.283; ENMIN  =  172.712 eV                                                          
+   ICORE  =        3    local potential                                                             
+   LCOR   =        T    correct aug charges                                                         
+   LPAW   =        T    paw PP                                                                      
+   EAUG   =  358.966                                                                                
+   DEXC   =    0.000                                                                                
+   RMAX   =    2.658    core radius for proj-oper                                                   
+   RAUG   =    1.300    factor for augmentation sphere                                              
+   RDEP   =    2.761    radius for radial grids                                                     
+   RDEPT  =    2.203    core radius for aug-charge                                                  
+                                                                                                    
+   Atomic configuration                                                                             
+   16 entries                                                                                       
+     n  l   j            E        occ.                                                              
+     1  0  0.50    -78401.1885   2.0000                                                             
+     2  0  0.50    -13770.7750   2.0000                                                             
+     2  1  1.50    -11931.0468   6.0000                                                             
+     3  0  0.50     -3234.7234   2.0000                                                             
+     3  1  1.50     -2699.2216   6.0000                                                             
+     3  2  2.50     -2119.5714  10.0000                                                             
+     4  0  0.50      -695.1528   2.0000                                                             
+     4  1  1.50      -519.6034   6.0000                                                             
+     4  2  2.50      -306.6786  10.0000                                                             
+     4  3  3.50       -70.1041  14.0000                                                             
+     5  0  0.50      -101.7747   2.0000                                                             
+     5  1  1.50       -55.9873   6.0000                                                             
+     5  2  2.50        -6.1423   9.0000                                                             
+     6  0  0.50        -5.6573   1.0000                                                             
+     6  1  1.50        -6.8029   0.0000                                                             
+     5  3  2.50        -1.3606   0.0000                                                             
+   Description                                                                                      
+     l       E           TYP  RCUT    TYP  RCUT                                                     
+     2     -6.1423404     23  2.500                                                                 
+     2     -7.5029230     23  2.500                                                                 
+     0     -5.6573207     23  2.500                                                                 
+     0      0.7416693     23  2.500                                                                 
+     1     -2.7211652     23  2.600                                                                 
+     1     20.4087390     23  2.600                                                                 
+     3     -1.3605826     23  2.500                                                                 
+  local pseudopotential read in
+  partial core-charges read in
+  partial kinetic energy density read in
+  atomic valenz-charges read in
+  non local Contribution for L=           2  read in
+    real space projection operators read in
+  non local Contribution for L=           2  read in
+    real space projection operators read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+    PAW grid and wavefunctions read in
+ 
+   number of l-projection  operators is LMAX  =           6
+   number of lm-projection operators is LMMAX =          18
+ 
+ Optimization of the real space projectors (new method)
+
+ maximal supplied QI-value         = 16.25
+ optimisation between [QCUT,QGAM] = [ 11.54, 23.24] = [ 37.28,151.24] Ry 
+ Optimized for a Real-space Cutoff    1.32 Angstroem
+
+   l    n(q)    QCUT    max X(q) W(low)/X(q) W(high)/X(q)  e(spline) 
+   1      9    11.539     3.262    0.69E-04    0.25E-03    0.10E-06
+   1      9    11.539     5.741    0.20E-03    0.59E-03    0.25E-06
+   2      8    11.539    60.438    0.24E-03    0.41E-03    0.22E-06
+   2      8    11.539    55.380    0.24E-03    0.42E-03    0.23E-06
+   0      9    11.539    80.273    0.11E-03    0.13E-03    0.76E-07
+   0      9    11.539    36.654    0.95E-04    0.12E-03    0.68E-07
+ Optimization of the real space projectors (new method)
+
+ maximal supplied QI-value         = 16.25
+ optimisation between [QCUT,QGAM] = [ 11.54, 23.24] = [ 37.28,151.24] Ry 
+ Optimized for a Real-space Cutoff    1.45 Angstroem
+
+   l    n(q)    QCUT    max X(q) W(low)/X(q) W(high)/X(q)  e(spline) 
+   1     10    11.539     3.658    0.56E-04    0.12E-03    0.13E-06
+   1     10    11.539     5.612    0.11E-03    0.23E-03    0.24E-06
+   2      9    11.539    55.373    0.45E-04    0.92E-04    0.22E-06
+   2      9    11.539    50.863    0.47E-04    0.95E-04    0.22E-06
+   0     10    11.539    79.536    0.46E-04    0.27E-04    0.11E-06
+   0     10    11.539    38.668    0.38E-04    0.25E-04    0.10E-06
+ Optimization of the real space projectors (new method)
+
+ maximal supplied QI-value         = 17.01
+ optimisation between [QCUT,QGAM] = [ 11.57, 23.30] = [ 37.45,152.03] Ry 
+ Optimized for a Real-space Cutoff    1.45 Angstroem
+
+   l    n(q)    QCUT    max X(q) W(low)/X(q) W(high)/X(q)  e(spline) 
+   1     10    11.565     4.267    0.91E-04    0.15E-03    0.13E-06
+   1     10    11.565     5.750    0.14E-03    0.22E-03    0.20E-06
+   2      9    11.565    53.656    0.13E-03    0.57E-04    0.16E-06
+   2      9    11.565    49.521    0.13E-03    0.59E-04    0.16E-06
+   0     10    11.565    31.246    0.61E-04    0.74E-05    0.89E-07
+   0     10    11.565    12.201    0.44E-04    0.68E-05    0.74E-07
+ Optimization of the real space projectors (new method)
+
+ maximal supplied QI-value         = 16.25
+ optimisation between [QCUT,QGAM] = [ 11.54, 23.24] = [ 37.28,151.24] Ry 
+ Optimized for a Real-space Cutoff    1.45 Angstroem
+
+   l    n(q)    QCUT    max X(q) W(low)/X(q) W(high)/X(q)  e(spline) 
+   2      9    11.539    65.824    0.19E-03    0.47E-04    0.16E-06
+   2      9    11.539    61.429    0.20E-03    0.48E-04    0.16E-06
+   0     10    11.539    56.174    0.76E-04    0.45E-04    0.23E-06
+   0     10    11.539    31.263    0.69E-04    0.41E-04    0.21E-06
+   1     10    11.539    19.828    0.78E-04    0.14E-03    0.70E-07
+   1     10    11.539    15.139    0.65E-04    0.12E-03    0.64E-07
+ Optimization of the real space projectors (new method)
+
+ maximal supplied QI-value         = 18.90
+ optimisation between [QCUT,QGAM] = [ 11.53, 23.24] = [ 37.21,151.29] Ry 
+ Optimized for a Real-space Cutoff    1.36 Angstroem
+
+   l    n(q)    QCUT    max X(q) W(low)/X(q) W(high)/X(q)  e(spline) 
+   1      9    11.527     2.836    0.16E-04    0.30E-04    0.95E-07
+   1      9    11.527     4.023    0.73E-04    0.81E-04    0.21E-06
+   2      9    11.527    73.368    0.15E-03    0.29E-03    0.28E-06
+   2      9    11.527    69.010    0.15E-03    0.29E-03    0.29E-06
+   0      9    11.527    54.797    0.43E-04    0.28E-04    0.85E-07
+   0      9    11.527    24.266    0.33E-04    0.24E-04    0.75E-07
+ Optimization of the real space projectors (new method)
+
+ maximal supplied QI-value         = 18.90
+ optimisation between [QCUT,QGAM] = [ 11.53, 23.24] = [ 37.21,151.29] Ry 
+ Optimized for a Real-space Cutoff    1.36 Angstroem
+
+   l    n(q)    QCUT    max X(q) W(low)/X(q) W(high)/X(q)  e(spline) 
+   1      9    11.527     3.172    0.21E-04    0.38E-04    0.11E-06
+   1      9    11.527     4.083    0.67E-04    0.79E-04    0.20E-06
+   2      9    11.527    65.342    0.13E-03    0.28E-03    0.26E-06
+   2      9    11.527    61.381    0.13E-03    0.29E-03    0.26E-06
+   0      9    11.527    65.742    0.32E-04    0.21E-04    0.72E-07
+   0      9    11.527    30.431    0.28E-04    0.19E-04    0.65E-07
+ Optimization of the real space projectors (new method)
+
+ maximal supplied QI-value         = 16.25
+ optimisation between [QCUT,QGAM] = [ 11.54, 23.24] = [ 37.28,151.24] Ry 
+ Optimized for a Real-space Cutoff    1.49 Angstroem
+
+   l    n(q)    QCUT    max X(q) W(low)/X(q) W(high)/X(q)  e(spline) 
+   2      9    11.539    46.356    0.17E-03    0.92E-04    0.19E-06
+   2      9    11.539    41.843    0.18E-03    0.96E-04    0.20E-06
+   0     10    11.539    48.958    0.57E-04    0.27E-04    0.28E-06
+   0     10    11.539    32.776    0.51E-04    0.25E-04    0.27E-06
+   1     10    11.539    17.787    0.55E-04    0.96E-04    0.11E-06
+   1     10    11.539    14.435    0.48E-04    0.86E-04    0.10E-06
+ Optimization of the real space projectors (new method)
+
+ maximal supplied QI-value         = 13.42
+ optimisation between [QCUT,QGAM] = [ 11.67, 23.35] = [ 38.16,152.62] Ry 
+ Optimized for a Real-space Cutoff    1.68 Angstroem
+
+   l    n(q)    QCUT    max X(q) W(low)/X(q) W(high)/X(q)  e(spline) 
+   0     12    11.673    14.902    0.22E-04    0.24E-05    0.52E-07
+   0     12    11.673     9.294    0.34E-04    0.58E-05    0.89E-07
+   1     11    11.673    69.520    0.10E-04    0.47E-04    0.49E-06
+   1     11    11.673    72.085    0.10E-04    0.48E-04    0.50E-06
+   2     11    11.673    62.934    0.94E-04    0.14E-04    0.82E-06
+   2     11    11.673    49.749    0.91E-04    0.13E-04    0.79E-06
+   3     10    11.673     8.311    0.92E-04    0.21E-04    0.59E-06
+ Optimization of the real space projectors (new method)
+
+ maximal supplied QI-value         = 15.12
+ optimisation between [QCUT,QGAM] = [ 11.64, 23.28] = [ 37.95,151.78] Ry 
+ Optimized for a Real-space Cutoff    1.58 Angstroem
+
+   l    n(q)    QCUT    max X(q) W(low)/X(q) W(high)/X(q)  e(spline) 
+   0     11    11.641    12.107    0.25E-04    0.86E-05    0.10E-06
+   0     11    11.641     9.948    0.34E-04    0.18E-04    0.23E-06
+   1     11    11.641     3.563    0.17E-04    0.12E-04    0.38E-07
+   1     11    11.641     4.524    0.18E-03    0.80E-04    0.37E-06
+   2     10    11.641    87.261    0.40E-04    0.20E-04    0.23E-06
+   2     10    11.641    70.950    0.40E-04    0.20E-04    0.23E-06
+ Optimization of the real space projectors (new method)
+
+ maximal supplied QI-value         = 13.61
+ optimisation between [QCUT,QGAM] = [ 11.57, 23.27] = [ 37.45,151.59] Ry 
+ Optimized for a Real-space Cutoff    1.63 Angstroem
+
+   l    n(q)    QCUT    max X(q) W(low)/X(q) W(high)/X(q)  e(spline) 
+   1     11    11.565     4.545    0.12E-04    0.18E-04    0.64E-07
+   1     11    11.565     6.014    0.42E-04    0.48E-04    0.13E-06
+   2     10    11.565   266.542    0.24E-03    0.87E-04    0.13E-05
+   2     10    11.565   232.726    0.24E-03    0.87E-04    0.13E-05
+   0     11    11.565    38.050    0.76E-04    0.32E-05    0.94E-06
+   0     11    11.565    16.565    0.58E-04    0.25E-05    0.73E-06
+ Optimization of the real space projectors (new method)
+
+ maximal supplied QI-value         = 13.98
+ optimisation between [QCUT,QGAM] = [ 11.61, 23.35] = [ 37.72,152.72] Ry 
+ Optimized for a Real-space Cutoff    1.68 Angstroem
+
+   l    n(q)    QCUT    max X(q) W(low)/X(q) W(high)/X(q)  e(spline) 
+   1     11    11.607     4.274    0.94E-05    0.70E-04    0.79E-06
+   1     11    11.607     7.035    0.16E-04    0.12E-03    0.14E-05
+   2     11    11.607    64.474    0.17E-03    0.12E-03    0.48E-06
+   2     11    11.607    61.199    0.17E-03    0.12E-03    0.48E-06
+   0     12    11.607    31.789    0.39E-04    0.85E-05    0.14E-06
+   0     12    11.607    13.589    0.21E-04    0.62E-05    0.11E-06
+ Optimization of the real space projectors (new method)
+
+ maximal supplied QI-value         = 15.68
+ optimisation between [QCUT,QGAM] = [ 11.61, 23.21] = [ 37.72,150.90] Ry 
+ Optimized for a Real-space Cutoff    1.45 Angstroem
+
+   l    n(q)    QCUT    max X(q) W(low)/X(q) W(high)/X(q)  e(spline) 
+   1     10    11.607     3.143    0.27E-04    0.48E-04    0.10E-06
+   1     10    11.607     5.034    0.71E-04    0.17E-03    0.32E-06
+   2      9    11.607    64.180    0.22E-03    0.59E-04    0.28E-06
+   2      9    11.607    61.342    0.22E-03    0.61E-04    0.29E-06
+   0     10    11.607    55.593    0.52E-04    0.32E-04    0.17E-06
+   0     10    11.607    26.178    0.47E-04    0.29E-04    0.15E-06
+ Optimization of the real space projectors (new method)
+
+ maximal supplied QI-value         = 14.36
+ optimisation between [QCUT,QGAM] = [ 11.63, 23.27] = [ 37.90,151.59] Ry 
+ Optimized for a Real-space Cutoff    1.49 Angstroem
+
+   l    n(q)    QCUT    max X(q) W(low)/X(q) W(high)/X(q)  e(spline) 
+   2      9    11.633    59.108    0.81E-04    0.17E-04    0.26E-06
+   2      9    11.633    58.101    0.82E-04    0.18E-04    0.27E-06
+   0     10    11.633   102.235    0.26E-04    0.16E-04    0.21E-06
+   0     10    11.633    58.388    0.23E-04    0.15E-04    0.20E-06
+   1     10    11.633    22.191    0.10E-03    0.20E-03    0.14E-06
+   1     10    11.633    15.590    0.86E-04    0.17E-03    0.12E-06
+ Optimization of the real space projectors (new method)
+
+ maximal supplied QI-value         = 15.12
+ optimisation between [QCUT,QGAM] = [ 11.64, 23.28] = [ 37.95,151.78] Ry 
+ Optimized for a Real-space Cutoff    1.53 Angstroem
+
+   l    n(q)    QCUT    max X(q) W(low)/X(q) W(high)/X(q)  e(spline) 
+   1     10    11.641     4.922    0.54E-05    0.52E-05    0.20E-07
+   1     10    11.641     5.461    0.12E-03    0.37E-04    0.26E-06
+   2     10    11.641     3.602    0.67E-05    0.12E-04    0.70E-07
+   2     10    11.641    60.440    0.23E-03    0.71E-03    0.14E-05
+   0     11    11.641    21.769    0.17E-04    0.95E-05    0.34E-07
+   0     11    11.641    71.369    0.37E-04    0.91E-04    0.47E-06
+ Optimization of the real space projectors (new method)
+
+ maximal supplied QI-value         = 14.36
+ optimisation between [QCUT,QGAM] = [ 11.63, 23.27] = [ 37.90,151.59] Ry 
+ Optimized for a Real-space Cutoff    1.63 Angstroem
+
+   l    n(q)    QCUT    max X(q) W(low)/X(q) W(high)/X(q)  e(spline) 
+   2     10    11.633   134.116    0.23E-03    0.25E-04    0.92E-06
+   2     10    11.633   130.192    0.23E-03    0.25E-04    0.92E-06
+   0     11    11.633    60.310    0.44E-04    0.29E-04    0.76E-06
+   0     11    11.633    39.218    0.38E-04    0.27E-04    0.71E-06
+   1     11    11.633    18.439    0.37E-04    0.62E-04    0.19E-06
+   1     11    11.633    12.760    0.29E-04    0.50E-04    0.16E-06
+ Optimization of the real space projectors (new method)
+
+ maximal supplied QI-value         = 14.36
+ optimisation between [QCUT,QGAM] = [ 11.63, 23.27] = [ 37.90,151.59] Ry 
+ Optimized for a Real-space Cutoff    1.49 Angstroem
+
+   l    n(q)    QCUT    max X(q) W(low)/X(q) W(high)/X(q)  e(spline) 
+   2      9    11.633    66.195    0.24E-03    0.97E-04    0.19E-06
+   2      9    11.633    64.643    0.25E-03    0.98E-04    0.20E-06
+   0     10    11.633    95.520    0.71E-04    0.29E-04    0.12E-06
+   0     10    11.633    63.403    0.69E-04    0.28E-04    0.12E-06
+   1     10    11.633    19.961    0.61E-04    0.16E-03    0.11E-06
+   1     10    11.633    13.289    0.50E-04    0.13E-03    0.90E-07
+  PAW_PBE Cr_pv 02Aug2007               :
+ energy of atom  1       EATOM=-1647.9177
+ kinetic energy error for atom=    0.0057 (will be added to EATOM!!)
+  PAW_PBE Mn_pv 02Aug2007               :
+ energy of atom  2       EATOM=-2025.2664
+ kinetic energy error for atom=    0.0058 (will be added to EATOM!!)
+  PAW_PBE Fe_pv 02Aug2007               :
+ energy of atom  3       EATOM=-2457.4239
+ kinetic energy error for atom=    0.0062 (will be added to EATOM!!)
+  PAW_PBE Co 02Aug2007                  :
+ energy of atom  4       EATOM= -813.3670
+ kinetic energy error for atom=    0.0028 (will be added to EATOM!!)
+  PAW_PBE Ni_pv 06Sep2000               :
+ energy of atom  5       EATOM=-3501.1230
+ kinetic energy error for atom=    0.0575 (will be added to EATOM!!)
+  PAW_PBE Cu_pv 06Sep2000               :
+ energy of atom  6       EATOM=-4120.1201
+ kinetic energy error for atom=    0.0541 (will be added to EATOM!!)
+  PAW_PBE Zn 06Sep2000                  :
+ energy of atom  7       EATOM=-1748.8345
+ kinetic energy error for atom=    0.0029 (will be added to EATOM!!)
+  PAW_PBE Y_sv 25May2007                :
+ energy of atom  8       EATOM=-1046.9140
+ kinetic energy error for atom=    0.0008 (will be added to EATOM!!)
+  PAW_PBE Zr_sv 04Jan2005               :
+ energy of atom  9       EATOM=-1284.2219
+ kinetic energy error for atom=    0.0043 (will be added to EATOM!!)
+  PAW_PBE Nb_pv 08Apr2002               :
+ energy of atom 10       EATOM=-1043.3917
+ kinetic energy error for atom=    0.0011 (will be added to EATOM!!)
+  PAW_PBE Mo_pv 04Feb2005               :
+ energy of atom 11       EATOM=-1284.3008
+ kinetic energy error for atom=    0.0019 (will be added to EATOM!!)
+  PAW_PBE Rh_pv 25Jan2005               :
+ energy of atom 12       EATOM=-2226.4782
+ kinetic energy error for atom=    0.0084 (will be added to EATOM!!)
+  PAW_PBE Pd 04Jan2005                  :
+ energy of atom 13       EATOM= -809.7530
+ kinetic energy error for atom=    0.0045 (will be added to EATOM!!)
+ PAW_PBE W_pv 06Sep2000                 :
+ energy of atom 14       EATOM=-1260.0376
+ kinetic energy error for atom=    0.0019 (will be added to EATOM!!)
+  PAW_PBE Ir 06Sep2000                  :
+ energy of atom 15       EATOM= -560.1833
+ kinetic energy error for atom=    0.0013 (will be added to EATOM!!)
+  PAW_PBE Pt 04Feb2005                  :
+ energy of atom 16       EATOM= -729.1176
+ kinetic energy error for atom=    0.0032 (will be added to EATOM!!)
+ 
+ 
+ POSCAR: Cr3 Mn5 Fe3 Co1 Ni4 Cu4 Zn2 Y5 Zr4 Nb5 M
+  positions in cartesian coordinates
+  No initial velocities read in
+ exchange correlation table for  LEXCH =        8
+   RHO(1)=    0.500       N(1)  =     2000
+   RHO(2)=  100.500       N(2)  =     4000
+ 
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+ ion  position               nearest neighbor table
+   1  0.499  0.248  0.506-   6 2.78  45 2.79  10 2.81  16 2.83  23 2.85  46 2.86  36 2.86  28 2.88
+                            40 2.91  41 2.92   8 2.93   3 2.93
+   2  0.744  0.770  0.333-  41 2.63  47 2.63  28 2.64  33 2.66  32 2.80   8 2.82  26 2.84  15 2.85
+                            20 2.85   5 2.90   3 2.95
+   3  0.510  0.487  0.323-  26 2.61  36 2.68   5 2.73  40 2.76  42 2.80  21 2.81   8 2.82  34 2.90
+                            23 2.93   1 2.93   2 2.95  32 2.97
+   4  0.496  0.257  0.836-  29 2.78   9 2.78  16 2.84  45 2.84  11 2.87  48 2.88   6 2.89  38 2.90
+                            37 2.92  30 2.92
+   5  0.483  0.735  0.169-   7 2.66  34 2.66  11 2.68   3 2.73  21 2.75  27 2.76  26 2.78  41 2.88
+                             2 2.90  47 2.98
+   6  0.246  0.255  0.664-  25 2.77  18 2.77  30 2.77   1 2.78  48 2.79  45 2.79  16 2.83  23 2.86
+                            46 2.88   4 2.89  43 2.92  31 2.96
+   7  0.266  0.748  0.002-   5 2.66   9 2.70  35 2.72  11 2.73  27 2.81  39 2.86  44 2.90  21 2.92
+                            30 2.93  48 2.98
+   8  0.745  0.517  0.495-  32 2.64  20 2.77  36 2.79   3 2.82   2 2.82  43 2.83  10 2.86  24 2.90
+                            25 2.90   1 2.93
+   9  0.496  0.993  0.986-   7 2.70  35 2.75   4 2.78  48 2.82  37 2.82  22 2.84  27 2.88  42 2.88
+                            29 2.90  47 3.04
+  10  0.769  0.254  0.654-  25 2.60  43 2.69   1 2.81   8 2.86  28 2.86  38 3.01  45 3.03  31 3.04
+
+  11  0.506  0.507  0.006-   5 2.68   7 2.73  35 2.76  26 2.78  38 2.85  29 2.87   4 2.87  22 2.89
+                            42 2.90  21 2.91  37 3.05  30 3.14
+  12  0.257  0.764  0.674-  48 2.62  45 2.67  35 2.74  46 2.79  44 2.80  18 2.80  30 2.80  32 2.88
+                            43 2.99  23 2.99
+  13  0.992  0.514  0.993-  38 2.64  31 2.67  44 2.68  22 2.70  30 2.76  29 2.88  26 2.94
+  14  0.994  0.249  0.162-  37 2.71  21 2.78  29 2.83  47 2.85  36 2.89  40 2.89  26 2.90  39 2.91
+                            33 2.93  27 2.94
+  15  0.985  0.739  0.161-  26 2.67  22 2.75  47 2.81  39 2.84   2 2.85  33 2.94  34 3.02  27 3.02
+
+  16  0.495  0.504  0.667-  35 2.75  32 2.76   6 2.83   1 2.83  23 2.83   4 2.84  30 2.88  24 2.94
+                            38 2.95
+  17  0.018  0.515  0.334-  21 2.67  34 2.71  23 2.72  40 2.86  25 2.88  26 2.93  36 2.96
+  18  0.007  0.006  0.659-  46 2.73  48 2.75   6 2.77  25 2.77  12 2.80  24 2.83  28 2.86  44 2.97
+                            31 3.09
+  19  0.747  0.005  0.833-  22 2.72  29 2.74  24 2.76  39 2.84  45 2.86  44 2.93  31 2.93  35 2.96
+
+  20  1.000  0.749  0.497-   8 2.77  33 2.77  28 2.80  43 2.81  46 2.82  23 2.83   2 2.85  24 2.88
+                            34 2.89
+  21  0.243  0.491  0.172-  40 2.66  17 2.67   5 2.75  14 2.78   3 2.81  34 2.83  37 2.85  11 2.91
+                             7 2.92  42 3.00
+  22  0.761  0.759  0.988-  39 2.68  13 2.70  44 2.70  38 2.71  19 2.72  15 2.75  35 2.83   9 2.84
+                            11 2.89  47 2.94  26 3.00
+  23  0.255  0.505  0.495-  17 2.72  32 2.77  34 2.78  16 2.83  20 2.83  25 2.83   1 2.85   6 2.86
+                            40 2.88   3 2.93  43 2.98  12 2.99  30 3.98
+  24  0.751  0.766  0.669-  28 2.75  19 2.76  43 2.80  32 2.83  18 2.83  45 2.86  44 2.86  35 2.88
+                            20 2.88   8 2.90  38 2.93  16 2.94
+  25  1.000  0.261  0.503-  10 2.60   6 2.77  18 2.77  43 2.79  36 2.80  23 2.83  17 2.88   8 2.90
+                            33 2.94  46 2.94  28 2.98  40 2.98
+  26  0.745  0.509  0.174-   3 2.61  15 2.67   5 2.78  11 2.78  36 2.84   2 2.84  14 2.90  42 2.90
+                            17 2.93  13 2.94  22 3.00  29 3.03  47 3.90
+  27  0.260  0.996  0.166-  37 2.68   5 2.76  42 2.79   7 2.81  40 2.82  34 2.82  41 2.82   9 2.88
+                            39 2.91  14 2.94  33 3.00  15 3.02  47 3.92
+  28  0.748  0.990  0.496-   2 2.64  33 2.73  24 2.75  41 2.76  32 2.79  20 2.80  10 2.86  18 2.86
+                            36 2.87   1 2.88  45 2.98  25 2.98
+  29  0.751  0.249  0.992-  31 2.67  19 2.74  38 2.77   4 2.78  42 2.81  14 2.83  11 2.87  13 2.88
+                             9 2.90  39 2.91  47 3.00  26 3.03
+  30  0.226  0.500  0.825-  31 2.63  44 2.66  43 2.72  13 2.76   6 2.77  12 2.80  35 2.87  16 2.88
+                             4 2.92   7 2.93  37 3.09  11 3.14  23 3.98
+  31  0.006  0.260  0.851-  30 2.63  29 2.67  13 2.67  37 2.70  39 2.78  38 2.82  48 2.84  19 2.93
+                             6 2.96  43 3.00  10 3.04  18 3.09
+  32  0.505  0.742  0.502-   8 2.64  16 2.76  23 2.77  28 2.79   2 2.80  24 2.83  34 2.84  46 2.88
+                            12 2.88  41 2.93  45 2.94   3 2.97
+  33  0.988  0.994  0.336-   2 2.66  28 2.73  47 2.74  20 2.77  36 2.84  46 2.89  14 2.93  25 2.94
+                            15 2.94  34 2.95  27 3.00  40 3.01
+  34  0.261  0.748  0.332-   5 2.66  17 2.71  23 2.78  27 2.82  46 2.83  21 2.83  32 2.84  41 2.85
+                            20 2.89   3 2.90  33 2.95  15 3.02
+  35  0.495  0.735  0.835-   7 2.72  12 2.74  16 2.75   9 2.75  11 2.76  38 2.80  22 2.83  30 2.87
+                            24 2.88  45 2.93  48 2.94  19 2.96
+  36  0.753  0.259  0.339-   3 2.68   8 2.79  25 2.80  26 2.84  33 2.84  41 2.85   1 2.86  42 2.87
+                            28 2.87  14 2.89  47 2.91  17 2.96
+  37  0.242  0.234  0.010-  27 2.68  31 2.70  14 2.71  39 2.75   9 2.82  21 2.85  42 2.86   4 2.92
+                            48 2.93  11 3.05  30 3.09
+  38  0.757  0.506  0.839-  13 2.64  22 2.71  29 2.77  43 2.78  44 2.79  35 2.80  31 2.82  11 2.85
+                             4 2.90  24 2.93  16 2.95  10 3.01
+  39  0.004  0.988  0.995-  22 2.68  44 2.73  37 2.75  31 2.78  15 2.84  19 2.84  48 2.84   7 2.86
+                            14 2.91  29 2.91  27 2.91  47 2.99
+  40  0.258  0.253  0.326-  21 2.66   3 2.76  27 2.82  42 2.84  17 2.86  23 2.88  41 2.88  14 2.89
+                             1 2.91  46 2.96  25 2.98  33 3.01
+  41  0.512  0.999  0.329-   2 2.63  47 2.66  42 2.75  28 2.76  27 2.82  36 2.85  34 2.85  40 2.88
+                             5 2.88   1 2.92  32 2.93  46 2.94
+  42  0.513  0.233  0.163-  47 2.69  41 2.75  27 2.79   3 2.80  29 2.81  40 2.84  37 2.86  36 2.87
+                             9 2.88  26 2.90  11 2.90  21 3.00
+  43  0.986  0.508  0.666-  10 2.69  30 2.72  38 2.78  25 2.79  24 2.80  44 2.80  20 2.81   8 2.83
+                             6 2.92  23 2.98  12 2.99  31 3.00
+  44  0.006  0.748  0.835-  30 2.66  13 2.68  22 2.70  39 2.73  38 2.79  12 2.80  43 2.80  48 2.80
+                            24 2.86   7 2.90  19 2.93  18 2.97
+  45  0.487  0.005  0.671-  48 2.66  12 2.67   1 2.79   6 2.79  46 2.81   4 2.84  19 2.86  24 2.86
+                            35 2.93  32 2.94  28 2.98  10 3.03
+  46  0.250  0.994  0.500-  18 2.73  12 2.79  45 2.81  20 2.82  34 2.83   1 2.86  32 2.88   6 2.88
+                            33 2.89  41 2.94  25 2.94  40 2.96
+  47  0.747  0.995  0.175-   2 2.63  41 2.66  42 2.69  33 2.74  15 2.81  14 2.85  36 2.91  22 2.94
+                             5 2.98  39 2.99  29 3.00   9 3.04  26 3.90  27 3.92
+  48  0.245  0.002  0.822-  12 2.62  45 2.66  18 2.75   6 2.79  44 2.80   9 2.82  31 2.84  39 2.84
+                             4 2.88  37 2.93  35 2.94   7 2.98
+ 
+  LATTYP: Found a simple tetragonal cell.
+ ALAT       =     8.0327170500
+ C/A-ratio  =     1.5000000000
+  
+  Lattice vectors:
+  
+ A1 = (   8.0327170500,   0.0000000000,   0.0000000000)
+ A2 = (   0.0000000000,   8.0327170500,   0.0000000000)
+ A3 = (   0.0000000000,   0.0000000000,  12.0490755750)
+
+
+Analysis of symmetry for initial positions (statically):
+=====================================================================
+ Subroutine PRICEL returns:
+ Original cell was already a primitive cell.
+ 
+
+ Routine SETGRP: Setting up the symmetry group for a 
+ simple tetragonal supercell.
+
+
+ Subroutine GETGRP returns: Found  1 space group operations
+ (whereof  1 operations were pure point group operations)
+ out of a pool of 16 trial point group operations.
+
+
+The static configuration has the point symmetry C_1 .
+
+
+Analysis of symmetry for dynamics (positions and initial velocities):
+=====================================================================
+ Subroutine PRICEL returns:
+ Original cell was already a primitive cell.
+ 
+
+ Routine SETGRP: Setting up the symmetry group for a 
+ simple tetragonal supercell.
+
+
+ Subroutine GETGRP returns: Found  1 space group operations
+ (whereof  1 operations were pure point group operations)
+ out of a pool of 16 trial point group operations.
+
+
+The dynamic configuration has the point symmetry C_1 .
+
+
+ Subroutine INISYM returns: Found  1 space group operations
+ (whereof  1 operations are pure point group operations),
+ and found     1 'primitive' translations
+
+
+----------------------------------------------------------------------------------------
+
+                                     Primitive cell                                     
+
+  volume of cell :     777.4611
+
+  direct lattice vectors                    reciprocal lattice vectors
+     8.032717050  0.000000000  0.000000000     0.124490878  0.000000000  0.000000000
+     0.000000000  8.032717050  0.000000000     0.000000000  0.124490878  0.000000000
+     0.000000000  0.000000000 12.049075575     0.000000000  0.000000000  0.082993919
+
+  length of vectors
+     8.032717050  8.032717050 12.049075575     0.124490878  0.124490878  0.082993919
+
+  position of ions in fractional coordinates (direct lattice)
+     0.499113809  0.247673357  0.506274524
+     0.744197756  0.769611323  0.333238843
+     0.510102618  0.487299624  0.322782439
+     0.495796127  0.257231767  0.836480769
+     0.482545318  0.734945594  0.168548200
+     0.246057466  0.255032013  0.664182904
+     0.266292213  0.747972319  0.001815077
+     0.745183723  0.516609757  0.495296918
+     0.495956720  0.992858326  0.985758611
+     0.768971440  0.254347313  0.654493363
+     0.505899806  0.507450963  0.006462736
+     0.256752477  0.763843661  0.673929709
+     0.991627111  0.514477228  0.992812264
+     0.994479197  0.249355229  0.162477195
+     0.984814970  0.739275386  0.161126884
+     0.494917221  0.503980157  0.667480252
+     0.017528316  0.514955273  0.334405737
+     0.007302635  0.006203380  0.658506119
+     0.746731145  0.004708245  0.833058930
+     0.999773794  0.748581079  0.497030661
+     0.242524415  0.490665858  0.172317784
+     0.761470865  0.758922537  0.988282456
+     0.254677214  0.504921308  0.495447137
+     0.750716098  0.765753351  0.668989081
+     0.999808651  0.261180618  0.503417873
+     0.744901129  0.509399245  0.173505427
+     0.259651870  0.996485990  0.165875796
+     0.747517927  0.989667624  0.496190763
+     0.751048489  0.248600814  0.992274463
+     0.225507756  0.500490678  0.825259161
+     0.006401321  0.259588379  0.850979806
+     0.505344577  0.741559794  0.501778743
+     0.987635933  0.994430645  0.336379333
+     0.260543224  0.748485221  0.331915920
+     0.494896058  0.735443557  0.835159506
+     0.752552338  0.259070497  0.339458407
+     0.242284147  0.233588459  0.009892045
+     0.756660537  0.506188625  0.839393855
+     0.003543010  0.988401552  0.994783370
+     0.258278735  0.253326488  0.325535347
+     0.511569121  0.999223544  0.329445191
+     0.513295809  0.233145272  0.163230780
+     0.986026266  0.508392114  0.666305058
+     0.005928256  0.748323383  0.834571079
+     0.486545210  0.004650979  0.671319551
+     0.250276462  0.993712333  0.500009313
+     0.747190516  0.994816567  0.174542021
+     0.245234581  0.001825036  0.822420769
+
+  ion indices of the primitive-cell ions
+   primitive index   ion index
+                 1           1
+                 2           2
+                 3           3
+                 4           4
+                 5           5
+                 6           6
+                 7           7
+                 8           8
+                 9           9
+                10          10
+                11          11
+                12          12
+                13          13
+                14          14
+                15          15
+                16          16
+                17          17
+                18          18
+                19          19
+                20          20
+                21          21
+                22          22
+                23          23
+                24          24
+                25          25
+                26          26
+                27          27
+                28          28
+                29          29
+                30          30
+                31          31
+                32          32
+                33          33
+                34          34
+                35          35
+                36          36
+                37          37
+                38          38
+                39          39
+                40          40
+                41          41
+                42          42
+                43          43
+                44          44
+                45          45
+                46          46
+                47          47
+                48          48
+
+----------------------------------------------------------------------------------------
+
+ 
+ -----------------------------------------------------------------------------
+|                                                                             |
+|           W    W    AA    RRRRR   N    N  II  N    N   GGGG   !!!           |
+|           W    W   A  A   R    R  NN   N  II  NN   N  G    G  !!!           |
+|           W    W  A    A  R    R  N N  N  II  N N  N  G       !!!           |
+|           W WW W  AAAAAA  RRRRR   N  N N  II  N  N N  G  GGG   !            |
+|           WW  WW  A    A  R   R   N   NN  II  N   NN  G    G                |
+|           W    W  A    A  R    R  N    N  II  N    N   GGGG   !!!           |
+|                                                                             |
+|     The requested file  could not be found or opened for reading            |
+|     k-point information. Automatic k-point generation is used as a          |
+|     fallback, which may lead to unwanted results.                           |
+|                                                                             |
+ -----------------------------------------------------------------------------
+
+ 
+
+Automatic generation of k-mesh.
+ Grid dimensions derived from KSPACING:
+ generate k-points for:    2    2    2
+
+ Generating k-lattice:
+
+  Cartesian coordinates                     Fractional coordinates (reciprocal lattice)
+     0.062245439  0.000000000  0.000000000     0.500000000  0.000000000  0.000000000
+     0.000000000  0.062245439  0.000000000     0.000000000  0.500000000  0.000000000
+     0.000000000  0.000000000  0.041496959     0.000000000  0.000000000  0.500000000
+
+  Length of vectors
+     0.062245439  0.062245439  0.041496959
+
+  Shift w.r.t. Gamma in fractional coordinates (k-lattice)
+     0.000000000  0.000000000  0.000000000
+
+ 
+ Subroutine IBZKPT returns following result:
+ ===========================================
+ 
+ Found      8 irreducible k-points:
+ 
+ Following reciprocal coordinates:
+            Coordinates               Weight
+  0.000000  0.000000  0.000000      1.000000
+  0.500000  0.000000  0.000000      1.000000
+  0.000000  0.500000  0.000000      1.000000
+  0.500000  0.500000  0.000000      1.000000
+  0.000000  0.000000  0.500000      1.000000
+  0.500000  0.000000  0.500000      1.000000
+  0.000000  0.500000  0.500000      1.000000
+  0.500000  0.500000  0.500000      1.000000
+ 
+ Following cartesian coordinates:
+            Coordinates               Weight
+  0.000000  0.000000  0.000000      1.000000
+  0.062245  0.000000  0.000000      1.000000
+  0.000000  0.062245  0.000000      1.000000
+  0.062245  0.062245  0.000000      1.000000
+  0.000000  0.000000  0.041497      1.000000
+  0.062245  0.000000  0.041497      1.000000
+  0.000000  0.062245  0.041497      1.000000
+  0.062245  0.062245  0.041497      1.000000
+ 
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+ Dimension of arrays:
+   k-points           NKPTS =      8   k-points in BZ     NKDIM =      8   number of bands    NBANDS=    360
+   number of dos      NEDOS =    301   number of ions     NIONS =     48
+   non local maximal  LDIM  =      7   non local SUM 2l+1 LMDIM =     25
+   total plane-waves  NPLWV = 324000
+   max r-space proj   IRMAX =   8268   max aug-charges    IRDMAX=  30331
+   dimension x,y,z NGX =    60 NGY =   60 NGZ =   90
+   dimension x,y,z NGXF=   120 NGYF=  120 NGZF=  180
+   support grid    NGXF=   120 NGYF=  120 NGZF=  180
+   ions per type =               3   5   3   1   4   4   2   5   4   5
+
+
+
+ Dimension of arrays:
+   k-points           NKPTS =      2   k-points in BZ     NKDIM =      1   number of bands    NBANDS=      1
+   number of dos      NEDOS =      3   number of ions     NIONS =      3
+   non local maximal  LDIM  =      2   non local SUM 2l+1 LMDIM = 
+   NGX,Y,Z   is equivalent  to a cutoff of  12.42, 12.42, 12.42 a.u.
+   NGXF,Y,Z  is equivalent  to a cutoff of  24.84, 24.84, 24.84 a.u.
+
+ SYSTEM =  unknown system                          
+ POSCAR =  Cr3 Mn5 Fe3 Co1 Ni4 Cu4 Zn2 Y5 Zr4 Nb5 M
+
+ Startparameter for this run:
+   NWRITE =      2    write-flag & timer
+   PREC   = accura    normal or accurate (medium, high low for compatibility)
+   ISTART =      0    job   : 0-new  1-cont  2-samecut
+   ICHARG =      2    charge: 1-file 2-atom 10-const
+   ISPIN  =      1    spin polarized calculation?
+   LNONCOLLINEAR =      F non collinear calculations
+   LSORBIT =      F    spin-orbit coupling
+   INIWAV =      1    electr: 0-lowe 1-rand  2-diag
+   LASPH  =      T    aspherical Exc in radial PAW
+ Electronic Relaxation 1
+   ENCUT  =  520.0 eV  38.22 Ry    6.18 a.u.  14.94 14.94 22.40*2*pi/ulx,y,z
+   ENINI  =  520.0     initial cutoff
+   ENAUG  =  758.2 eV  augmentation charge cutoff
+   NELM   =    500;   NELMIN=  2; NELMDL= -5     # of ELM steps 
+   EDIFF  = 0.5E-04   stopping-criterion for ELM
+   LREAL  =      T    real-space projection
+   NLSPLINE    = F    spline interpolate recip. space projectors
+   LCOMPAT=      F    compatible to vasp.4.4
+   GGA_COMPAT  = T    GGA compatible to vasp.4.4-vasp.4.6
+   LMAXPAW     = -100 max onsite density
+   LMAXMIX     =    2 max onsite mixed and CHGCAR
+   VOSKOWN=      0    Vosko Wilk Nusair interpolation
+   ROPT   =   -0.00025  -0.00025  -0.00025  -0.00025
+   ROPT   =   -0.00025  -0.00025  -0.00025  -0.00025
+   ROPT   =   -0.00025  -0.00025  -0.00025  -0.00025
+   ROPT   =   -0.00025  -0.00025  -0.00025  -0.00025
+ Ionic relaxation
+   EDIFFG = 0.5E-03   stopping-criterion for IOM
+   NSW    =      0    number of steps for IOM
+   NBLOCK =      1;   KBLOCK =      1    inner block; outer block 
+   IBRION =     -1    ionic relax: 0-MD 1-quasi-New 2-CG
+   NFREE  =      1    steps in history (QN), initial steepest desc. (CG)
+   ISIF   =      3    stress and relaxation
+   IWAVPR =     10    prediction:  0-non 1-charg 2-wave 3-comb
+   ISYM   =      2    0-nonsym 1-usesym 2-fastsym
+   LCORR  =      T    Harris-Foulkes like correction to forces
+
+   POTIM  = 0.5000    time-step for ionic-motion
+   TEIN   =    0.0    initial temperature
+   TEBEG  =    0.0;   TEEND  =   0.0 temperature during run
+   SMASS  =  -3.00    Nose mass-parameter (am)
+   estimated Nose-frequenzy (Omega)   =  0.10E-29 period in steps = 0.13E+47 mass=  -0.147E-26a.u.
+   SCALEE = 1.0000    scale energy and forces
+   NPACO  =    256;   APACO  = 10.0  distance and # of slots for P.C.
+   PSTRESS=    0.0 pullay stress
+
+  Mass of Ions in am
+   POMASS =  52.00 54.94 55.85 58.93 58.69 63.55 65.39 88.91
+   POMASS =  91.22 92.00 95.94102.91106.42183.85192.22195.08
+  Ionic Valenz
+   ZVAL   =  12.00 13.00 14.00  9.00 16.00 17.00 12.00 11.00
+   ZVAL   =  12.00 11.00 12.00 15.00 10.00 12.00  9.00 10.00
+  Atomic Wigner-Seitz radii
+   RWIGS  =  -1.00 -1.00 -1.00 -1.00 -1.00 -1.00 -1.00 -1.00
+   RWIGS  =  -1.00 -1.00 -1.00 -1.00 -1.00 -1.00 -1.00 -1.00
+  virtual crystal weights 
+   VCA    =   1.00  1.00  1.00  1.00  1.00  1.00  1.00  1.00
+   VCA    =   1.00  1.00  1.00  1.00  1.00  1.00  1.00  1.00
+   NELECT =     598.0000    total number of electrons
+   NUPDOWN=      -1.0000    fix difference up-down
+
+ DOS related values:
+   EMIN   =  10.00;   EMAX   =-10.00  energy-range for DOS
+   EFERMI =   0.00
+   ISMEAR =     1;   SIGMA  =   0.05  broadening in eV -4-tet -1-fermi 0-gaus
+
+ Electronic relaxation 2 (details)
+   IALGO  =     68    algorithm
+   LDIAG  =      T    sub-space diagonalisation (order eigenvalues)
+   LSUBROT=      F    optimize rotation matrix (better conditioning)
+   TURBO    =      0    0=normal 1=particle mesh
+   IRESTART =      0    0=no restart 2=restart with 2 vectors
+   NREBOOT  =      0    no. of reboots
+   NMIN     =      0    reboot dimension
+   EREF     =   0.00    reference energy to select bands
+   IMIX   =      4    mixing-type and parameters
+     AMIX     =   0.40;   BMIX     =  1.00
+     AMIX_MAG =   1.60;   BMIX_MAG =  1.00
+     AMIN     =   0.10
+     WC   =   100.;   INIMIX=   1;  MIXPRE=   1;  MAXMIX= -45
+
+ Intra band minimization:
+   WEIMIN = 0.0000     energy-eigenvalue tresh-hold
+   EBREAK =  0.35E-07  absolut break condition
+   DEPER  =   0.30     relativ break condition  
+
+   TIME   =   0.40     timestep for ELM
+
+  volume/ion in A,a.u.               =      16.20       109.30
+  Fermi-wavevector in a.u.,A,eV,Ry     =   1.499969  2.834531 30.611851  2.249908
+  Thomas-Fermi vector in A             =   2.611530
+ 
+ Write flags
+   LWAVE        =      F    write WAVECAR
+   LDOWNSAMPLE  =      F    k-point downsampling of WAVECAR
+   LCHARG       =      T    write CHGCAR
+   LVTOT        =      F    write LOCPOT, total local potential
+   LVHAR        =      F    write LOCPOT, Hartree potential only
+   LELF         =      F    write electronic localiz. function (ELF)
+   LORBIT       =      0    0 simple, 1 ext, 2 COOP (PROOUT), +10 PAW based schemes
+
+
+ Dipole corrections
+   LMONO  =      F    monopole corrections only (constant potential shift)
+   LDIPOL =      F    correct potential (dipole corrections)
+   IDIPOL =      0    1-x, 2-y, 3-z, 4-all directions 
+   EPSILON=  1.0000000 bulk dielectric constant
+
+ Exchange correlation treatment:
+   GGA     =    --    GGA type
+   LEXCH   =     8    internal setting for exchange type
+   LIBXC   =     F    Libxc                    
+   VOSKOWN =     0    Vosko Wilk Nusair interpolation
+   LHFCALC =     F    Hartree Fock is set to
+   LHFONE  =     F    Hartree Fock one center treatment
+   AEXX    =    0.0000 exact exchange contribution
+
+ Linear response parameters
+   LEPSILON=     F    determine dielectric tensor
+   LRPA    =     F    only Hartree local field effects (RPA)
+   LNABLA  =     F    use nabla operator in PAW spheres
+   LVEL    =     F    velocity operator in full k-point grid
+   CSHIFT  =0.1000    complex shift for real part using Kramers Kronig
+   OMEGAMAX=  -1.0    maximum frequency
+   DEG_THRESHOLD= 0.2000000E-02 threshold for treating states as degnerate
+   RTIME   =   -0.100 relaxation time in fs
+  (WPLASMAI=    0.000 imaginary part of plasma frequency in eV, 0.658/RTIME)
+   DFIELD  = 0.0000000 0.0000000 0.0000000 field for delta impulse in time
+ 
+  Optional k-point grid parameters
+   LKPOINTS_OPT  =     F    use optional k-point grid
+   KPOINTS_OPT_MODE=     1    mode for optional k-point grid
+ 
+ Orbital magnetization related:
+   ORBITALMAG=     F  switch on orbital magnetization
+   LCHIMAG   =     F  perturbation theory with respect to B field
+   DQ        =  0.001000  dq finite difference perturbation B field
+   LLRAUG    =     F  two centre corrections for induced B field
+
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+ Static calculation
+ charge density and potential will be updated during run
+ non-spin polarized calculation
+ RMM-DIIS sequential band-by-band and
+  variant of blocked Davidson during initial phase
+ perform sub-space diagonalisation
+    before iterative eigenvector-optimisation
+ modified Broyden-mixing scheme, WC =      100.0
+ initial mixing is a Kerker type mixing with AMIX =  0.4000 and BMIX =      1.0000
+ Hartree-type preconditioning will be used
+ using additional bands           61
+ real space projection scheme for non local part
+ use partial core corrections
+ calculate Harris-corrections to forces 
+   (improved forces if not selfconsistent)
+ use gradient corrections 
+ use of overlap-Matrix (Vanderbilt PP)
+ Methfessel and Paxton  Order N= 1 SIGMA  =   0.05
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+  energy-cutoff  :      520.00
+  volume of cell :      777.46
+      direct lattice vectors                 reciprocal lattice vectors
+     8.032717050  0.000000000  0.000000000     0.124490878  0.000000000  0.000000000
+     0.000000000  8.032717050  0.000000000     0.000000000  0.124490878  0.000000000
+     0.000000000  0.000000000 12.049075575     0.000000000  0.000000000  0.082993919
+
+  length of vectors
+     8.032717050  8.032717050 12.049075575     0.124490878  0.124490878  0.082993919
+
+
+ 
+ k-points in units of 2pi/SCALE and weight: read from INCAR                         
+   0.00000000  0.00000000  0.00000000       0.125
+   0.06224544  0.00000000  0.00000000       0.125
+   0.00000000  0.06224544  0.00000000       0.125
+   0.06224544  0.06224544  0.00000000       0.125
+   0.00000000  0.00000000  0.04149696       0.125
+   0.06224544  0.00000000  0.04149696       0.125
+   0.00000000  0.06224544  0.04149696       0.125
+   0.06224544  0.06224544  0.04149696       0.125
+ 
+ k-points in reciprocal lattice and weights: read from INCAR                         
+   0.00000000  0.00000000  0.00000000       0.125
+   0.50000000  0.00000000  0.00000000       0.125
+   0.00000000  0.50000000  0.00000000       0.125
+   0.50000000  0.50000000  0.00000000       0.125
+   0.00000000  0.00000000  0.50000000       0.125
+   0.50000000  0.00000000  0.50000000       0.125
+   0.00000000  0.50000000  0.50000000       0.125
+   0.50000000  0.50000000  0.50000000       0.125
+ 
+ position of ions in fractional coordinates (direct lattice) 
+   0.49911381  0.24767336  0.50627452
+   0.74419776  0.76961132  0.33323884
+   0.51010262  0.48729962  0.32278244
+   0.49579613  0.25723177  0.83648077
+   0.48254532  0.73494559  0.16854820
+   0.24605747  0.25503201  0.66418290
+   0.26629221  0.74797232  0.00181508
+   0.74518372  0.51660976  0.49529692
+   0.49595672  0.99285833  0.98575861
+   0.76897144  0.25434731  0.65449336
+   0.50589981  0.50745096  0.00646274
+   0.25675248  0.76384366  0.67392971
+   0.99162711  0.51447723  0.99281226
+   0.99447920  0.24935523  0.16247719
+   0.98481497  0.73927539  0.16112688
+   0.49491722  0.50398016  0.66748025
+   0.01752832  0.51495527  0.33440574
+   0.00730263  0.00620338  0.65850612
+   0.74673114  0.00470825  0.83305893
+   0.99977379  0.74858108  0.49703066
+   0.24252441  0.49066586  0.17231778
+   0.76147086  0.75892254  0.98828246
+   0.25467721  0.50492131  0.49544714
+   0.75071610  0.76575335  0.66898908
+   0.99980865  0.26118062  0.50341787
+   0.74490113  0.50939924  0.17350543
+   0.25965187  0.99648599  0.16587580
+   0.74751793  0.98966762  0.49619076
+   0.75104849  0.24860081  0.99227446
+   0.22550776  0.50049068  0.82525916
+   0.00640132  0.25958838  0.85097981
+   0.50534458  0.74155979  0.50177874
+   0.98763593  0.99443065  0.33637933
+   0.26054322  0.74848522  0.33191592
+   0.49489606  0.73544356  0.83515951
+   0.75255234  0.25907050  0.33945841
+   0.24228415  0.23358846  0.00989205
+   0.75666054  0.50618863  0.83939386
+   0.00354301  0.98840155  0.99478337
+   0.25827874  0.25332649  0.32553535
+   0.51156912  0.99922354  0.32944519
+   0.51329581  0.23314527  0.16323078
+   0.98602627  0.50839211  0.66630506
+   0.00592826  0.74832338  0.83457108
+   0.48654521  0.00465098  0.67131955
+   0.25027646  0.99371233  0.50000931
+   0.74719052  0.99481657  0.17454202
+   0.24523458  0.00182504  0.82242077
+ 
+ position of ions in cartesian coordinates  (Angst):
+   4.00924000  1.98949000  6.10014000
+   5.97793000  6.18207000  4.01522000
+   4.09751000  3.91434000  3.88923000
+   3.98259000  2.06627000 10.07882000
+   3.87615000  5.90361000  2.03085000
+   1.97651000  2.04860000  8.00279000
+   2.13905000  6.00825000  0.02187000
+   5.98585000  4.14978000  5.96787000
+   3.98388000  7.97535000 11.87748000
+   6.17693000  2.04310000  7.88604000
+   4.06375000  4.07621000  0.07787000
+   2.06242000  6.13574000  8.12023000
+   7.96546000  4.13265000 11.96247000
+   7.98837000  2.00300000  1.95770000
+   7.91074000  5.93839000  1.94143000
+   3.97553000  4.04833000  8.04252000
+   0.14080000  4.13649000  4.02928000
+   0.05866000  0.04983000  7.93439000
+   5.99828000  0.03782000 10.03759000
+   8.03090000  6.01314000  5.98876000
+   1.94813000  3.94138000  2.07627000
+   6.11668000  6.09621000 11.90789000
+   2.04575000  4.05589000  5.96968000
+   6.03029000  6.15108000  8.06070000
+   8.03118000  2.09799000  6.06572000
+   5.98358000  4.09186000  2.09058000
+   2.08571000  8.00449000  1.99865000
+   6.00460000  7.94972000  5.97864000
+   6.03296000  1.99694000 11.95599000
+   1.81144000  4.02030000  9.94361000
+   0.05142000  2.08520000 10.25352000
+   4.05929000  5.95674000  6.04597000
+   7.93340000  7.98798000  4.05306000
+   2.09287000  6.01237000  3.99928000
+   3.97536000  5.90761000 10.06290000
+   6.04504000  2.08104000  4.09016000
+   1.94620000  1.87635000  0.11919000
+   6.07804000  4.06607000 10.11392000
+   0.02846000  7.93955000 11.98622000
+   2.07468000  2.03490000  3.92240000
+   4.10929000  8.02648000  3.96951000
+   4.12316000  1.87279000  1.96678000
+   7.92047000  4.08377000  8.02836000
+   0.04762000  6.01107000 10.05581000
+   3.90828000  0.03736000  8.08878000
+   2.01040000  7.98221000  6.02465000
+   6.00197000  7.99108000  2.10307000
+   1.96990000  0.01466000  9.90941000
+ 
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+ k-point   1 :   0.0000 0.0000 0.0000  plane waves:   20885
+ k-point   2 :   0.5000 0.0000 0.0000  plane waves:   20942
+ k-point   3 :   0.0000 0.5000 0.0000  plane waves:   20942
+ k-point   4 :   0.5000 0.5000 0.0000  plane waves:   21020
+ k-point   5 :   0.0000 0.0000 0.5000  plane waves:   20908
+ k-point   6 :   0.5000 0.0000 0.5000  plane waves:   20908
+ k-point   7 :   0.0000 0.5000 0.5000  plane waves:   20908
+ k-point   8 :   0.5000 0.5000 0.5000  plane waves:   20888
+
+ maximum and minimum number of plane-waves per node :      5300     5191
+
+ maximum number of plane-waves:     21020
+ maximum index in each direction: 
+   IXMAX=   14   IYMAX=   14   IZMAX=   22
+   IXMIN=  -15   IYMIN=  -15   IZMIN=  -22
+
+
+ real space projection operators:
+  total allocation   :      42175.82 KBytes
+  max/ min on nodes  :      10553.19      10532.78
+
+
+ parallel 3D FFT for wavefunctions:
+    minimum data exchange during FFTs selected (reduces bandwidth)
+ parallel 3D FFT for charge:
+    minimum data exchange during FFTs selected (reduces bandwidth)
+
+
+ total amount of memory used by VASP MPI-rank0   153862. kBytes
+=======================================================================
+
+   base      :      30000. kBytes
+   nonlr-proj:      19725. kBytes
+   fftplans  :       8164. kBytes
+   grid      :      32576. kBytes
+   one-center:        360. kBytes
+   wavefun   :      63037. kBytes
+ 
+     INWAV:  cpu time      0.0000: real time      0.0000
+ Broyden mixing: mesh for mixing (old mesh)
+   NGX = 29   NGY = 29   NGZ = 45
+  (NGX  =120   NGY  =120   NGZ  =180)
+  gives a total of  37845 points
+
+ initial charge density was supplied:
+ charge density of overlapping atoms calculated
+ number of electron     598.0000000 magnetization 
+ keeping initial charge density in first step
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+ Maximum index for non-local projection operator         2019
+ Maximum index for augmentation-charges         2470 (set IRDMAX)
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+ First call to EWALD:  gamma=   0.193
+ Maximum number of real-space cells 3x 3x 2
+ Maximum number of reciprocal cells 2x 2x 3
+
+    FEWALD:  cpu time      0.0039: real time      0.0040
+
+
+--------------------------------------- Iteration      1(   1)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0971: real time      0.1037
+    SETDIJ:  cpu time      0.5105: real time      0.5125
+     EDDAV:  cpu time     18.8668: real time     19.0640
+       DOS:  cpu time      0.0017: real time      0.0183
+    --------------------------------------------
+      LOOP:  cpu time     19.4762: real time     19.6986
+
+ eigenvalue-minimisations  :  5928
+ total energy-change (2. order) : 0.8889689E+04  (-0.3077044E+05)
+ number of electron     598.0000000 magnetization 
+ augmentation part      598.0000000 magnetization 
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =      4840.36664911
+  Ewald energy   TEWEN  =    -61578.18855354
+  -Hartree energ DENC   =    -23167.77953276
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      2358.68446052
+  PAW double counting   =     69832.82018455   -71526.06296893
+  entropy T*S    EENTRO =        -0.00075775
+  eigenvalues    EBANDS =      2779.91613039
+  atomic energy  EATOM  =     85349.93293081
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      8889.68854239 eV
+
+  energy without entropy =     8889.68930014  energy(sigma->0) =     8889.68879497
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(   2)  ---------------------------------------
+
+
+     EDDAV:  cpu time     18.8501: real time     19.0198
+       DOS:  cpu time      0.0021: real time      0.0021
+    --------------------------------------------
+      LOOP:  cpu time     18.8522: real time     19.0220
+
+ eigenvalue-minimisations  :  5760
+ total energy-change (2. order) :-0.8204724E+04  (-0.8000612E+04)
+ number of electron     598.0000000 magnetization 
+ augmentation part      598.0000000 magnetization 
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =      4840.36664911
+  Ewald energy   TEWEN  =    -61578.18855354
+  -Hartree energ DENC   =    -23167.77953276
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      2358.68446052
+  PAW double counting   =     69832.82018455   -71526.06296893
+  entropy T*S    EENTRO =        -0.00409111
+  eigenvalues    EBANDS =     -5424.80476032
+  atomic energy  EATOM  =     85349.93293081
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =       684.96431831 eV
+
+  energy without entropy =      684.96840943  energy(sigma->0) =      684.96568202
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(   3)  ---------------------------------------
+
+
+     EDDAV:  cpu time     20.4583: real time     20.6436
+       DOS:  cpu time      0.0017: real time      0.0087
+    --------------------------------------------
+      LOOP:  cpu time     20.4601: real time     20.6523
+
+ eigenvalue-minimisations  :  6592
+ total energy-change (2. order) :-0.9060257E+03  (-0.7878142E+03)
+ number of electron     598.0000000 magnetization 
+ augmentation part      598.0000000 magnetization 
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =      4840.36664911
+  Ewald energy   TEWEN  =    -61578.18855354
+  -Hartree energ DENC   =    -23167.77953276
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      2358.68446052
+  PAW double counting   =     69832.82018455   -71526.06296893
+  entropy T*S    EENTRO =        -0.00119733
+  eigenvalues    EBANDS =     -6330.83331228
+  atomic energy  EATOM  =     85349.93293081
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -221.06133986 eV
+
+  energy without entropy =     -221.06014253  energy(sigma->0) =     -221.06094075
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(   4)  ---------------------------------------
+
+
+     EDDAV:  cpu time     29.4822: real time     29.7484
+       DOS:  cpu time      0.0018: real time      0.0083
+    --------------------------------------------
+      LOOP:  cpu time     29.4840: real time     29.7567
+
+ eigenvalue-minimisations  : 10208
+ total energy-change (2. order) :-0.1717287E+03  (-0.1573624E+03)
+ number of electron     598.0000000 magnetization 
+ augmentation part      598.0000000 magnetization 
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =      4840.36664911
+  Ewald energy   TEWEN  =    -61578.18855354
+  -Hartree energ DENC   =    -23167.77953276
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      2358.68446052
+  PAW double counting   =     69832.82018455   -71526.06296893
+  entropy T*S    EENTRO =        -0.00489141
+  eigenvalues    EBANDS =     -6502.55831670
+  atomic energy  EATOM  =     85349.93293081
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -392.79003836 eV
+
+  energy without entropy =     -392.78514695  energy(sigma->0) =     -392.78840789
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(   5)  ---------------------------------------
+
+
+     EDDAV:  cpu time     31.9425: real time     32.2350
+       DOS:  cpu time      0.0019: real time      0.0076
+    CHARGE:  cpu time      0.5895: real time      0.6209
+    MIXING:  cpu time      0.0026: real time      0.0042
+    --------------------------------------------
+      LOOP:  cpu time     32.5365: real time     32.8678
+
+ eigenvalue-minimisations  : 11272
+ total energy-change (2. order) :-0.2020565E+02  (-0.1947538E+02)
+ number of electron     598.0000037 magnetization 
+ augmentation part      233.8854540 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.16710E+02    rms(broyden)= 0.16710E+02
+  rms(prec ) = 0.18023E+02
+  weight for this iteration     100.00
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =      4840.36664911
+  Ewald energy   TEWEN  =    -61578.18855354
+  -Hartree energ DENC   =    -23167.77953276
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      2358.68446052
+  PAW double counting   =     69832.82018455   -71526.06296893
+  entropy T*S    EENTRO =        -0.00570959
+  eigenvalues    EBANDS =     -6522.76314476
+  atomic energy  EATOM  =     85349.93293081
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -412.99568461 eV
+
+  energy without entropy =     -412.98997501  energy(sigma->0) =     -412.99378141
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(   6)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.1520: real time      0.1600
+    SETDIJ:  cpu time      0.5113: real time      0.5138
+    EDDIAG:  cpu time      2.2383: real time      2.2634
+  RMM-DIIS:  cpu time     14.5214: real time     14.6930
+    ORTHCH:  cpu time      0.3648: real time      0.3815
+       DOS:  cpu time      0.0021: real time      0.0021
+    CHARGE:  cpu time      0.5569: real time      0.5615
+    MIXING:  cpu time      0.0035: real time      0.0201
+    --------------------------------------------
+      LOOP:  cpu time     18.3503: real time     18.5954
+
+ eigenvalue-minimisations  :  8617
+ total energy-change (2. order) :-0.3741958E+03  (-0.2350003E+03)
+ number of electron     598.0000013 magnetization 
+ augmentation part      291.8274933 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.20520E+02    rms(broyden)= 0.20520E+02
+  rms(prec ) = 0.24380E+02
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.4169
+  0.4169
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =      4840.36664911
+  Ewald energy   TEWEN  =    -61578.18855354
+  -Hartree energ DENC   =    -21144.68882937
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      2283.47427450
+  PAW double counting   =     75262.52345909   -76823.41275528
+  entropy T*S    EENTRO =        -0.00014379
+  eigenvalues    EBANDS =     -8977.19849854
+  atomic energy  EATOM  =     85349.93293081
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -787.19146701 eV
+
+  energy without entropy =     -787.19132321  energy(sigma->0) =     -787.19141908
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(   7)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0924: real time      0.0931
+    SETDIJ:  cpu time      0.5062: real time      0.5081
+    EDDIAG:  cpu time      2.2690: real time      2.2905
+  RMM-DIIS:  cpu time     10.7462: real time     10.8494
+    ORTHCH:  cpu time      0.3675: real time      0.3704
+       DOS:  cpu time      0.0023: real time      0.0023
+    CHARGE:  cpu time      0.5833: real time      0.5884
+    MIXING:  cpu time      0.0031: real time      0.0078
+    --------------------------------------------
+      LOOP:  cpu time     14.5698: real time     14.7101
+
+ eigenvalue-minimisations  :  6162
+ total energy-change (2. order) : 0.3850245E+03  (-0.3722986E+02)
+ number of electron     598.0000021 magnetization 
+ augmentation part      260.8198668 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.10204E+02    rms(broyden)= 0.10203E+02
+  rms(prec ) = 0.13148E+02
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.5349
+  0.7091  0.3606
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =      4840.36664911
+  Ewald energy   TEWEN  =    -61578.18855354
+  -Hartree energ DENC   =    -22087.35852192
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      2317.64962465
+  PAW double counting   =     79117.69296410   -80846.63728075
+  entropy T*S    EENTRO =         0.00158346
+  eigenvalues    EBANDS =     -7515.62638695
+  atomic energy  EATOM  =     85349.93293081
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -402.16699104 eV
+
+  energy without entropy =     -402.16857450  energy(sigma->0) =     -402.16751886
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(   8)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0908: real time      0.0914
+    SETDIJ:  cpu time      0.5051: real time      0.5070
+    EDDIAG:  cpu time      2.2336: real time      2.2538
+  RMM-DIIS:  cpu time     14.9399: real time     15.0851
+    ORTHCH:  cpu time      0.3629: real time      0.3722
+       DOS:  cpu time      0.0017: real time      0.0017
+    CHARGE:  cpu time      0.5684: real time      0.5743
+    MIXING:  cpu time      0.0027: real time      0.0027
+    --------------------------------------------
+      LOOP:  cpu time     18.7052: real time     18.8884
+
+ eigenvalue-minimisations  :  8814
+ total energy-change (2. order) :-0.1690322E+03  (-0.3738076E+02)
+ number of electron     598.0000058 magnetization 
+ augmentation part      255.7328074 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.15691E+02    rms(broyden)= 0.15691E+02
+  rms(prec ) = 0.21165E+02
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.6251
+  1.3534  0.3573  0.1645
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =      4840.36664911
+  Ewald energy   TEWEN  =    -61578.18855354
+  -Hartree energ DENC   =    -22218.15902420
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      2320.37596897
+  PAW double counting   =     81274.12964998   -83069.26133315
+  entropy T*S    EENTRO =        -0.00046448
+  eigenvalues    EBANDS =     -7490.39503610
+  atomic energy  EATOM  =     85349.93293081
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -571.19921261 eV
+
+  energy without entropy =     -571.19874813  energy(sigma->0) =     -571.19905778
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(   9)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0940: real time      0.0948
+    SETDIJ:  cpu time      0.4986: real time      0.5011
+    EDDIAG:  cpu time      2.2297: real time      2.2502
+  RMM-DIIS:  cpu time     14.0143: real time     14.1481
+    ORTHCH:  cpu time      0.3697: real time      0.3728
+       DOS:  cpu time      0.0026: real time      0.0027
+    CHARGE:  cpu time      0.5903: real time      0.5954
+    MIXING:  cpu time      0.0028: real time      0.0049
+    --------------------------------------------
+      LOOP:  cpu time     17.8019: real time     17.9700
+
+ eigenvalue-minimisations  :  8258
+ total energy-change (2. order) : 0.6748006E+02  (-0.2732872E+02)
+ number of electron     598.0000019 magnetization 
+ augmentation part      250.1368470 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.16505E+02    rms(broyden)= 0.16504E+02
+  rms(prec ) = 0.21286E+02
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.5771
+  1.6276  0.3489  0.1659  0.1659
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =      4840.36664911
+  Ewald energy   TEWEN  =    -61578.18855354
+  -Hartree energ DENC   =    -22216.35854301
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      2321.14625911
+  PAW double counting   =     84885.00876916   -86719.58512005
+  entropy T*S    EENTRO =        -0.00442690
+  eigenvalues    EBANDS =     -7386.03711912
+  atomic energy  EATOM  =     85349.93293081
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -503.71915443 eV
+
+  energy without entropy =     -503.71472753  energy(sigma->0) =     -503.71767880
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  10)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0888: real time      0.0894
+    SETDIJ:  cpu time      0.5125: real time      0.5144
+    EDDIAG:  cpu time      2.2787: real time      2.2991
+  RMM-DIIS:  cpu time     12.5573: real time     12.6764
+    ORTHCH:  cpu time      0.3777: real time      0.3848
+       DOS:  cpu time      0.0023: real time      0.0023
+    CHARGE:  cpu time      0.5935: real time      0.5987
+    MIXING:  cpu time      0.0028: real time      0.0028
+    --------------------------------------------
+      LOOP:  cpu time     16.4135: real time     16.5679
+
+ eigenvalue-minimisations  :  7248
+ total energy-change (2. order) : 0.8663154E+02  (-0.1697746E+02)
+ number of electron     598.0000037 magnetization 
+ augmentation part      258.7538836 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.85459E+01    rms(broyden)= 0.85453E+01
+  rms(prec ) = 0.11793E+02
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.5001
+  1.6300  0.3567  0.1935  0.1935  0.1270
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =      4840.36664911
+  Ewald energy   TEWEN  =    -61578.18855354
+  -Hartree energ DENC   =    -22008.08454292
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      2316.11177402
+  PAW double counting   =     86521.30760028   -88371.18682562
+  entropy T*S    EENTRO =         0.00139410
+  eigenvalues    EBANDS =     -7487.34803696
+  atomic energy  EATOM  =     85349.93293081
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -417.08761072 eV
+
+  energy without entropy =     -417.08900482  energy(sigma->0) =     -417.08807542
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  11)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0917: real time      0.0953
+    SETDIJ:  cpu time      0.5167: real time      0.5188
+    EDDIAG:  cpu time      2.3206: real time      2.3439
+  RMM-DIIS:  cpu time     13.8414: real time     13.9765
+    ORTHCH:  cpu time      0.3627: real time      0.3716
+       DOS:  cpu time      0.0022: real time      0.0022
+    CHARGE:  cpu time      0.5898: real time      0.5949
+    MIXING:  cpu time      0.0027: real time      0.0027
+    --------------------------------------------
+      LOOP:  cpu time     17.7277: real time     17.9059
+
+ eigenvalue-minimisations  :  8120
+ total energy-change (2. order) : 0.4357515E+02  (-0.5562364E+01)
+ number of electron     598.0000018 magnetization 
+ augmentation part      257.6871105 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.56129E+01    rms(broyden)= 0.56125E+01
+  rms(prec ) = 0.74396E+01
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.4494
+  1.6121  0.3079  0.2098  0.2098  0.2145  0.1421
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =      4840.36664911
+  Ewald energy   TEWEN  =    -61578.18855354
+  -Hartree energ DENC   =    -22077.91497527
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      2317.50209191
+  PAW double counting   =     86841.58615117   -88698.12041239
+  entropy T*S    EENTRO =         0.00033363
+  eigenvalues    EBANDS =     -7368.67667155
+  atomic energy  EATOM  =     85349.93293081
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -373.51245611 eV
+
+  energy without entropy =     -373.51278974  energy(sigma->0) =     -373.51256732
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  12)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0914: real time      0.0951
+    SETDIJ:  cpu time      0.5003: real time      0.5021
+    EDDIAG:  cpu time      2.2764: real time      2.2974
+  RMM-DIIS:  cpu time     13.7842: real time     13.9137
+    ORTHCH:  cpu time      0.3633: real time      0.3662
+       DOS:  cpu time      0.0022: real time      0.0022
+    CHARGE:  cpu time      0.5886: real time      0.5937
+    MIXING:  cpu time      0.0029: real time      0.0029
+    --------------------------------------------
+      LOOP:  cpu time     17.6092: real time     17.7733
+
+ eigenvalue-minimisations  :  8156
+ total energy-change (2. order) : 0.2527615E+01  (-0.3741501E+01)
+ number of electron     598.0000045 magnetization 
+ augmentation part      255.1377064 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.58140E+01    rms(broyden)= 0.58136E+01
+  rms(prec ) = 0.75072E+01
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.4506
+  1.6588  0.3880  0.3880  0.2365  0.2365  0.1513  0.0954
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =      4840.36664911
+  Ewald energy   TEWEN  =    -61578.18855354
+  -Hartree energ DENC   =    -22151.78012950
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      2319.03398479
+  PAW double counting   =     86941.40372565   -88797.54687214
+  entropy T*S    EENTRO =        -0.00430915
+  eigenvalues    EBANDS =     -7294.20226706
+  atomic energy  EATOM  =     85349.93293081
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -370.98484103 eV
+
+  energy without entropy =     -370.98053188  energy(sigma->0) =     -370.98340465
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  13)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0884: real time      0.0891
+    SETDIJ:  cpu time      0.5025: real time      0.5044
+    EDDIAG:  cpu time      2.2698: real time      2.2906
+  RMM-DIIS:  cpu time     15.4009: real time     15.5524
+    ORTHCH:  cpu time      0.3619: real time      0.3722
+       DOS:  cpu time      0.0017: real time      0.0017
+    CHARGE:  cpu time      0.6043: real time      0.6101
+    MIXING:  cpu time      0.0030: real time      0.0030
+    --------------------------------------------
+      LOOP:  cpu time     19.2325: real time     19.4234
+
+ eigenvalue-minimisations  :  9061
+ total energy-change (2. order) : 0.8585630E+00  (-0.1810961E+01)
+ number of electron     598.0000020 magnetization 
+ augmentation part      255.3931062 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.54375E+01    rms(broyden)= 0.54371E+01
+  rms(prec ) = 0.73674E+01
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.4255
+  1.6756  0.4401  0.4401  0.2410  0.2410  0.1576  0.1114  0.0975
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =      4840.36664911
+  Ewald energy   TEWEN  =    -61578.18855354
+  -Hartree energ DENC   =    -22121.90538733
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      2317.66712556
+  PAW double counting   =     86983.20916671   -88832.03799141
+  entropy T*S    EENTRO =        -0.00380126
+  eigenvalues    EBANDS =     -7329.16641670
+  atomic energy  EATOM  =     85349.93293081
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -370.12627805 eV
+
+  energy without entropy =     -370.12247679  energy(sigma->0) =     -370.12501096
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  14)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0919: real time      0.1071
+    SETDIJ:  cpu time      0.5032: real time      0.5050
+    EDDIAG:  cpu time      2.3246: real time      2.3460
+  RMM-DIIS:  cpu time     16.4756: real time     16.6367
+    ORTHCH:  cpu time      0.3837: real time      0.3866
+       DOS:  cpu time      0.0026: real time      0.0026
+    CHARGE:  cpu time      0.5834: real time      0.5885
+    MIXING:  cpu time      0.0030: real time      0.0030
+    --------------------------------------------
+      LOOP:  cpu time     20.3680: real time     20.5754
+
+ eigenvalue-minimisations  :  9678
+ total energy-change (2. order) : 0.6289690E+01  (-0.7103577E+00)
+ number of electron     598.0000034 magnetization 
+ augmentation part      253.9980103 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.51149E+01    rms(broyden)= 0.51146E+01
+  rms(prec ) = 0.67270E+01
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.4208
+  1.7127  0.5401  0.5401  0.2288  0.2288  0.2141  0.1188  0.1188  0.0847
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =      4840.36664911
+  Ewald energy   TEWEN  =    -61578.18855354
+  -Hartree energ DENC   =    -22104.31204419
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      2316.77938300
+  PAW double counting   =     86998.87575690   -88843.44511300
+  entropy T*S    EENTRO =        -0.00190545
+  eigenvalues    EBANDS =     -7343.84369206
+  atomic energy  EATOM  =     85349.93293081
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -363.83658841 eV
+
+  energy without entropy =     -363.83468296  energy(sigma->0) =     -363.83595326
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  15)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0922: real time      0.0957
+    SETDIJ:  cpu time      0.5027: real time      0.5045
+    EDDIAG:  cpu time      2.2569: real time      2.2775
+  RMM-DIIS:  cpu time     14.9399: real time     15.0808
+    ORTHCH:  cpu time      0.3580: real time      0.3666
+       DOS:  cpu time      0.0023: real time      0.0023
+    CHARGE:  cpu time      0.5722: real time      0.5771
+    MIXING:  cpu time      0.0029: real time      0.0029
+    --------------------------------------------
+      LOOP:  cpu time     18.7271: real time     18.9073
+
+ eigenvalue-minimisations  :  8893
+ total energy-change (2. order) : 0.1937486E+01  (-0.7131425E+00)
+ number of electron     598.0000029 magnetization 
+ augmentation part      255.4601658 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.42495E+01    rms(broyden)= 0.42492E+01
+  rms(prec ) = 0.54585E+01
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.4327
+  1.7402  0.7099  0.7099  0.2823  0.2255  0.2255  0.1363  0.1363  0.0897  0.0711
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =      4840.36664911
+  Ewald energy   TEWEN  =    -61578.18855354
+  -Hartree energ DENC   =    -22097.31914051
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      2316.08293873
+  PAW double counting   =     87050.08267138   -88886.71021501
+  entropy T*S    EENTRO =         0.00496632
+  eigenvalues    EBANDS =     -7356.15135012
+  atomic energy  EATOM  =     85349.93293081
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -361.89910283 eV
+
+  energy without entropy =     -361.90406915  energy(sigma->0) =     -361.90075827
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  16)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0892: real time      0.0898
+    SETDIJ:  cpu time      0.4994: real time      0.5013
+    EDDIAG:  cpu time      2.2572: real time      2.2801
+  RMM-DIIS:  cpu time     16.3374: real time     16.5023
+    ORTHCH:  cpu time      0.3683: real time      0.3771
+       DOS:  cpu time      0.0027: real time      0.0027
+    CHARGE:  cpu time      0.5950: real time      0.6006
+    MIXING:  cpu time      0.0035: real time      0.0058
+    --------------------------------------------
+      LOOP:  cpu time     20.1527: real time     20.3598
+
+ eigenvalue-minimisations  :  9626
+ total energy-change (2. order) : 0.1618565E+01  (-0.6904645E+00)
+ number of electron     598.0000031 magnetization 
+ augmentation part      258.0878393 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.34813E+01    rms(broyden)= 0.34809E+01
+  rms(prec ) = 0.45435E+01
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.4507
+  1.7308  0.9304  0.9304  0.3565  0.2299  0.2299  0.1632  0.1353  0.0968  0.0772
+  0.0772
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =      4840.36664911
+  Ewald energy   TEWEN  =    -61578.18855354
+  -Hartree energ DENC   =    -22089.36779835
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      2315.27824881
+  PAW double counting   =     87026.35290230   -88852.85965682
+  entropy T*S    EENTRO =         0.00188595
+  eigenvalues    EBANDS =     -7371.79714605
+  atomic energy  EATOM  =     85349.93293081
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -360.28053779 eV
+
+  energy without entropy =     -360.28242374  energy(sigma->0) =     -360.28116644
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  17)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0919: real time      0.0974
+    SETDIJ:  cpu time      0.5003: real time      0.5021
+    EDDIAG:  cpu time      2.3923: real time      2.4153
+  RMM-DIIS:  cpu time     16.4127: real time     16.5671
+    ORTHCH:  cpu time      0.3862: real time      0.3891
+       DOS:  cpu time      0.0023: real time      0.0023
+    CHARGE:  cpu time      0.5834: real time      0.5886
+    MIXING:  cpu time      0.0036: real time      0.0037
+    --------------------------------------------
+      LOOP:  cpu time     20.3729: real time     20.5656
+
+ eigenvalue-minimisations  :  9655
+ total energy-change (2. order) : 0.1979523E+01  (-0.5180134E+00)
+ number of electron     598.0000024 magnetization 
+ augmentation part      259.0268535 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.28839E+01    rms(broyden)= 0.28837E+01
+  rms(prec ) = 0.37299E+01
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.4372
+  1.6797  1.0249  1.0249  0.3648  0.2271  0.2271  0.1794  0.1445  0.1062  0.1062
+  0.0935  0.0686
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =      4840.36664911
+  Ewald energy   TEWEN  =    -61578.18855354
+  -Hartree energ DENC   =    -22075.94797851
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      2314.39962108
+  PAW double counting   =     86873.83184572   -88684.68682588
+  entropy T*S    EENTRO =         0.00468232
+  eigenvalues    EBANDS =     -7398.01338615
+  atomic energy  EATOM  =     85349.93293081
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -358.30101503 eV
+
+  energy without entropy =     -358.30569735  energy(sigma->0) =     -358.30257580
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  18)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0909: real time      0.0944
+    SETDIJ:  cpu time      0.5012: real time      0.5032
+    EDDIAG:  cpu time      2.2903: real time      2.3107
+  RMM-DIIS:  cpu time     16.7459: real time     16.9042
+    ORTHCH:  cpu time      0.3647: real time      0.3766
+       DOS:  cpu time      0.0022: real time      0.0022
+    CHARGE:  cpu time      0.5826: real time      0.5877
+    MIXING:  cpu time      0.0032: real time      0.0033
+    --------------------------------------------
+      LOOP:  cpu time     20.5810: real time     20.7822
+
+ eigenvalue-minimisations  :  9890
+ total energy-change (2. order) : 0.8008630E+00  (-0.2548363E+00)
+ number of electron     598.0000027 magnetization 
+ augmentation part      258.1905750 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.25189E+01    rms(broyden)= 0.25187E+01
+  rms(prec ) = 0.34329E+01
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.4393
+  1.5409  1.1768  1.1768  0.3394  0.3394  0.2301  0.2301  0.1847  0.1348  0.1148
+  0.0913  0.0824  0.0688
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =      4840.36664911
+  Ewald energy   TEWEN  =    -61578.18855354
+  -Hartree energ DENC   =    -22081.31054266
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      2314.44162118
+  PAW double counting   =     86751.76107023   -88553.55107496
+  entropy T*S    EENTRO =         0.00363477
+  eigenvalues    EBANDS =     -7400.95588697
+  atomic energy  EATOM  =     85349.93293081
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -357.50015203 eV
+
+  energy without entropy =     -357.50378680  energy(sigma->0) =     -357.50136362
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  19)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0907: real time      0.0943
+    SETDIJ:  cpu time      0.5020: real time      0.5040
+    EDDIAG:  cpu time      2.2715: real time      2.2928
+  RMM-DIIS:  cpu time     16.5032: real time     16.6769
+    ORTHCH:  cpu time      0.3858: real time      0.4409
+       DOS:  cpu time      0.0022: real time      0.0031
+    CHARGE:  cpu time      0.6049: real time      0.6105
+    MIXING:  cpu time      0.0054: real time      0.0155
+    --------------------------------------------
+      LOOP:  cpu time     20.3656: real time     20.6380
+
+ eigenvalue-minimisations  :  9724
+ total energy-change (2. order) :-0.2834658E+00  (-0.2043865E+00)
+ number of electron     598.0000027 magnetization 
+ augmentation part      258.2682777 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.27166E+01    rms(broyden)= 0.27163E+01
+  rms(prec ) = 0.35883E+01
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.4525
+  1.5129  1.5129  1.1177  0.4675  0.4675  0.2269  0.2269  0.2063  0.1447  0.1193
+  0.1043  0.0804  0.0804  0.0672
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =      4840.36664911
+  Ewald energy   TEWEN  =    -61578.18855354
+  -Hartree energ DENC   =    -22095.04295490
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      2314.56613442
+  PAW double counting   =     86629.79039836   -88421.65796008
+  entropy T*S    EENTRO =        -0.00081801
+  eigenvalues    EBANDS =     -7397.54944398
+  atomic energy  EATOM  =     85349.93293081
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -357.78361781 eV
+
+  energy without entropy =     -357.78279980  energy(sigma->0) =     -357.78334514
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  20)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0916: real time      0.1034
+    SETDIJ:  cpu time      0.5005: real time      0.5025
+    EDDIAG:  cpu time      2.4399: real time      2.5422
+  RMM-DIIS:  cpu time     16.7019: real time     16.8757
+    ORTHCH:  cpu time      0.3591: real time      0.3622
+       DOS:  cpu time      0.0021: real time      0.0022
+    CHARGE:  cpu time      0.5851: real time      0.5903
+    MIXING:  cpu time      0.0045: real time      0.0045
+    --------------------------------------------
+      LOOP:  cpu time     20.6848: real time     20.9830
+
+ eigenvalue-minimisations  :  9807
+ total energy-change (2. order) : 0.2370381E+00  (-0.2427995E+00)
+ number of electron     598.0000024 magnetization 
+ augmentation part      258.5932017 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.26391E+01    rms(broyden)= 0.26388E+01
+  rms(prec ) = 0.34663E+01
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.4840
+  1.9129  1.9129  0.8545  0.5594  0.5594  0.2858  0.2276  0.2276  0.1637  0.1345
+  0.0961  0.0945  0.0945  0.0720  0.0650
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =      4840.36664911
+  Ewald energy   TEWEN  =    -61578.18855354
+  -Hartree energ DENC   =    -22107.41135956
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      2314.69160811
+  PAW double counting   =     86520.81872521   -88302.59871319
+  entropy T*S    EENTRO =         0.00021871
+  eigenvalues    EBANDS =     -7395.15808539
+  atomic energy  EATOM  =     85349.93293081
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -357.54657974 eV
+
+  energy without entropy =     -357.54679844  energy(sigma->0) =     -357.54665264
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  21)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0997: real time      0.1004
+    SETDIJ:  cpu time      0.5090: real time      0.5112
+    EDDIAG:  cpu time      2.2760: real time      2.2984
+  RMM-DIIS:  cpu time     16.4585: real time     16.6411
+    ORTHCH:  cpu time      0.3704: real time      0.3821
+       DOS:  cpu time      0.0024: real time      0.0024
+    CHARGE:  cpu time      0.6400: real time      0.6457
+    MIXING:  cpu time      0.0068: real time      0.0068
+    --------------------------------------------
+      LOOP:  cpu time     20.3628: real time     20.5880
+
+ eigenvalue-minimisations  :  9794
+ total energy-change (2. order) :-0.1050871E+01  (-0.4064599E+00)
+ number of electron     598.0000032 magnetization 
+ augmentation part      258.9576148 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.29039E+01    rms(broyden)= 0.29035E+01
+  rms(prec ) = 0.41893E+01
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.4893
+  1.9443  1.9443  0.9979  0.6513  0.6513  0.3478  0.2306  0.2306  0.1689  0.1382
+  0.1088  0.1088  0.0860  0.0860  0.0691  0.0644
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =      4840.36664911
+  Ewald energy   TEWEN  =    -61578.18855354
+  -Hartree energ DENC   =    -22124.38367747
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      2314.86168538
+  PAW double counting   =     86396.79745619   -88163.67038197
+  entropy T*S    EENTRO =         0.00723607
+  eigenvalues    EBANDS =     -7394.32079532
+  atomic energy  EATOM  =     85349.93293081
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -358.59745074 eV
+
+  energy without entropy =     -358.60468681  energy(sigma->0) =     -358.59986277
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  22)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0954: real time      0.1004
+    SETDIJ:  cpu time      0.5032: real time      0.5051
+    EDDIAG:  cpu time      2.3678: real time      2.4104
+  RMM-DIIS:  cpu time     16.8989: real time     17.0646
+    ORTHCH:  cpu time      0.3736: real time      0.3852
+       DOS:  cpu time      0.0046: real time      0.0046
+    CHARGE:  cpu time      0.5818: real time      0.5871
+    MIXING:  cpu time      0.0063: real time      0.0064
+    --------------------------------------------
+      LOOP:  cpu time     20.8317: real time     21.0638
+
+ eigenvalue-minimisations  :  9740
+ total energy-change (2. order) : 0.1361900E+01  (-0.1706516E+00)
+ number of electron     598.0000030 magnetization 
+ augmentation part      258.2285127 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.20379E+01    rms(broyden)= 0.20376E+01
+  rms(prec ) = 0.28529E+01
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.4887
+  1.9833  1.9833  1.1257  0.7068  0.7068  0.3700  0.2310  0.2310  0.1721  0.1397
+  0.1397  0.1124  0.1004  0.0862  0.0862  0.0701  0.0636
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =      4840.36664911
+  Ewald energy   TEWEN  =    -61578.18855354
+  -Hartree energ DENC   =    -22128.22886940
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      2315.13245009
+  PAW double counting   =     86424.00926039   -88187.42049973
+  entropy T*S    EENTRO =         0.00283433
+  eigenvalues    EBANDS =     -7392.84175297
+  atomic energy  EATOM  =     85349.93293081
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -357.23555091 eV
+
+  energy without entropy =     -357.23838524  energy(sigma->0) =     -357.23649569
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  23)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0910: real time      0.0945
+    SETDIJ:  cpu time      0.5032: real time      0.5051
+    EDDIAG:  cpu time      2.3402: real time      2.3847
+  RMM-DIIS:  cpu time     16.6224: real time     16.7814
+    ORTHCH:  cpu time      0.3659: real time      0.3754
+       DOS:  cpu time      0.0018: real time      0.0018
+    CHARGE:  cpu time      0.5690: real time      0.5747
+    MIXING:  cpu time      0.0038: real time      0.0038
+    --------------------------------------------
+      LOOP:  cpu time     20.4972: real time     20.7214
+
+ eigenvalue-minimisations  :  9752
+ total energy-change (2. order) : 0.7267505E+00  (-0.1202440E+00)
+ number of electron     598.0000031 magnetization 
+ augmentation part      258.0979446 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.18257E+01    rms(broyden)= 0.18256E+01
+  rms(prec ) = 0.26056E+01
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.4934
+  1.7788  1.7788  1.6565  0.7713  0.7713  0.3532  0.3263  0.2286  0.2286  0.1936
+  0.1569  0.1330  0.0997  0.0997  0.0893  0.0813  0.0695  0.0640
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =      4840.36664911
+  Ewald energy   TEWEN  =    -61578.18855354
+  -Hartree energ DENC   =    -22138.53910475
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      2315.53339212
+  PAW double counting   =     86489.50545804   -88251.97912733
+  entropy T*S    EENTRO =         0.00640159
+  eigenvalues    EBANDS =     -7383.14684651
+  atomic energy  EATOM  =     85349.93293081
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -356.50880045 eV
+
+  energy without entropy =     -356.51520204  energy(sigma->0) =     -356.51093432
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  24)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0904: real time      0.0964
+    SETDIJ:  cpu time      0.5056: real time      0.5078
+    EDDIAG:  cpu time      2.2928: real time      2.3154
+  RMM-DIIS:  cpu time     16.3934: real time     16.5690
+    ORTHCH:  cpu time      0.5048: real time      0.5382
+       DOS:  cpu time      0.0023: real time      0.0160
+    CHARGE:  cpu time      0.5724: real time      0.6263
+    MIXING:  cpu time      0.0047: real time      0.0146
+    --------------------------------------------
+      LOOP:  cpu time     20.3667: real time     20.6848
+
+ eigenvalue-minimisations  :  9711
+ total energy-change (2. order) :-0.1865655E+00  (-0.1090904E+00)
+ number of electron     598.0000028 magnetization 
+ augmentation part      258.6387415 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.18974E+01    rms(broyden)= 0.18974E+01
+  rms(prec ) = 0.26624E+01
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.5023
+  2.1115  1.7346  1.7346  0.8003  0.8003  0.4064  0.4064  0.2291  0.2291  0.1891
+  0.1575  0.1307  0.1051  0.1029  0.1029  0.0848  0.0848  0.0698  0.0639
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =      4840.36664911
+  Ewald energy   TEWEN  =    -61578.18855354
+  -Hartree energ DENC   =    -22132.32818053
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      2315.36536127
+  PAW double counting   =     86602.09153906   -88364.29329117
+  entropy T*S    EENTRO =         0.00519273
+  eigenvalues    EBANDS =     -7389.64701373
+  atomic energy  EATOM  =     85349.93293081
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -356.69536599 eV
+
+  energy without entropy =     -356.70055872  energy(sigma->0) =     -356.69709690
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  25)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0973: real time      0.1153
+    SETDIJ:  cpu time      0.5050: real time      0.5166
+    EDDIAG:  cpu time      2.3116: real time      2.3891
+  RMM-DIIS:  cpu time     17.1677: real time     17.3407
+    ORTHCH:  cpu time      0.3781: real time      0.3812
+       DOS:  cpu time      0.0022: real time      0.0022
+    CHARGE:  cpu time      0.5738: real time      0.5790
+    MIXING:  cpu time      0.0040: real time      0.0040
+    --------------------------------------------
+      LOOP:  cpu time     21.0396: real time     21.3271
+
+ eigenvalue-minimisations  :  9680
+ total energy-change (2. order) : 0.6404732E+00  (-0.4406708E-01)
+ number of electron     598.0000026 magnetization 
+ augmentation part      258.4566498 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.13172E+01    rms(broyden)= 0.13170E+01
+  rms(prec ) = 0.18748E+01
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.4912
+  2.3977  1.6128  1.6128  0.8314  0.8314  0.4441  0.4032  0.2288  0.2288  0.2055
+  0.1640  0.1324  0.1324  0.1051  0.0988  0.0910  0.0910  0.0802  0.0696  0.0639
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =      4840.36664911
+  Ewald energy   TEWEN  =    -61578.18855354
+  -Hartree energ DENC   =    -22131.22943528
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      2315.41299586
+  PAW double counting   =     86654.71416990   -88415.22622159
+  entropy T*S    EENTRO =         0.00245233
+  eigenvalues    EBANDS =     -7391.83988044
+  atomic energy  EATOM  =     85349.93293081
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -356.05489284 eV
+
+  energy without entropy =     -356.05734517  energy(sigma->0) =     -356.05571029
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  26)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0912: real time      0.0919
+    SETDIJ:  cpu time      0.5049: real time      0.5069
+    EDDIAG:  cpu time      2.5021: real time      2.5280
+  RMM-DIIS:  cpu time     16.6827: real time     16.8608
+    ORTHCH:  cpu time      0.3651: real time      0.3679
+       DOS:  cpu time      0.0020: real time      0.0020
+    CHARGE:  cpu time      0.5929: real time      0.5984
+    MIXING:  cpu time      0.0074: real time      0.0355
+    --------------------------------------------
+      LOOP:  cpu time     20.7482: real time     20.9915
+
+ eigenvalue-minimisations  :  9885
+ total energy-change (2. order) : 0.3021142E+00  (-0.2353108E-01)
+ number of electron     598.0000029 magnetization 
+ augmentation part      258.1294310 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.10827E+01    rms(broyden)= 0.10826E+01
+  rms(prec ) = 0.15378E+01
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.4818
+  2.6087  1.5326  1.1330  1.1330  0.8783  0.4364  0.4364  0.3320  0.2295  0.2295
+  0.1739  0.1446  0.1446  0.1292  0.0995  0.0995  0.0894  0.0811  0.0639  0.0698
+  0.0718
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =      4840.36664911
+  Ewald energy   TEWEN  =    -61578.18855354
+  -Hartree energ DENC   =    -22136.29920119
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      2315.56372531
+  PAW double counting   =     86644.92791414   -88403.42327697
+  entropy T*S    EENTRO =         0.00064835
+  eigenvalues    EBANDS =     -7388.63361470
+  atomic energy  EATOM  =     85349.93293081
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -355.75277868 eV
+
+  energy without entropy =     -355.75342703  energy(sigma->0) =     -355.75299480
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  27)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0954: real time      0.0961
+    SETDIJ:  cpu time      0.5103: real time      0.5124
+    EDDIAG:  cpu time      2.3005: real time      2.3216
+  RMM-DIIS:  cpu time     16.4440: real time     16.6005
+    ORTHCH:  cpu time      0.3903: real time      0.3938
+       DOS:  cpu time      0.0057: real time      0.0058
+    CHARGE:  cpu time      0.5892: real time      0.5945
+    MIXING:  cpu time      0.0080: real time      0.0081
+    --------------------------------------------
+      LOOP:  cpu time     20.3433: real time     20.5326
+
+ eigenvalue-minimisations  :  9796
+ total energy-change (2. order) : 0.1748322E+00  (-0.1345889E-01)
+ number of electron     598.0000028 magnetization 
+ augmentation part      257.8224152 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.76688E+00    rms(broyden)= 0.76682E+00
+  rms(prec ) = 0.10847E+01
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.4859
+  2.6843  1.7955  1.1792  1.1792  0.7263  0.4914  0.4914  0.3516  0.2300  0.2300
+  0.1729  0.1729  0.1683  0.1315  0.1043  0.1017  0.1017  0.0852  0.0852  0.0639
+  0.0696  0.0734
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =      4840.36664911
+  Ewald energy   TEWEN  =    -61578.18855354
+  -Hartree energ DENC   =    -22140.36758024
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      2315.69155681
+  PAW double counting   =     86631.75399345   -88389.07613715
+  entropy T*S    EENTRO =        -0.00093938
+  eigenvalues    EBANDS =     -7385.68986639
+  atomic energy  EATOM  =     85349.93293081
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -355.57794652 eV
+
+  energy without entropy =     -355.57700714  energy(sigma->0) =     -355.57763339
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  28)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0914: real time      0.0920
+    SETDIJ:  cpu time      0.5031: real time      0.5051
+    EDDIAG:  cpu time      2.2877: real time      2.3099
+  RMM-DIIS:  cpu time     16.8229: real time     17.0053
+    ORTHCH:  cpu time      0.3956: real time      0.4383
+       DOS:  cpu time      0.0024: real time      0.0024
+    CHARGE:  cpu time      0.6010: real time      0.6067
+    MIXING:  cpu time      0.0046: real time      0.0046
+    --------------------------------------------
+      LOOP:  cpu time     20.7086: real time     20.9642
+
+ eigenvalue-minimisations  :  9630
+ total energy-change (2. order) :-0.2176190E-01  (-0.1373843E-01)
+ number of electron     598.0000027 magnetization 
+ augmentation part      257.8549756 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.87335E+00    rms(broyden)= 0.87330E+00
+  rms(prec ) = 0.12486E+01
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.4826
+  2.5506  1.9531  1.2010  1.2010  0.7415  0.5581  0.5581  0.3375  0.2966  0.2287
+  0.2287  0.1842  0.1580  0.1269  0.1269  0.1009  0.1009  0.0859  0.0859  0.0773
+  0.0696  0.0638  0.0638
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =      4840.36664911
+  Ewald energy   TEWEN  =    -61578.18855354
+  -Hartree energ DENC   =    -22141.73994051
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      2315.71636258
+  PAW double counting   =     86614.36637375   -88370.98039788
+  entropy T*S    EENTRO =         0.00016953
+  eigenvalues    EBANDS =     -7385.07330225
+  atomic energy  EATOM  =     85349.93293081
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -355.59970842 eV
+
+  energy without entropy =     -355.59987795  energy(sigma->0) =     -355.59976493
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  29)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0919: real time      0.0960
+    SETDIJ:  cpu time      0.5034: real time      0.5059
+    EDDIAG:  cpu time      2.4633: real time      2.4862
+  RMM-DIIS:  cpu time     16.5217: real time     16.6752
+    ORTHCH:  cpu time      0.3633: real time      0.3721
+       DOS:  cpu time      0.0023: real time      0.0023
+    CHARGE:  cpu time      0.5895: real time      0.5946
+    MIXING:  cpu time      0.0072: real time      0.0073
+    --------------------------------------------
+      LOOP:  cpu time     20.5426: real time     20.7397
+
+ eigenvalue-minimisations  :  9782
+ total energy-change (2. order) : 0.5845636E-01  (-0.6041247E-02)
+ number of electron     598.0000029 magnetization 
+ augmentation part      257.8319757 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.72728E+00    rms(broyden)= 0.72726E+00
+  rms(prec ) = 0.10242E+01
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.4773
+  2.4324  2.0777  1.2187  1.2187  0.7705  0.6113  0.6113  0.3452  0.3452  0.2287
+  0.2287  0.1868  0.1586  0.1301  0.1177  0.1177  0.0985  0.0985  0.0905  0.0817
+  0.0817  0.0639  0.0694  0.0711
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =      4840.36664911
+  Ewald energy   TEWEN  =    -61578.18855354
+  -Hartree energ DENC   =    -22140.20753969
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      2315.69191412
+  PAW double counting   =     86602.48570548   -88358.72988009
+  entropy T*S    EENTRO =        -0.00183689
+  eigenvalues    EBANDS =     -7386.89064136
+  atomic energy  EATOM  =     85349.93293081
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -355.54125206 eV
+
+  energy without entropy =     -355.53941517  energy(sigma->0) =     -355.54063977
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  30)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0960: real time      0.1012
+    SETDIJ:  cpu time      0.5056: real time      0.5075
+    EDDIAG:  cpu time      2.4135: real time      2.4348
+  RMM-DIIS:  cpu time     16.3434: real time     16.4994
+    ORTHCH:  cpu time      0.3688: real time      0.3772
+       DOS:  cpu time      0.0021: real time      0.0022
+    CHARGE:  cpu time      0.5768: real time      0.5815
+    MIXING:  cpu time      0.0078: real time      0.0079
+    --------------------------------------------
+      LOOP:  cpu time     20.3140: real time     20.5117
+
+ eigenvalue-minimisations  :  9656
+ total energy-change (2. order) :-0.2890144E-01  (-0.6260356E-02)
+ number of electron     598.0000027 magnetization 
+ augmentation part      257.9035268 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.82770E+00    rms(broyden)= 0.82766E+00
+  rms(prec ) = 0.11820E+01
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.4837
+  2.5241  2.0711  1.2898  1.2898  0.7601  0.6977  0.6977  0.3826  0.3826  0.2289
+  0.2289  0.2242  0.1722  0.1438  0.1438  0.1329  0.1004  0.1004  0.0891  0.0838
+  0.0838  0.0639  0.0696  0.0723  0.0591
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =      4840.36664911
+  Ewald energy   TEWEN  =    -61578.18855354
+  -Hartree energ DENC   =    -22138.71238097
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      2315.64531594
+  PAW double counting   =     86593.38368293   -88349.63020558
+  entropy T*S    EENTRO =         0.00022703
+  eigenvalues    EBANDS =     -7388.36781923
+  atomic energy  EATOM  =     85349.93293081
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -355.57015350 eV
+
+  energy without entropy =     -355.57038052  energy(sigma->0) =     -355.57022917
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  31)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0973: real time      0.1054
+    SETDIJ:  cpu time      0.5004: real time      0.5021
+    EDDIAG:  cpu time      2.5788: real time      2.5991
+  RMM-DIIS:  cpu time     16.4468: real time     16.5971
+    ORTHCH:  cpu time      0.3633: real time      0.3779
+       DOS:  cpu time      0.0026: real time      0.0026
+    CHARGE:  cpu time      0.5854: real time      0.5904
+    MIXING:  cpu time      0.0053: real time      0.0053
+    --------------------------------------------
+      LOOP:  cpu time     20.5798: real time     20.7800
+
+ eigenvalue-minimisations  :  9537
+ total energy-change (2. order) : 0.5018354E-01  (-0.3397654E-02)
+ number of electron     598.0000028 magnetization 
+ augmentation part      257.8496310 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.70844E+00    rms(broyden)= 0.70843E+00
+  rms(prec ) = 0.10060E+01
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.5007
+  2.8131  2.0033  1.4557  1.4557  0.7764  0.7764  0.6597  0.4575  0.3914  0.2925
+  0.2292  0.2292  0.1750  0.1619  0.1619  0.1282  0.1282  0.1008  0.1008  0.0866
+  0.0866  0.0801  0.0701  0.0704  0.0640  0.0643
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =      4840.36664911
+  Ewald energy   TEWEN  =    -61578.18855354
+  -Hartree energ DENC   =    -22138.67750030
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      2315.65934002
+  PAW double counting   =     86584.28106006   -88340.08928026
+  entropy T*S    EENTRO =        -0.00155420
+  eigenvalues    EBANDS =     -7388.80306165
+  atomic energy  EATOM  =     85349.93293081
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -355.51996995 eV
+
+  energy without entropy =     -355.51841575  energy(sigma->0) =     -355.51945189
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  32)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0912: real time      0.0954
+    SETDIJ:  cpu time      0.5039: real time      0.5058
+    EDDIAG:  cpu time      2.3752: real time      2.3951
+  RMM-DIIS:  cpu time     16.1360: real time     16.3001
+    ORTHCH:  cpu time      0.3789: real time      0.4338
+       DOS:  cpu time      0.0019: real time      0.0029
+    CHARGE:  cpu time      0.5687: real time      0.5733
+    MIXING:  cpu time      0.0063: real time      0.0326
+    --------------------------------------------
+      LOOP:  cpu time     20.0621: real time     20.3389
+
+ eigenvalue-minimisations  :  9543
+ total energy-change (2. order) : 0.2719164E-01  (-0.3368654E-02)
+ number of electron     598.0000028 magnetization 
+ augmentation part      257.7316045 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.66173E+00    rms(broyden)= 0.66171E+00
+  rms(prec ) = 0.95417E+00
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.5011
+  2.8487  2.0144  1.5624  1.5624  0.8214  0.8214  0.5696  0.5696  0.3985  0.3254
+  0.2292  0.2292  0.1791  0.1791  0.1641  0.1300  0.1300  0.1007  0.1007  0.0870
+  0.0870  0.0787  0.0639  0.0695  0.0742  0.0726  0.0604
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =      4840.36664911
+  Ewald energy   TEWEN  =    -61578.18855354
+  -Hartree energ DENC   =    -22139.75341773
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      2315.70217924
+  PAW double counting   =     86576.26946772   -88331.75281328
+  entropy T*S    EENTRO =        -0.00141459
+  eigenvalues    EBANDS =     -7388.06780604
+  atomic energy  EATOM  =     85349.93293081
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -355.49277831 eV
+
+  energy without entropy =     -355.49136372  energy(sigma->0) =     -355.49230678
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  33)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0941: real time      0.1005
+    SETDIJ:  cpu time      0.5116: real time      0.5208
+    EDDIAG:  cpu time      2.4247: real time      2.5301
+  RMM-DIIS:  cpu time     15.8765: real time     16.0279
+    ORTHCH:  cpu time      0.4549: real time      0.4666
+       DOS:  cpu time      0.0023: real time      0.0023
+    CHARGE:  cpu time      0.5778: real time      0.5827
+    MIXING:  cpu time      0.0052: real time      0.0053
+    --------------------------------------------
+      LOOP:  cpu time     19.9472: real time     20.2362
+
+ eigenvalue-minimisations  :  9416
+ total energy-change (2. order) : 0.4998567E-01  (-0.2657438E-02)
+ number of electron     598.0000028 magnetization 
+ augmentation part      257.6256503 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.49199E+00    rms(broyden)= 0.49196E+00
+  rms(prec ) = 0.69531E+00
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.5123
+  2.6681  1.9266  1.7823  1.7823  0.9433  0.9433  0.5918  0.5918  0.5016  0.3409
+  0.2740  0.2289  0.2289  0.1817  0.1527  0.1527  0.1343  0.1309  0.1007  0.1007
+  0.0867  0.0867  0.0812  0.0698  0.0715  0.0650  0.0638  0.0634
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =      4840.36664911
+  Ewald energy   TEWEN  =    -61578.18855354
+  -Hartree energ DENC   =    -22139.30545638
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      2315.72067076
+  PAW double counting   =     86578.95518528   -88334.48980984
+  entropy T*S    EENTRO =        -0.00348549
+  eigenvalues    EBANDS =     -7388.43092334
+  atomic energy  EATOM  =     85349.93293081
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -355.44279264 eV
+
+  energy without entropy =     -355.43930715  energy(sigma->0) =     -355.44163081
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  34)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0944: real time      0.0983
+    SETDIJ:  cpu time      0.4996: real time      0.5013
+    EDDIAG:  cpu time      2.3107: real time      2.3311
+  RMM-DIIS:  cpu time     16.3102: real time     16.4792
+    ORTHCH:  cpu time      0.3866: real time      0.4015
+       DOS:  cpu time      0.0023: real time      0.0131
+    CHARGE:  cpu time      0.5901: real time      0.6298
+    MIXING:  cpu time      0.0056: real time      0.0108
+    --------------------------------------------
+      LOOP:  cpu time     20.1996: real time     20.4663
+
+ eigenvalue-minimisations  :  9474
+ total energy-change (2. order) : 0.4248085E-01  (-0.3123282E-02)
+ number of electron     598.0000028 magnetization 
+ augmentation part      257.6640358 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.33496E+00    rms(broyden)= 0.33493E+00
+  rms(prec ) = 0.48107E+00
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.5406
+  3.1074  1.9138  1.9138  1.8239  1.0558  1.0558  0.6291  0.6291  0.5974  0.3682
+  0.3452  0.2289  0.2289  0.2461  0.1779  0.1513  0.1513  0.1348  0.1288  0.1007
+  0.1007  0.0867  0.0867  0.0810  0.0698  0.0713  0.0639  0.0654  0.0624
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =      4840.36664911
+  Ewald energy   TEWEN  =    -61578.18855354
+  -Hartree energ DENC   =    -22137.21500306
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      2315.70540889
+  PAW double counting   =     86595.26335599   -88351.18761723
+  entropy T*S    EENTRO =        -0.00457105
+  eigenvalues    EBANDS =     -7390.07291171
+  atomic energy  EATOM  =     85349.93293081
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -355.40031179 eV
+
+  energy without entropy =     -355.39574074  energy(sigma->0) =     -355.39878811
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  35)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0944: real time      0.1074
+    SETDIJ:  cpu time      0.5025: real time      0.5130
+    EDDIAG:  cpu time      2.3186: real time      2.3606
+  RMM-DIIS:  cpu time     16.4146: real time     16.5799
+    ORTHCH:  cpu time      0.3769: real time      0.3856
+       DOS:  cpu time      0.0022: real time      0.0022
+    CHARGE:  cpu time      0.5767: real time      0.5818
+    MIXING:  cpu time      0.0050: real time      0.0051
+    --------------------------------------------
+      LOOP:  cpu time     20.2908: real time     20.5346
+
+ eigenvalue-minimisations  :  9630
+ total energy-change (2. order) : 0.2766491E-01  (-0.3676513E-02)
+ number of electron     598.0000028 magnetization 
+ augmentation part      257.4189682 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.68728E-01    rms(broyden)= 0.68426E-01
+  rms(prec ) = 0.93412E-01
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.5355
+  3.1190  1.9586  1.9586  1.6156  1.1309  1.1309  0.6381  0.6381  0.6166  0.3647
+  0.3647  0.2289  0.2289  0.2689  0.2689  0.1788  0.1515  0.1515  0.1344  0.1289
+  0.1007  0.1007  0.0867  0.0867  0.0810  0.0698  0.0713  0.0639  0.0654  0.0623
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =      4840.36664911
+  Ewald energy   TEWEN  =    -61578.18855354
+  -Hartree energ DENC   =    -22139.20668158
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      2315.82425202
+  PAW double counting   =     86606.87403876   -88363.08927979
+  entropy T*S    EENTRO =        -0.00559520
+  eigenvalues    EBANDS =     -7387.88040747
+  atomic energy  EATOM  =     85349.93293081
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -355.37264688 eV
+
+  energy without entropy =     -355.36705168  energy(sigma->0) =     -355.37078181
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  36)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0906: real time      0.0954
+    SETDIJ:  cpu time      0.5156: real time      0.5175
+    EDDIAG:  cpu time      2.3122: real time      2.3332
+  RMM-DIIS:  cpu time     15.5563: real time     15.7178
+    ORTHCH:  cpu time      0.3754: real time      0.4031
+       DOS:  cpu time      0.0021: real time      0.0041
+    CHARGE:  cpu time      0.5751: real time      0.5798
+    MIXING:  cpu time      0.0062: real time      0.0223
+    --------------------------------------------
+      LOOP:  cpu time     19.4334: real time     19.6733
+
+ eigenvalue-minimisations  :  9136
+ total energy-change (2. order) :-0.1298408E-03  (-0.1895554E-02)
+ number of electron     598.0000028 magnetization 
+ augmentation part      257.3701637 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.36543E-01    rms(broyden)= 0.36524E-01
+  rms(prec ) = 0.48228E-01
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.5594
+  2.6735  2.6735  2.1930  1.4913  1.4913  0.7910  0.7910  0.6396  0.6396  0.5594
+  0.4914  0.3362  0.3362  0.2289  0.2289  0.2445  0.1786  0.1513  0.1513  0.1345
+  0.1289  0.1007  0.1007  0.0867  0.0867  0.0810  0.0698  0.0713  0.0639  0.0654
+  0.0623
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =      4840.36664911
+  Ewald energy   TEWEN  =    -61578.18855354
+  -Hartree energ DENC   =    -22139.71833235
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      2315.85221047
+  PAW double counting   =     86609.63541598   -88365.92488022
+  entropy T*S    EENTRO =        -0.00564408
+  eigenvalues    EBANDS =     -7387.32257290
+  atomic energy  EATOM  =     85349.93293081
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -355.37277672 eV
+
+  energy without entropy =     -355.36713264  energy(sigma->0) =     -355.37089536
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  37)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0914: real time      0.1000
+    SETDIJ:  cpu time      0.5053: real time      0.5071
+    EDDIAG:  cpu time      2.4016: real time      2.4842
+  RMM-DIIS:  cpu time     16.3053: real time     16.4472
+    ORTHCH:  cpu time      0.4015: real time      0.4160
+       DOS:  cpu time      0.0028: real time      0.0028
+    CHARGE:  cpu time      0.5965: real time      0.6015
+    MIXING:  cpu time      0.0058: real time      0.0058
+    --------------------------------------------
+      LOOP:  cpu time     20.3102: real time     20.5648
+
+ eigenvalue-minimisations  :  8733
+ total energy-change (2. order) :-0.8775078E-03  (-0.6685043E-03)
+ number of electron     598.0000028 magnetization 
+ augmentation part      257.4065545 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.42041E-01    rms(broyden)= 0.42039E-01
+  rms(prec ) = 0.57999E-01
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.5769
+  2.8198  2.8198  1.8890  1.6021  1.6021  0.9575  0.9575  0.7974  0.6263  0.6263
+  0.5042  0.3974  0.3355  0.2876  0.2289  0.2289  0.2478  0.1786  0.1513  0.1513
+  0.1345  0.1289  0.1007  0.1007  0.0867  0.0867  0.0810  0.0698  0.0713  0.0639
+  0.0654  0.0623
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =      4840.36664911
+  Ewald energy   TEWEN  =    -61578.18855354
+  -Hartree energ DENC   =    -22138.90981311
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      2315.83008584
+  PAW double counting   =     86617.90964990   -88374.56706692
+  entropy T*S    EENTRO =        -0.00582973
+  eigenvalues    EBANDS =     -7387.74170658
+  atomic energy  EATOM  =     85349.93293081
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -355.37365423 eV
+
+  energy without entropy =     -355.36782450  energy(sigma->0) =     -355.37171098
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  38)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0910: real time      0.0951
+    SETDIJ:  cpu time      0.5121: real time      0.5143
+    EDDIAG:  cpu time      2.2942: real time      2.3165
+  RMM-DIIS:  cpu time     14.5373: real time     14.6952
+    ORTHCH:  cpu time      0.3769: real time      0.4032
+       DOS:  cpu time      0.0023: real time      0.0067
+    CHARGE:  cpu time      0.5768: real time      0.6204
+    MIXING:  cpu time      0.0059: real time      0.0107
+    --------------------------------------------
+      LOOP:  cpu time     18.3966: real time     18.6635
+
+ eigenvalue-minimisations  :  8503
+ total energy-change (2. order) : 0.9809347E-04  (-0.4982431E-03)
+ number of electron     598.0000028 magnetization 
+ augmentation part      257.3597636 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.26723E-01    rms(broyden)= 0.26711E-01
+  rms(prec ) = 0.35717E-01
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.6000
+  3.0300  3.0300  1.8727  1.8727  1.4406  1.1127  1.1127  0.7364  0.7364  0.6120
+  0.6120  0.3923  0.3923  0.3395  0.2289  0.2289  0.2708  0.2461  0.1786  0.1513
+  0.1513  0.1345  0.1289  0.1007  0.1007  0.0867  0.0867  0.0810  0.0698  0.0713
+  0.0639  0.0654  0.0623
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =      4840.36664911
+  Ewald energy   TEWEN  =    -61578.18855354
+  -Hartree energ DENC   =    -22139.59087378
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      2315.85422643
+  PAW double counting   =     86618.50215013   -88375.07732815
+  entropy T*S    EENTRO =        -0.00555145
+  eigenvalues    EBANDS =     -7387.16720569
+  atomic energy  EATOM  =     85349.93293081
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -355.37355614 eV
+
+  energy without entropy =     -355.36800468  energy(sigma->0) =     -355.37170565
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  39)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0926: real time      0.1051
+    SETDIJ:  cpu time      0.5083: real time      0.5182
+    EDDIAG:  cpu time      2.3360: real time      2.3805
+  RMM-DIIS:  cpu time     14.2634: real time     14.4070
+    ORTHCH:  cpu time      0.3649: real time      0.3734
+       DOS:  cpu time      0.0023: real time      0.0023
+    CHARGE:  cpu time      0.5805: real time      0.5859
+    MIXING:  cpu time      0.0057: real time      0.0057
+    --------------------------------------------
+      LOOP:  cpu time     18.1535: real time     18.3768
+
+ eigenvalue-minimisations  :  8327
+ total energy-change (2. order) :-0.2101675E-05  (-0.2494259E-03)
+ number of electron     598.0000028 magnetization 
+ augmentation part      257.3654774 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.10674E-01    rms(broyden)= 0.10666E-01
+  rms(prec ) = 0.14121E-01
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.6069
+  2.9477  2.9477  1.9705  1.9705  1.5011  1.1487  1.1487  0.7822  0.7822  0.6108
+  0.6108  0.5569  0.4425  0.3756  0.3347  0.2289  0.2289  0.2674  0.2467  0.1786
+  0.1513  0.1513  0.1345  0.1289  0.1007  0.1007  0.0867  0.0867  0.0810  0.0698
+  0.0713  0.0639  0.0654  0.0623
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =      4840.36664911
+  Ewald energy   TEWEN  =    -61578.18855354
+  -Hartree energ DENC   =    -22139.79815152
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      2315.85334932
+  PAW double counting   =     86616.76669717   -88373.18437651
+  entropy T*S    EENTRO =        -0.00572310
+  eigenvalues    EBANDS =     -7387.11637997
+  atomic energy  EATOM  =     85349.93293081
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -355.37355824 eV
+
+  energy without entropy =     -355.36783513  energy(sigma->0) =     -355.37165054
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  40)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0904: real time      0.0943
+    SETDIJ:  cpu time      0.5031: real time      0.5052
+    EDDIAG:  cpu time      2.4317: real time      2.4532
+  RMM-DIIS:  cpu time     14.2516: real time     14.3873
+    ORTHCH:  cpu time      0.3829: real time      0.3857
+       DOS:  cpu time      0.0020: real time      0.0020
+    CHARGE:  cpu time      0.5940: real time      0.5994
+    MIXING:  cpu time      0.0056: real time      0.0056
+    --------------------------------------------
+      LOOP:  cpu time     18.2612: real time     18.4327
+
+ eigenvalue-minimisations  :  8158
+ total energy-change (2. order) :-0.1286003E-03  (-0.1661523E-03)
+ number of electron     598.0000028 magnetization 
+ augmentation part      257.3693601 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.95160E-02    rms(broyden)= 0.95132E-02
+  rms(prec ) = 0.13448E-01
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.6154
+  2.9922  2.5174  2.5174  1.7429  1.7429  1.1903  1.1903  0.8315  0.8315  0.7169
+  0.6215  0.6215  0.4463  0.3936  0.3420  0.3389  0.2289  0.2289  0.2652  0.2470
+  0.1786  0.1513  0.1513  0.1345  0.1289  0.1007  0.1007  0.0867  0.0867  0.0810
+  0.0698  0.0713  0.0639  0.0654  0.0623
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =      4840.36664911
+  Ewald energy   TEWEN  =    -61578.18855354
+  -Hartree energ DENC   =    -22139.61859006
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      2315.84615713
+  PAW double counting   =     86617.92646842   -88374.34517126
+  entropy T*S    EENTRO =        -0.00572904
+  eigenvalues    EBANDS =     -7387.28784842
+  atomic energy  EATOM  =     85349.93293081
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -355.37368684 eV
+
+  energy without entropy =     -355.36795780  energy(sigma->0) =     -355.37177716
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  41)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0919: real time      0.0926
+    SETDIJ:  cpu time      0.5101: real time      0.5121
+    EDDIAG:  cpu time      2.3522: real time      2.3765
+WARNING in EDDRMM: call to ZHEGV failed, returncode =   6  3     68
+  RMM-DIIS:  cpu time     13.2139: real time     13.3428
+    ORTHCH:  cpu time      0.3653: real time      0.3681
+       DOS:  cpu time      0.0022: real time      0.0022
+    CHARGE:  cpu time      0.5783: real time      0.5832
+    MIXING:  cpu time      0.0056: real time      0.0057
+    --------------------------------------------
+      LOOP:  cpu time     17.1197: real time     17.2831
+
+ eigenvalue-minimisations  :  7585
+ total energy-change (2. order) :-0.6736981E-04  (-0.8901035E-04)
+ number of electron     598.0000028 magnetization 
+ augmentation part      257.3718966 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.71065E-02    rms(broyden)= 0.71061E-02
+  rms(prec ) = 0.10090E-01
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.6360
+  3.4417  2.6249  2.6249  1.5743  1.5743  1.4921  1.1214  1.1214  0.7740  0.7740
+  0.6051  0.6051  0.5685  0.4255  0.3939  0.3364  0.3364  0.2289  0.2289  0.2652
+  0.2468  0.1786  0.1513  0.1513  0.1345  0.1289  0.1007  0.1007  0.0867  0.0867
+  0.0810  0.0698  0.0713  0.0639  0.0654  0.0623
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =      4840.36664911
+  Ewald energy   TEWEN  =    -61578.18855354
+  -Hartree energ DENC   =    -22139.53002391
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      2315.84246565
+  PAW double counting   =     86619.63206170   -88376.03619280
+  entropy T*S    EENTRO =        -0.00569331
+  eigenvalues    EBANDS =     -7387.38739792
+  atomic energy  EATOM  =     85349.93293081
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -355.37375421 eV
+
+  energy without entropy =     -355.36806090  energy(sigma->0) =     -355.37185644
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  42)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0941: real time      0.0947
+    SETDIJ:  cpu time      0.5043: real time      0.5060
+    EDDIAG:  cpu time      2.4349: real time      2.4567
+WARNING in EDDRMM: call to ZHEGV failed, returncode =   8  4     56
+  RMM-DIIS:  cpu time     12.2587: real time     12.3819
+    ORTHCH:  cpu time      0.3738: real time      0.4209
+       DOS:  cpu time      0.0021: real time      0.0046
+    CHARGE:  cpu time      0.6200: real time      0.6273
+    MIXING:  cpu time      0.0079: real time      0.0387
+    --------------------------------------------
+      LOOP:  cpu time     16.2958: real time     16.5308
+
+ eigenvalue-minimisations  :  6975
+ total energy-change (2. order) :-0.4765582E-04  (-0.6109131E-04)
+ number of electron     598.0000028 magnetization 
+ augmentation part      257.3657176 magnetization 
+
+ Broyden mixing:
+  rms(total) = 0.37995E-02    rms(broyden)= 0.37983E-02
+  rms(prec ) = 0.51406E-02
+  weight for this iteration     100.00
+
+ eigenvalues of (default mixing * dielectric matrix)
+  average eigenvalue GAMMA=   0.6453
+  3.4879  2.6712  2.6712  1.6843  1.6843  1.4128  1.1697  1.1697  0.7935  0.7935
+  0.6402  0.6126  0.6126  0.4799  0.4467  0.3821  0.3303  0.3303  0.2289  0.2289
+  0.2649  0.2469  0.1786  0.1513  0.1513  0.1345  0.1289  0.1007  0.1007  0.0867
+  0.0867  0.0810  0.0698  0.0713  0.0639  0.0654  0.0623
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =      4840.36664911
+  Ewald energy   TEWEN  =    -61578.18855354
+  -Hartree energ DENC   =    -22139.58720528
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      2315.84446747
+  PAW double counting   =     86620.04004900   -88376.39593560
+  entropy T*S    EENTRO =        -0.00570903
+  eigenvalues    EBANDS =     -7387.38049482
+  atomic energy  EATOM  =     85349.93293081
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -355.37380186 eV
+
+  energy without entropy =     -355.36809284  energy(sigma->0) =     -355.37189885
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+--------------------------------------- Iteration      1(  43)  ---------------------------------------
+
+
+    POTLOK:  cpu time      0.0930: real time      0.1018
+    SETDIJ:  cpu time      0.5097: real time      0.5126
+    EDDIAG:  cpu time      2.3246: real time      2.4155
+  RMM-DIIS:  cpu time     11.2689: real time     11.3723
+    ORTHCH:  cpu time      0.3635: real time      0.3688
+       DOS:  cpu time      0.0023: real time      0.0023
+    --------------------------------------------
+      LOOP:  cpu time     14.5620: real time     14.7733
+
+ eigenvalue-minimisations  :  6367
+ total energy-change (2. order) :-0.2887145E-04  (-0.3490627E-04)
+ number of electron     598.0000028 magnetization 
+ augmentation part      257.3657176 magnetization 
+
+ Free energy of the ion-electron system (eV)
+  ---------------------------------------------------
+  alpha Z        PSCENC =      4840.36664911
+  Ewald energy   TEWEN  =    -61578.18855354
+  -Hartree energ DENC   =    -22139.52298257
+  -exchange      EXHF   =         0.00000000
+  -V(xc)+E(xc)   XCENC  =      2315.84316923
+  PAW double counting   =     86620.81243963   -88377.17049764
+  entropy T*S    EENTRO =        -0.00569946
+  eigenvalues    EBANDS =     -7387.44128630
+  atomic energy  EATOM  =     85349.93293081
+  Solvation  Ediel_sol  =         0.00000000
+  ---------------------------------------------------
+  free energy    TOTEN  =      -355.37383073 eV
+
+  energy without entropy =     -355.36813127  energy(sigma->0) =     -355.37193091
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+
+ average (electrostatic) potential at core
+  the test charge radii are     1.0025  0.9577  0.9500  1.0452  0.8614  0.8297  0.9521  1.2780  1.0638  1.2125)
+
+
+ average (electrostatic) potential at core
+  the test charge radii are     1.1533  1.1074  1.1199  1.1823  1.2793  1.2059
+  (the norm of the test charge is              1.0000)
+       1 -69.6305       2 -69.4091       3 -69.4734       4 -67.5568       5 -67.4177
+       6 -67.3781       7 -67.4967       8 -67.4349       9 -76.0122      10 -76.0005
+      11 -76.0508      12 -80.9510      13 -79.9503      14 -79.7853      15 -79.6062
+      16 -79.8490      17 -79.6343      18 -79.4389      19 -79.4391      20 -79.6542
+      21 -32.0788      22 -32.1977      23 -32.3809      24 -32.4343      25 -32.2244
+      26 -32.3626      27 -32.1202      28 -75.7257      29 -76.1338      30 -75.9974
+      31 -76.0852      32 -33.4211      33 -33.4046      34 -33.3699      35 -33.7210
+      36 -33.4009      37 -65.9971      38 -65.8809      39 -74.9581      40 -73.8452
+      41 -38.1995      42 -38.2680      43 -38.2077      44 -51.1042      45 -51.0207
+      46 -51.0967      47 -67.2429      48 -67.1335
+ 
+ 
+ 
+ E-fermi :   7.0743     XC(G=0): -12.3202     alpha+bet :-14.3008
+
+ Fermi energy:         7.0743228788
+
+ k-point     1 :       0.0000    0.0000    0.0000
+  band No.  band energies     occupation 
+      1     -63.1770      2.00000
+      2     -63.1576      2.00000
+      3     -63.1335      2.00000
+      4     -63.0842      2.00000
+      5     -63.0026      2.00000
+      6     -63.0021      2.00000
+      7     -62.9859      2.00000
+      8     -62.9508      2.00000
+      9     -62.8858      2.00000
+     10     -62.8551      2.00000
+     11     -62.8202      2.00000
+     12     -62.8025      2.00000
+     13     -56.3565      2.00000
+     14     -56.3257      2.00000
+     15     -56.2807      2.00000
+     16     -56.2466      2.00000
+     17     -56.2456      2.00000
+     18     -56.2251      2.00000
+     19     -56.1660      2.00000
+     20     -56.1207      2.00000
+     21     -56.0999      2.00000
+     22     -56.0232      2.00000
+     23     -55.9880      2.00000
+     24     -55.9328      2.00000
+     25     -45.6027      2.00000
+     26     -45.5571      2.00000
+     27     -45.5541      2.00000
+     28     -45.5234      2.00000
+     29     -45.5042      2.00000
+     30     -45.5041      2.00000
+     31     -45.4014      2.00000
+     32     -45.3915      2.00000
+     33     -45.3903      2.00000
+     34     -41.4024      2.00000
+     35     -41.2494      2.00000
+     36     -41.1016      2.00000
+     37     -40.9704      2.00000
+     38     -40.7839      2.00000
+     39     -40.7514      2.00000
+     40     -40.7318      2.00000
+     41     -40.7135      2.00000
+     42     -40.7121      2.00000
+     43     -40.6800      2.00000
+     44     -40.6228      2.00000
+     45     -40.6113      2.00000
+     46     -40.5896      2.00000
+     47     -40.5789      2.00000
+     48     -40.5533      2.00000
+     49     -40.4993      2.00000
+     50     -40.4943      2.00000
+     51     -40.4923      2.00000
+     52     -40.4603      2.00000
+     53     -39.0261      2.00000
+     54     -38.9845      2.00000
+     55     -38.8845      2.00000
+     56     -35.9478      2.00000
+     57     -35.8923      2.00000
+     58     -35.8128      2.00000
+     59     -35.8012      2.00000
+     60     -35.7856      2.00000
+     61     -35.7650      2.00000
+     62     -35.6926      2.00000
+     63     -35.6598      2.00000
+     64     -35.6339      2.00000
+     65     -34.4712      2.00000
+     66     -34.4417      2.00000
+     67     -34.3606      2.00000
+     68     -34.2353      2.00000
+     69     -34.1723      2.00000
+     70     -30.9606      2.00000
+     71     -30.8233      2.00000
+     72     -30.8156      2.00000
+     73     -30.7935      2.00000
+     74     -30.7636      2.00000
+     75     -30.7231      2.00000
+     76     -30.6757      2.00000
+     77     -30.6658      2.00000
+     78     -30.5176      2.00000
+     79     -27.8189      2.00000
+     80     -27.8078      2.00000
+     81     -27.7451      2.00000
+     82     -27.7255      2.00000
+     83     -27.6900      2.00000
+     84     -27.6204      2.00000
+     85     -24.0418      2.00000
+     86     -23.9949      2.00000
+     87     -23.9416      2.00000
+     88     -23.9372      2.00000
+     89     -23.9176      2.00000
+     90     -23.8118      2.00000
+     91     -23.7954      2.00000
+     92     -23.7636      2.00000
+     93     -23.7549      2.00000
+     94     -23.7378      2.00000
+     95     -23.7034      2.00000
+     96     -23.6764      2.00000
+     97     -23.6055      2.00000
+     98     -23.4823      2.00000
+     99     -23.3458      2.00000
+    100     -20.2540      2.00000
+    101     -19.8132      2.00000
+    102     -19.4636      2.00000
+    103     -19.4363      2.00000
+    104     -19.3152      2.00000
+    105     -19.3070      2.00000
+    106     -19.2626      2.00000
+    107     -19.2056      2.00000
+    108     -19.1501      2.00000
+    109     -19.0521      2.00000
+    110     -19.0292      2.00000
+    111     -18.7009      2.00000
+    112     -15.2391      2.00000
+    113     -14.7249      2.00000
+    114     -14.6723      2.00000
+    115     -14.6283      2.00000
+    116     -14.6155      2.00000
+    117     -14.6049      2.00000
+    118     -14.5802      2.00000
+    119     -14.5622      2.00000
+    120     -14.5211      2.00000
+    121     -14.4687      2.00000
+    122     -14.4147      2.00000
+    123     -14.3907      2.00000
+    124     -14.3757      2.00000
+    125     -14.3229      2.00000
+    126     -14.1293      2.00000
+    127      -0.4554      2.00000
+    128       0.1347      2.00000
+    129       0.1530      2.00000
+    130       0.1708      2.00000
+    131       0.1832      2.00000
+    132       0.2123      2.00000
+    133       0.2788      2.00000
+    134       0.3059      2.00000
+    135       0.3194      2.00000
+    136       0.3414      2.00000
+    137       0.3621      2.00000
+    138       0.6160      2.00000
+    139       0.8404      2.00000
+    140       1.4977      2.00000
+    141       1.6427      2.00000
+    142       2.0455      2.00000
+    143       2.1062      2.00000
+    144       2.2831      2.00000
+    145       2.3199      2.00000
+    146       2.3250      2.00000
+    147       2.3649      2.00000
+    148       2.4310      2.00000
+    149       2.4914      2.00000
+    150       2.5344      2.00000
+    151       2.5897      2.00000
+    152       2.6651      2.00000
+    153       2.7123      2.00000
+    154       2.7651      2.00000
+    155       2.8085      2.00000
+    156       2.8994      2.00000
+    157       2.9489      2.00000
+    158       3.0268      2.00000
+    159       3.0555      2.00000
+    160       3.1179      2.00000
+    161       3.1329      2.00000
+    162       3.1551      2.00000
+    163       3.1839      2.00000
+    164       3.2228      2.00000
+    165       3.2914      2.00000
+    166       3.3130      2.00000
+    167       3.3430      2.00000
+    168       3.3831      2.00000
+    169       3.4214      2.00000
+    170       3.5096      2.00000
+    171       3.5217      2.00000
+    172       3.5434      2.00000
+    173       3.5727      2.00000
+    174       3.6163      2.00000
+    175       3.6591      2.00000
+    176       3.7060      2.00000
+    177       3.7434      2.00000
+    178       3.7627      2.00000
+    179       3.8136      2.00000
+    180       3.8570      2.00000
+    181       3.8761      2.00000
+    182       3.8945      2.00000
+    183       3.9001      2.00000
+    184       3.9245      2.00000
+    185       3.9628      2.00000
+    186       3.9952      2.00000
+    187       4.0088      2.00000
+    188       4.0426      2.00000
+    189       4.0802      2.00000
+    190       4.0966      2.00000
+    191       4.1543      2.00000
+    192       4.1898      2.00000
+    193       4.2326      2.00000
+    194       4.2433      2.00000
+    195       4.2687      2.00000
+    196       4.3051      2.00000
+    197       4.3512      2.00000
+    198       4.3637      2.00000
+    199       4.4082      2.00000
+    200       4.4222      2.00000
+    201       4.4489      2.00000
+    202       4.4780      2.00000
+    203       4.5075      2.00000
+    204       4.5496      2.00000
+    205       4.5653      2.00000
+    206       4.5755      2.00000
+    207       4.6100      2.00000
+    208       4.6566      2.00000
+    209       4.7039      2.00000
+    210       4.7223      2.00000
+    211       4.7574      2.00000
+    212       4.7802      2.00000
+    213       4.8116      2.00000
+    214       4.8374      2.00000
+    215       4.9015      2.00000
+    216       4.9369      2.00000
+    217       4.9497      2.00000
+    218       4.9813      2.00000
+    219       5.0249      2.00000
+    220       5.0260      2.00000
+    221       5.0655      2.00000
+    222       5.0672      2.00000
+    223       5.1128      2.00000
+    224       5.1437      2.00000
+    225       5.1867      2.00000
+    226       5.1952      2.00000
+    227       5.2163      2.00000
+    228       5.2388      2.00000
+    229       5.2592      2.00000
+    230       5.3005      2.00000
+    231       5.3281      2.00000
+    232       5.3366      2.00000
+    233       5.3687      2.00000
+    234       5.3898      2.00000
+    235       5.4039      2.00000
+    236       5.4529      2.00000
+    237       5.4823      2.00000
+    238       5.4967      2.00000
+    239       5.5139      2.00000
+    240       5.5449      2.00000
+    241       5.5675      2.00000
+    242       5.6167      2.00000
+    243       5.6286      2.00000
+    244       5.6476      2.00000
+    245       5.6483      2.00000
+    246       5.6918      2.00000
+    247       5.7347      2.00000
+    248       5.7440      2.00000
+    249       5.7620      2.00000
+    250       5.7787      2.00000
+    251       5.8138      2.00000
+    252       5.8415      2.00000
+    253       5.8607      2.00000
+    254       5.8864      2.00000
+    255       5.9262      2.00000
+    256       5.9318      2.00000
+    257       5.9814      2.00000
+    258       5.9910      2.00000
+    259       6.0033      2.00000
+    260       6.0245      2.00000
+    261       6.0490      2.00000
+    262       6.0934      2.00000
+    263       6.1021      2.00000
+    264       6.1258      2.00000
+    265       6.1752      2.00000
+    266       6.1899      2.00000
+    267       6.1971      2.00000
+    268       6.2042      2.00000
+    269       6.2473      2.00000
+    270       6.2747      2.00000
+    271       6.2901      2.00000
+    272       6.3039      2.00000
+    273       6.3447      2.00000
+    274       6.3639      2.00000
+    275       6.3829      2.00000
+    276       6.4288      2.00000
+    277       6.4496      2.00000
+    278       6.4617      2.00000
+    279       6.5056      2.00000
+    280       6.5158      2.00000
+    281       6.5683      2.00000
+    282       6.5960      2.00000
+    283       6.6168      2.00000
+    284       6.6590      2.00000
+    285       6.6962      2.00000
+    286       6.7167      2.00000
+    287       6.7391      2.00000
+    288       6.7513      2.00000
+    289       6.7921      2.00000
+    290       6.8241      2.00000
+    291       6.8336      2.00000
+    292       6.8687      2.00000
+    293       6.8928      2.00000
+    294       6.9168      2.00008
+    295       6.9240      2.00018
+    296       6.9549      2.00377
+    297       6.9918      2.04159
+    298       7.0434      1.85575
+    299       7.0603      1.45411
+    300       7.0692      1.17270
+    301       7.0776      0.88770
+    302       7.1431     -0.06521
+    303       7.1628     -0.03129
+    304       7.2013     -0.00194
+    305       7.2286     -0.00011
+    306       7.2714     -0.00000
+    307       7.2916     -0.00000
+    308       7.3220     -0.00000
+    309       7.3506     -0.00000
+    310       7.3724     -0.00000
+    311       7.3974     -0.00000
+    312       7.4485     -0.00000
+    313       7.4874     -0.00000
+    314       7.5151     -0.00000
+    315       7.5722     -0.00000
+    316       7.6177     -0.00000
+    317       7.6399     -0.00000
+    318       7.6584     -0.00000
+    319       7.6929     -0.00000
+    320       7.7169     -0.00000
+    321       7.7365     -0.00000
+    322       7.7943     -0.00000
+    323       7.8225     -0.00000
+    324       7.8640     -0.00000
+    325       7.8845     -0.00000
+    326       7.9370     -0.00000
+    327       8.0007     -0.00000
+    328       8.0310     -0.00000
+    329       8.0696     -0.00000
+    330       8.1056     -0.00000
+    331       8.1964     -0.00000
+    332       8.2101     -0.00000
+    333       8.2345     -0.00000
+    334       8.2831     -0.00000
+    335       8.3319     -0.00000
+    336       8.4066     -0.00000
+    337       8.4175     -0.00000
+    338       8.5422      0.00000
+    339       8.5508      0.00000
+    340       8.6097      0.00000
+    341       8.7035      0.00000
+    342       8.7084      0.00000
+    343       8.7356      0.00000
+    344       8.8076      0.00000
+    345       8.8439      0.00000
+    346       8.9677      0.00000
+    347       9.0337      0.00000
+    348       9.0716      0.00000
+    349       9.1988      0.00000
+    350       9.2424      0.00000
+    351       9.3092      0.00000
+    352       9.3773      0.00000
+    353       9.4319      0.00000
+    354       9.4654      0.00000
+    355       9.6083      0.00000
+    356       9.7034      0.00000
+    357       9.8203      0.00000
+    358      10.0136      0.00000
+    359      10.1096      0.00000
+    360      10.3259      0.00000
+
+ k-point     2 :       0.5000    0.0000    0.0000
+  band No.  band energies     occupation 
+      1     -63.1771      2.00000
+      2     -63.1577      2.00000
+      3     -63.1336      2.00000
+      4     -63.0842      2.00000
+      5     -63.0026      2.00000
+      6     -63.0021      2.00000
+      7     -62.9859      2.00000
+      8     -62.9508      2.00000
+      9     -62.8858      2.00000
+     10     -62.8552      2.00000
+     11     -62.8202      2.00000
+     12     -62.8025      2.00000
+     13     -56.3565      2.00000
+     14     -56.3257      2.00000
+     15     -56.2807      2.00000
+     16     -56.2467      2.00000
+     17     -56.2456      2.00000
+     18     -56.2252      2.00000
+     19     -56.1661      2.00000
+     20     -56.1207      2.00000
+     21     -56.1000      2.00000
+     22     -56.0232      2.00000
+     23     -55.9880      2.00000
+     24     -55.9328      2.00000
+     25     -45.6027      2.00000
+     26     -45.5571      2.00000
+     27     -45.5541      2.00000
+     28     -45.5234      2.00000
+     29     -45.5042      2.00000
+     30     -45.5041      2.00000
+     31     -45.4014      2.00000
+     32     -45.3915      2.00000
+     33     -45.3903      2.00000
+     34     -41.4029      2.00000
+     35     -41.2480      2.00000
+     36     -41.1024      2.00000
+     37     -40.9704      2.00000
+     38     -40.7839      2.00000
+     39     -40.7515      2.00000
+     40     -40.7319      2.00000
+     41     -40.7135      2.00000
+     42     -40.7121      2.00000
+     43     -40.6800      2.00000
+     44     -40.6227      2.00000
+     45     -40.6113      2.00000
+     46     -40.5896      2.00000
+     47     -40.5789      2.00000
+     48     -40.5533      2.00000
+     49     -40.4993      2.00000
+     50     -40.4943      2.00000
+     51     -40.4923      2.00000
+     52     -40.4603      2.00000
+     53     -39.0261      2.00000
+     54     -38.9845      2.00000
+     55     -38.8845      2.00000
+     56     -35.9478      2.00000
+     57     -35.8923      2.00000
+     58     -35.8128      2.00000
+     59     -35.8012      2.00000
+     60     -35.7856      2.00000
+     61     -35.7650      2.00000
+     62     -35.6926      2.00000
+     63     -35.6598      2.00000
+     64     -35.6339      2.00000
+     65     -34.4710      2.00000
+     66     -34.4419      2.00000
+     67     -34.3606      2.00000
+     68     -34.2354      2.00000
+     69     -34.1723      2.00000
+     70     -30.9606      2.00000
+     71     -30.8233      2.00000
+     72     -30.8156      2.00000
+     73     -30.7935      2.00000
+     74     -30.7636      2.00000
+     75     -30.7231      2.00000
+     76     -30.6757      2.00000
+     77     -30.6658      2.00000
+     78     -30.5176      2.00000
+     79     -27.8189      2.00000
+     80     -27.8078      2.00000
+     81     -27.7451      2.00000
+     82     -27.7255      2.00000
+     83     -27.6900      2.00000
+     84     -27.6204      2.00000
+     85     -24.0306      2.00000
+     86     -23.9949      2.00000
+     87     -23.9573      2.00000
+     88     -23.9394      2.00000
+     89     -23.9176      2.00000
+     90     -23.8122      2.00000
+     91     -23.7929      2.00000
+     92     -23.7693      2.00000
+     93     -23.7497      2.00000
+     94     -23.7326      2.00000
+     95     -23.7029      2.00000
+     96     -23.6792      2.00000
+     97     -23.6024      2.00000
+     98     -23.4814      2.00000
+     99     -23.3478      2.00000
+    100     -20.2538      2.00000
+    101     -19.8135      2.00000
+    102     -19.4645      2.00000
+    103     -19.4363      2.00000
+    104     -19.3132      2.00000
+    105     -19.3073      2.00000
+    106     -19.2628      2.00000
+    107     -19.2066      2.00000
+    108     -19.1508      2.00000
+    109     -19.0521      2.00000
+    110     -19.0289      2.00000
+    111     -18.7011      2.00000
+    112     -15.2312      2.00000
+    113     -14.7270      2.00000
+    114     -14.6726      2.00000
+    115     -14.6298      2.00000
+    116     -14.6132      2.00000
+    117     -14.6051      2.00000
+    118     -14.5798      2.00000
+    119     -14.5632      2.00000
+    120     -14.5203      2.00000
+    121     -14.4696      2.00000
+    122     -14.4141      2.00000
+    123     -14.3917      2.00000
+    124     -14.3755      2.00000
+    125     -14.3232      2.00000
+    126     -14.1343      2.00000
+    127       0.0760      2.00000
+    128       0.1291      2.00000
+    129       0.1666      2.00000
+    130       0.1846      2.00000
+    131       0.2006      2.00000
+    132       0.2203      2.00000
+    133       0.2714      2.00000
+    134       0.2841      2.00000
+    135       0.3076      2.00000
+    136       0.3312      2.00000
+    137       0.3424      2.00000
+    138       0.3850      2.00000
+    139       1.0189      2.00000
+    140       1.2743      2.00000
+    141       1.4245      2.00000
+    142       1.5593      2.00000
+    143       2.2283      2.00000
+    144       2.3236      2.00000
+    145       2.3442      2.00000
+    146       2.4314      2.00000
+    147       2.4556      2.00000
+    148       2.5282      2.00000
+    149       2.5635      2.00000
+    150       2.5816      2.00000
+    151       2.6110      2.00000
+    152       2.6803      2.00000
+    153       2.7195      2.00000
+    154       2.8130      2.00000
+    155       2.8531      2.00000
+    156       2.8820      2.00000
+    157       2.9196      2.00000
+    158       2.9571      2.00000
+    159       3.0295      2.00000
+    160       3.0717      2.00000
+    161       3.1356      2.00000
+    162       3.1730      2.00000
+    163       3.1938      2.00000
+    164       3.2215      2.00000
+    165       3.2743      2.00000
+    166       3.2967      2.00000
+    167       3.3251      2.00000
+    168       3.3405      2.00000
+    169       3.4055      2.00000
+    170       3.4211      2.00000
+    171       3.4416      2.00000
+    172       3.5069      2.00000
+    173       3.5445      2.00000
+    174       3.6416      2.00000
+    175       3.6611      2.00000
+    176       3.6936      2.00000
+    177       3.7093      2.00000
+    178       3.7359      2.00000
+    179       3.8143      2.00000
+    180       3.8499      2.00000
+    181       3.8654      2.00000
+    182       3.8697      2.00000
+    183       3.8960      2.00000
+    184       3.9214      2.00000
+    185       3.9491      2.00000
+    186       3.9720      2.00000
+    187       4.0099      2.00000
+    188       4.0258      2.00000
+    189       4.0359      2.00000
+    190       4.0586      2.00000
+    191       4.0824      2.00000
+    192       4.1195      2.00000
+    193       4.1530      2.00000
+    194       4.1803      2.00000
+    195       4.2194      2.00000
+    196       4.2633      2.00000
+    197       4.3205      2.00000
+    198       4.3356      2.00000
+    199       4.3552      2.00000
+    200       4.4128      2.00000
+    201       4.4516      2.00000
+    202       4.4768      2.00000
+    203       4.5094      2.00000
+    204       4.5746      2.00000
+    205       4.5909      2.00000
+    206       4.6101      2.00000
+    207       4.6534      2.00000
+    208       4.6932      2.00000
+    209       4.7211      2.00000
+    210       4.7501      2.00000
+    211       4.7746      2.00000
+    212       4.8148      2.00000
+    213       4.8251      2.00000
+    214       4.8925      2.00000
+    215       4.8987      2.00000
+    216       4.9302      2.00000
+    217       4.9530      2.00000
+    218       4.9877      2.00000
+    219       5.0149      2.00000
+    220       5.0384      2.00000
+    221       5.0731      2.00000
+    222       5.0797      2.00000
+    223       5.0960      2.00000
+    224       5.1244      2.00000
+    225       5.1581      2.00000
+    226       5.1717      2.00000
+    227       5.2084      2.00000
+    228       5.2319      2.00000
+    229       5.2486      2.00000
+    230       5.2953      2.00000
+    231       5.3014      2.00000
+    232       5.3372      2.00000
+    233       5.3456      2.00000
+    234       5.3979      2.00000
+    235       5.4259      2.00000
+    236       5.4662      2.00000
+    237       5.4758      2.00000
+    238       5.4839      2.00000
+    239       5.5180      2.00000
+    240       5.5362      2.00000
+    241       5.5546      2.00000
+    242       5.6161      2.00000
+    243       5.6471      2.00000
+    244       5.6642      2.00000
+    245       5.6951      2.00000
+    246       5.7029      2.00000
+    247       5.7148      2.00000
+    248       5.7419      2.00000
+    249       5.7711      2.00000
+    250       5.7737      2.00000
+    251       5.8135      2.00000
+    252       5.8511      2.00000
+    253       5.8827      2.00000
+    254       5.9038      2.00000
+    255       5.9198      2.00000
+    256       5.9266      2.00000
+    257       5.9333      2.00000
+    258       5.9607      2.00000
+    259       5.9995      2.00000
+    260       6.0400      2.00000
+    261       6.0569      2.00000
+    262       6.0720      2.00000
+    263       6.1204      2.00000
+    264       6.1532      2.00000
+    265       6.1582      2.00000
+    266       6.1891      2.00000
+    267       6.2032      2.00000
+    268       6.2321      2.00000
+    269       6.2673      2.00000
+    270       6.2807      2.00000
+    271       6.2925      2.00000
+    272       6.3251      2.00000
+    273       6.3441      2.00000
+    274       6.3806      2.00000
+    275       6.3968      2.00000
+    276       6.4387      2.00000
+    277       6.4470      2.00000
+    278       6.4681      2.00000
+    279       6.4903      2.00000
+    280       6.5240      2.00000
+    281       6.5475      2.00000
+    282       6.5624      2.00000
+    283       6.5994      2.00000
+    284       6.6346      2.00000
+    285       6.6572      2.00000
+    286       6.6801      2.00000
+    287       6.7086      2.00000
+    288       6.7732      2.00000
+    289       6.8083      2.00000
+    290       6.8270      2.00000
+    291       6.8510      2.00000
+    292       6.8697      2.00000
+    293       6.8773      2.00000
+    294       6.9025      2.00001
+    295       6.9345      2.00056
+    296       6.9488      2.00222
+    297       6.9776      2.01963
+    298       7.0309      2.01078
+    299       7.0625      1.38678
+    300       7.0812      0.77062
+    301       7.1010      0.22424
+    302       7.1374     -0.07051
+    303       7.1520     -0.05036
+    304       7.2010     -0.00200
+    305       7.2343     -0.00006
+    306       7.2446     -0.00002
+    307       7.2754     -0.00000
+    308       7.2958     -0.00000
+    309       7.3565     -0.00000
+    310       7.3962     -0.00000
+    311       7.4108     -0.00000
+    312       7.4219     -0.00000
+    313       7.4831     -0.00000
+    314       7.5321     -0.00000
+    315       7.5401     -0.00000
+    316       7.5795     -0.00000
+    317       7.6197     -0.00000
+    318       7.6774     -0.00000
+    319       7.6988     -0.00000
+    320       7.7587     -0.00000
+    321       7.7850     -0.00000
+    322       7.8258     -0.00000
+    323       7.8382     -0.00000
+    324       7.9291     -0.00000
+    325       7.9659     -0.00000
+    326       7.9957     -0.00000
+    327       8.0216     -0.00000
+    328       8.0574     -0.00000
+    329       8.1135     -0.00000
+    330       8.1206     -0.00000
+    331       8.1913     -0.00000
+    332       8.2424     -0.00000
+    333       8.2626     -0.00000
+    334       8.3021     -0.00000
+    335       8.3743     -0.00000
+    336       8.4864      0.00000
+    337       8.5433      0.00000
+    338       8.5708      0.00000
+    339       8.6349      0.00000
+    340       8.6444      0.00000
+    341       8.6887      0.00000
+    342       8.7645      0.00000
+    343       8.7956      0.00000
+    344       8.8503      0.00000
+    345       8.9201      0.00000
+    346       8.9445      0.00000
+    347       9.0475      0.00000
+    348       9.0769      0.00000
+    349       9.1446      0.00000
+    350       9.1952      0.00000
+    351       9.2686      0.00000
+    352       9.3363      0.00000
+    353       9.3825      0.00000
+    354       9.4229      0.00000
+    355       9.5792      0.00000
+    356       9.6475      0.00000
+    357       9.7796      0.00000
+    358       9.8899      0.00000
+    359      10.1642      0.00000
+    360      10.3241      0.00000
+
+ k-point     3 :       0.0000    0.5000    0.0000
+  band No.  band energies     occupation 
+      1     -63.1770      2.00000
+      2     -63.1576      2.00000
+      3     -63.1336      2.00000
+      4     -63.0842      2.00000
+      5     -63.0026      2.00000
+      6     -63.0022      2.00000
+      7     -62.9859      2.00000
+      8     -62.9508      2.00000
+      9     -62.8858      2.00000
+     10     -62.8551      2.00000
+     11     -62.8202      2.00000
+     12     -62.8025      2.00000
+     13     -56.3566      2.00000
+     14     -56.3257      2.00000
+     15     -56.2807      2.00000
+     16     -56.2466      2.00000
+     17     -56.2457      2.00000
+     18     -56.2252      2.00000
+     19     -56.1660      2.00000
+     20     -56.1207      2.00000
+     21     -56.1000      2.00000
+     22     -56.0232      2.00000
+     23     -55.9881      2.00000
+     24     -55.9329      2.00000
+     25     -45.6027      2.00000
+     26     -45.5570      2.00000
+     27     -45.5541      2.00000
+     28     -45.5234      2.00000
+     29     -45.5042      2.00000
+     30     -45.5041      2.00000
+     31     -45.4014      2.00000
+     32     -45.3915      2.00000
+     33     -45.3903      2.00000
+     34     -41.4024      2.00000
+     35     -41.2494      2.00000
+     36     -41.1016      2.00000
+     37     -40.9704      2.00000
+     38     -40.7839      2.00000
+     39     -40.7514      2.00000
+     40     -40.7319      2.00000
+     41     -40.7135      2.00000
+     42     -40.7121      2.00000
+     43     -40.6800      2.00000
+     44     -40.6228      2.00000
+     45     -40.6113      2.00000
+     46     -40.5896      2.00000
+     47     -40.5789      2.00000
+     48     -40.5533      2.00000
+     49     -40.4993      2.00000
+     50     -40.4943      2.00000
+     51     -40.4923      2.00000
+     52     -40.4603      2.00000
+     53     -39.0261      2.00000
+     54     -38.9845      2.00000
+     55     -38.8845      2.00000
+     56     -35.9478      2.00000
+     57     -35.8923      2.00000
+     58     -35.8128      2.00000
+     59     -35.8011      2.00000
+     60     -35.7856      2.00000
+     61     -35.7650      2.00000
+     62     -35.6926      2.00000
+     63     -35.6598      2.00000
+     64     -35.6338      2.00000
+     65     -34.4710      2.00000
+     66     -34.4418      2.00000
+     67     -34.3607      2.00000
+     68     -34.2354      2.00000
+     69     -34.1722      2.00000
+     70     -30.9606      2.00000
+     71     -30.8234      2.00000
+     72     -30.8156      2.00000
+     73     -30.7935      2.00000
+     74     -30.7636      2.00000
+     75     -30.7231      2.00000
+     76     -30.6757      2.00000
+     77     -30.6658      2.00000
+     78     -30.5176      2.00000
+     79     -27.8189      2.00000
+     80     -27.8078      2.00000
+     81     -27.7451      2.00000
+     82     -27.7255      2.00000
+     83     -27.6900      2.00000
+     84     -27.6204      2.00000
+     85     -24.0432      2.00000
+     86     -23.9949      2.00000
+     87     -23.9414      2.00000
+     88     -23.9370      2.00000
+     89     -23.9176      2.00000
+     90     -23.8110      2.00000
+     91     -23.7963      2.00000
+     92     -23.7626      2.00000
+     93     -23.7556      2.00000
+     94     -23.7380      2.00000
+     95     -23.7027      2.00000
+     96     -23.6762      2.00000
+     97     -23.6032      2.00000
+     98     -23.4820      2.00000
+     99     -23.3483      2.00000
+    100     -20.2539      2.00000
+    101     -19.8132      2.00000
+    102     -19.4637      2.00000
+    103     -19.4364      2.00000
+    104     -19.3153      2.00000
+    105     -19.3072      2.00000
+    106     -19.2626      2.00000
+    107     -19.2055      2.00000
+    108     -19.1508      2.00000
+    109     -19.0521      2.00000
+    110     -19.0292      2.00000
+    111     -18.7010      2.00000
+    112     -15.2310      2.00000
+    113     -14.7264      2.00000
+    114     -14.6720      2.00000
+    115     -14.6302      2.00000
+    116     -14.6130      2.00000
+    117     -14.6052      2.00000
+    118     -14.5796      2.00000
+    119     -14.5629      2.00000
+    120     -14.5214      2.00000
+    121     -14.4707      2.00000
+    122     -14.4127      2.00000
+    123     -14.3927      2.00000
+    124     -14.3755      2.00000
+    125     -14.3232      2.00000
+    126     -14.1343      2.00000
+    127      -0.0271      2.00000
+    128       0.1347      2.00000
+    129       0.1586      2.00000
+    130       0.1752      2.00000
+    131       0.1927      2.00000
+    132       0.2162      2.00000
+    133       0.2720      2.00000
+    134       0.3035      2.00000
+    135       0.3317      2.00000
+    136       0.3434      2.00000
+    137       0.3681      2.00000
+    138       0.4959      2.00000
+    139       1.0073      2.00000
+    140       1.1362      2.00000
+    141       1.5327      2.00000
+    142       1.8910      2.00000
+    143       2.0627      2.00000
+    144       2.1927      2.00000
+    145       2.2418      2.00000
+    146       2.3263      2.00000
+    147       2.3536      2.00000
+    148       2.4466      2.00000
+    149       2.5108      2.00000
+    150       2.6010      2.00000
+    151       2.6429      2.00000
+    152       2.6900      2.00000
+    153       2.7429      2.00000
+    154       2.7847      2.00000
+    155       2.8480      2.00000
+    156       2.9125      2.00000
+    157       2.9624      2.00000
+    158       3.0067      2.00000
+    159       3.0395      2.00000
+    160       3.0838      2.00000
+    161       3.1492      2.00000
+    162       3.1724      2.00000
+    163       3.2016      2.00000
+    164       3.2719      2.00000
+    165       3.3084      2.00000
+    166       3.3243      2.00000
+    167       3.3499      2.00000
+    168       3.3831      2.00000
+    169       3.4547      2.00000
+    170       3.4809      2.00000
+    171       3.4957      2.00000
+    172       3.5096      2.00000
+    173       3.5578      2.00000
+    174       3.5893      2.00000
+    175       3.6143      2.00000
+    176       3.6630      2.00000
+    177       3.7178      2.00000
+    178       3.7559      2.00000
+    179       3.7646      2.00000
+    180       3.8110      2.00000
+    181       3.8409      2.00000
+    182       3.8755      2.00000
+    183       3.8920      2.00000
+    184       3.9274      2.00000
+    185       3.9448      2.00000
+    186       3.9601      2.00000
+    187       3.9653      2.00000
+    188       4.0180      2.00000
+    189       4.0249      2.00000
+    190       4.0710      2.00000
+    191       4.1356      2.00000
+    192       4.1680      2.00000
+    193       4.1932      2.00000
+    194       4.2413      2.00000
+    195       4.2522      2.00000
+    196       4.2945      2.00000
+    197       4.3223      2.00000
+    198       4.3678      2.00000
+    199       4.3850      2.00000
+    200       4.3957      2.00000
+    201       4.4291      2.00000
+    202       4.4498      2.00000
+    203       4.4753      2.00000
+    204       4.4871      2.00000
+    205       4.5067      2.00000
+    206       4.5670      2.00000
+    207       4.5722      2.00000
+    208       4.6414      2.00000
+    209       4.6782      2.00000
+    210       4.7341      2.00000
+    211       4.7625      2.00000
+    212       4.7862      2.00000
+    213       4.8368      2.00000
+    214       4.8517      2.00000
+    215       4.8767      2.00000
+    216       4.9407      2.00000
+    217       4.9586      2.00000
+    218       4.9810      2.00000
+    219       5.0059      2.00000
+    220       5.0360      2.00000
+    221       5.0708      2.00000
+    222       5.1093      2.00000
+    223       5.1170      2.00000
+    224       5.1514      2.00000
+    225       5.1580      2.00000
+    226       5.1859      2.00000
+    227       5.2015      2.00000
+    228       5.2230      2.00000
+    229       5.2380      2.00000
+    230       5.2893      2.00000
+    231       5.3225      2.00000
+    232       5.3351      2.00000
+    233       5.3625      2.00000
+    234       5.3956      2.00000
+    235       5.4128      2.00000
+    236       5.4545      2.00000
+    237       5.5056      2.00000
+    238       5.5274      2.00000
+    239       5.5477      2.00000
+    240       5.5845      2.00000
+    241       5.6210      2.00000
+    242       5.6536      2.00000
+    243       5.6565      2.00000
+    244       5.6953      2.00000
+    245       5.7010      2.00000
+    246       5.7092      2.00000
+    247       5.7385      2.00000
+    248       5.7426      2.00000
+    249       5.7631      2.00000
+    250       5.7872      2.00000
+    251       5.8337      2.00000
+    252       5.8515      2.00000
+    253       5.8572      2.00000
+    254       5.8817      2.00000
+    255       5.9054      2.00000
+    256       5.9297      2.00000
+    257       5.9407      2.00000
+    258       5.9703      2.00000
+    259       5.9853      2.00000
+    260       6.0166      2.00000
+    261       6.0532      2.00000
+    262       6.0692      2.00000
+    263       6.0975      2.00000
+    264       6.1097      2.00000
+    265       6.1370      2.00000
+    266       6.1539      2.00000
+    267       6.2183      2.00000
+    268       6.2294      2.00000
+    269       6.2522      2.00000
+    270       6.2801      2.00000
+    271       6.3060      2.00000
+    272       6.3406      2.00000
+    273       6.3832      2.00000
+    274       6.3864      2.00000
+    275       6.4130      2.00000
+    276       6.4310      2.00000
+    277       6.4447      2.00000
+    278       6.4824      2.00000
+    279       6.4963      2.00000
+    280       6.5329      2.00000
+    281       6.5378      2.00000
+    282       6.5847      2.00000
+    283       6.6038      2.00000
+    284       6.6447      2.00000
+    285       6.6772      2.00000
+    286       6.6816      2.00000
+    287       6.7217      2.00000
+    288       6.7463      2.00000
+    289       6.7853      2.00000
+    290       6.8073      2.00000
+    291       6.8400      2.00000
+    292       6.8730      2.00000
+    293       6.9028      2.00001
+    294       6.9108      2.00004
+    295       6.9415      2.00111
+    296       6.9564      2.00425
+    297       6.9910      2.04013
+    298       7.0182      2.06717
+    299       7.0457      1.81428
+    300       7.0753      0.96761
+    301       7.0945      0.37489
+    302       7.1243     -0.05008
+    303       7.1689     -0.02237
+    304       7.2038     -0.00154
+    305       7.2156     -0.00048
+    306       7.2510     -0.00001
+    307       7.3058     -0.00000
+    308       7.3462     -0.00000
+    309       7.3745     -0.00000
+    310       7.4132     -0.00000
+    311       7.4577     -0.00000
+    312       7.5106     -0.00000
+    313       7.5251     -0.00000
+    314       7.5507     -0.00000
+    315       7.5634     -0.00000
+    316       7.5980     -0.00000
+    317       7.6107     -0.00000
+    318       7.6274     -0.00000
+    319       7.7021     -0.00000
+    320       7.7276     -0.00000
+    321       7.7704     -0.00000
+    322       7.8147     -0.00000
+    323       7.8508     -0.00000
+    324       7.8802     -0.00000
+    325       7.8949     -0.00000
+    326       7.9258     -0.00000
+    327       7.9893     -0.00000
+    328       8.0457     -0.00000
+    329       8.1267     -0.00000
+    330       8.1834     -0.00000
+    331       8.2023     -0.00000
+    332       8.2413     -0.00000
+    333       8.2988     -0.00000
+    334       8.3343     -0.00000
+    335       8.3557     -0.00000
+    336       8.4992      0.00000
+    337       8.5193      0.00000
+    338       8.5541      0.00000
+    339       8.6075      0.00000
+    340       8.6214      0.00000
+    341       8.7027      0.00000
+    342       8.7625      0.00000
+    343       8.7984      0.00000
+    344       8.8549      0.00000
+    345       8.8748      0.00000
+    346       8.9513      0.00000
+    347       8.9610      0.00000
+    348       9.0362      0.00000
+    349       9.0987      0.00000
+    350       9.1735      0.00000
+    351       9.2595      0.00000
+    352       9.3975      0.00000
+    353       9.4506      0.00000
+    354       9.4847      0.00000
+    355       9.5427      0.00000
+    356       9.6448      0.00000
+    357       9.7469      0.00000
+    358       9.9127      0.00000
+    359       9.9817      0.00000
+    360      10.1454      0.00000
+
+ k-point     4 :       0.5000    0.5000    0.0000
+  band No.  band energies     occupation 
+      1     -63.1771      2.00000
+      2     -63.1577      2.00000
+      3     -63.1337      2.00000
+      4     -63.0843      2.00000
+      5     -63.0026      2.00000
+      6     -63.0022      2.00000
+      7     -62.9860      2.00000
+      8     -62.9509      2.00000
+      9     -62.8859      2.00000
+     10     -62.8552      2.00000
+     11     -62.8203      2.00000
+     12     -62.8026      2.00000
+     13     -56.3566      2.00000
+     14     -56.3257      2.00000
+     15     -56.2808      2.00000
+     16     -56.2467      2.00000
+     17     -56.2457      2.00000
+     18     -56.2253      2.00000
+     19     -56.1661      2.00000
+     20     -56.1207      2.00000
+     21     -56.1001      2.00000
+     22     -56.0233      2.00000
+     23     -55.9881      2.00000
+     24     -55.9329      2.00000
+     25     -45.6027      2.00000
+     26     -45.5570      2.00000
+     27     -45.5541      2.00000
+     28     -45.5234      2.00000
+     29     -45.5042      2.00000
+     30     -45.5041      2.00000
+     31     -45.4014      2.00000
+     32     -45.3915      2.00000
+     33     -45.3903      2.00000
+     34     -41.4029      2.00000
+     35     -41.2480      2.00000
+     36     -41.1024      2.00000
+     37     -40.9704      2.00000
+     38     -40.7839      2.00000
+     39     -40.7515      2.00000
+     40     -40.7319      2.00000
+     41     -40.7135      2.00000
+     42     -40.7121      2.00000
+     43     -40.6800      2.00000
+     44     -40.6227      2.00000
+     45     -40.6114      2.00000
+     46     -40.5896      2.00000
+     47     -40.5789      2.00000
+     48     -40.5533      2.00000
+     49     -40.4993      2.00000
+     50     -40.4943      2.00000
+     51     -40.4923      2.00000
+     52     -40.4603      2.00000
+     53     -39.0262      2.00000
+     54     -38.9845      2.00000
+     55     -38.8845      2.00000
+     56     -35.9478      2.00000
+     57     -35.8923      2.00000
+     58     -35.8128      2.00000
+     59     -35.8011      2.00000
+     60     -35.7856      2.00000
+     61     -35.7650      2.00000
+     62     -35.6926      2.00000
+     63     -35.6598      2.00000
+     64     -35.6338      2.00000
+     65     -34.4709      2.00000
+     66     -34.4419      2.00000
+     67     -34.3606      2.00000
+     68     -34.2354      2.00000
+     69     -34.1722      2.00000
+     70     -30.9606      2.00000
+     71     -30.8234      2.00000
+     72     -30.8156      2.00000
+     73     -30.7935      2.00000
+     74     -30.7636      2.00000
+     75     -30.7231      2.00000
+     76     -30.6757      2.00000
+     77     -30.6658      2.00000
+     78     -30.5176      2.00000
+     79     -27.8189      2.00000
+     80     -27.8078      2.00000
+     81     -27.7451      2.00000
+     82     -27.7255      2.00000
+     83     -27.6900      2.00000
+     84     -27.6204      2.00000
+     85     -24.0281      2.00000
+     86     -23.9949      2.00000
+     87     -23.9589      2.00000
+     88     -23.9395      2.00000
+     89     -23.9176      2.00000
+     90     -23.8122      2.00000
+     91     -23.7930      2.00000
+     92     -23.7695      2.00000
+     93     -23.7494      2.00000
+     94     -23.7321      2.00000
+     95     -23.7035      2.00000
+     96     -23.6800      2.00000
+     97     -23.6047      2.00000
+     98     -23.4818      2.00000
+     99     -23.3453      2.00000
+    100     -20.2538      2.00000
+    101     -19.8136      2.00000
+    102     -19.4645      2.00000
+    103     -19.4364      2.00000
+    104     -19.3132      2.00000
+    105     -19.3071      2.00000
+    106     -19.2628      2.00000
+    107     -19.2064      2.00000
+    108     -19.1501      2.00000
+    109     -19.0521      2.00000
+    110     -19.0288      2.00000
+    111     -18.7011      2.00000
+    112     -15.2379      2.00000
+    113     -14.7247      2.00000
+    114     -14.6721      2.00000
+    115     -14.6285      2.00000
+    116     -14.6156      2.00000
+    117     -14.6048      2.00000
+    118     -14.5801      2.00000
+    119     -14.5639      2.00000
+    120     -14.5219      2.00000
+    121     -14.4696      2.00000
+    122     -14.4124      2.00000
+    123     -14.3920      2.00000
+    124     -14.3752      2.00000
+    125     -14.3231      2.00000
+    126     -14.1291      2.00000
+    127       0.1288      2.00000
+    128       0.1322      2.00000
+    129       0.1665      2.00000
+    130       0.1865      2.00000
+    131       0.2197      2.00000
+    132       0.2713      2.00000
+    133       0.2960      2.00000
+    134       0.3182      2.00000
+    135       0.3387      2.00000
+    136       0.3734      2.00000
+    137       0.4840      2.00000
+    138       0.5839      2.00000
+    139       0.9550      2.00000
+    140       1.1789      2.00000
+    141       1.5482      2.00000
+    142       1.6386      2.00000
+    143       1.7215      2.00000
+    144       1.9961      2.00000
+    145       2.0412      2.00000
+    146       2.1599      2.00000
+    147       2.2383      2.00000
+    148       2.4373      2.00000
+    149       2.5366      2.00000
+    150       2.5835      2.00000
+    151       2.6396      2.00000
+    152       2.6861      2.00000
+    153       2.7960      2.00000
+    154       2.8349      2.00000
+    155       2.8770      2.00000
+    156       2.9333      2.00000
+    157       2.9690      2.00000
+    158       3.0315      2.00000
+    159       3.0630      2.00000
+    160       3.1290      2.00000
+    161       3.1801      2.00000
+    162       3.2037      2.00000
+    163       3.2596      2.00000
+    164       3.2785      2.00000
+    165       3.3275      2.00000
+    166       3.3668      2.00000
+    167       3.4027      2.00000
+    168       3.4457      2.00000
+    169       3.4689      2.00000
+    170       3.5006      2.00000
+    171       3.5151      2.00000
+    172       3.5692      2.00000
+    173       3.5947      2.00000
+    174       3.6097      2.00000
+    175       3.6483      2.00000
+    176       3.6681      2.00000
+    177       3.6828      2.00000
+    178       3.7430      2.00000
+    179       3.7665      2.00000
+    180       3.7894      2.00000
+    181       3.8235      2.00000
+    182       3.8360      2.00000
+    183       3.8647      2.00000
+    184       3.9167      2.00000
+    185       3.9419      2.00000
+    186       3.9646      2.00000
+    187       4.0083      2.00000
+    188       4.0451      2.00000
+    189       4.0592      2.00000
+    190       4.1053      2.00000
+    191       4.1306      2.00000
+    192       4.1591      2.00000
+    193       4.2004      2.00000
+    194       4.2202      2.00000
+    195       4.2637      2.00000
+    196       4.2775      2.00000
+    197       4.3249      2.00000
+    198       4.3655      2.00000
+    199       4.4045      2.00000
+    200       4.4087      2.00000
+    201       4.4398      2.00000
+    202       4.4603      2.00000
+    203       4.4730      2.00000
+    204       4.4984      2.00000
+    205       4.5348      2.00000
+    206       4.5833      2.00000
+    207       4.6040      2.00000
+    208       4.6666      2.00000
+    209       4.6996      2.00000
+    210       4.7192      2.00000
+    211       4.7504      2.00000
+    212       4.7589      2.00000
+    213       4.8021      2.00000
+    214       4.8350      2.00000
+    215       4.8606      2.00000
+    216       4.8781      2.00000
+    217       4.8949      2.00000
+    218       4.9177      2.00000
+    219       4.9593      2.00000
+    220       5.0020      2.00000
+    221       5.0174      2.00000
+    222       5.0312      2.00000
+    223       5.0693      2.00000
+    224       5.1096      2.00000
+    225       5.1282      2.00000
+    226       5.1632      2.00000
+    227       5.1870      2.00000
+    228       5.2447      2.00000
+    229       5.2460      2.00000
+    230       5.2927      2.00000
+    231       5.3340      2.00000
+    232       5.3627      2.00000
+    233       5.3682      2.00000
+    234       5.3975      2.00000
+    235       5.4125      2.00000
+    236       5.4314      2.00000
+    237       5.4633      2.00000
+    238       5.5058      2.00000
+    239       5.5316      2.00000
+    240       5.5572      2.00000
+    241       5.5819      2.00000
+    242       5.6313      2.00000
+    243       5.6390      2.00000
+    244       5.6483      2.00000
+    245       5.6816      2.00000
+    246       5.7016      2.00000
+    247       5.7082      2.00000
+    248       5.7767      2.00000
+    249       5.7877      2.00000
+    250       5.8272      2.00000
+    251       5.8483      2.00000
+    252       5.8803      2.00000
+    253       5.8980      2.00000
+    254       5.9036      2.00000
+    255       5.9195      2.00000
+    256       5.9425      2.00000
+    257       5.9627      2.00000
+    258       5.9903      2.00000
+    259       5.9973      2.00000
+    260       6.0213      2.00000
+    261       6.0423      2.00000
+    262       6.0777      2.00000
+    263       6.0931      2.00000
+    264       6.1153      2.00000
+    265       6.1464      2.00000
+    266       6.2019      2.00000
+    267       6.2162      2.00000
+    268       6.2385      2.00000
+    269       6.2528      2.00000
+    270       6.2750      2.00000
+    271       6.3000      2.00000
+    272       6.3136      2.00000
+    273       6.3530      2.00000
+    274       6.3783      2.00000
+    275       6.3883      2.00000
+    276       6.4187      2.00000
+    277       6.4623      2.00000
+    278       6.4653      2.00000
+    279       6.5216      2.00000
+    280       6.5295      2.00000
+    281       6.5416      2.00000
+    282       6.5645      2.00000
+    283       6.6122      2.00000
+    284       6.6433      2.00000
+    285       6.6738      2.00000
+    286       6.6870      2.00000
+    287       6.7022      2.00000
+    288       6.7355      2.00000
+    289       6.7661      2.00000
+    290       6.8140      2.00000
+    291       6.8299      2.00000
+    292       6.8708      2.00000
+    293       6.8840      2.00000
+    294       6.9079      2.00003
+    295       6.9264      2.00023
+    296       6.9427      2.00125
+    297       7.0229      2.05569
+    298       7.0360      1.96164
+    299       7.0621      1.40129
+    300       7.0805      0.79277
+    301       7.1124      0.04129
+    302       7.1392     -0.06947
+    303       7.1798     -0.01107
+    304       7.2104     -0.00082
+    305       7.2141     -0.00056
+    306       7.2576     -0.00000
+    307       7.2683     -0.00000
+    308       7.2849     -0.00000
+    309       7.3558     -0.00000
+    310       7.3946     -0.00000
+    311       7.4325     -0.00000
+    312       7.4779     -0.00000
+    313       7.5037     -0.00000
+    314       7.5411     -0.00000
+    315       7.5559     -0.00000
+    316       7.5788     -0.00000
+    317       7.5881     -0.00000
+    318       7.6317     -0.00000
+    319       7.6674     -0.00000
+    320       7.6964     -0.00000
+    321       7.7170     -0.00000
+    322       7.7684     -0.00000
+    323       7.7961     -0.00000
+    324       7.8407     -0.00000
+    325       7.9061     -0.00000
+    326       7.9715     -0.00000
+    327       7.9980     -0.00000
+    328       8.0472     -0.00000
+    329       8.0897     -0.00000
+    330       8.1114     -0.00000
+    331       8.1498     -0.00000
+    332       8.1944     -0.00000
+    333       8.2415     -0.00000
+    334       8.2922     -0.00000
+    335       8.3601     -0.00000
+    336       8.4286     -0.00000
+    337       8.5100      0.00000
+    338       8.5659      0.00000
+    339       8.6128      0.00000
+    340       8.6749      0.00000
+    341       8.7449      0.00000
+    342       8.8139      0.00000
+    343       8.8459      0.00000
+    344       8.9213      0.00000
+    345       9.0473      0.00000
+    346       9.0724      0.00000
+    347       9.0922      0.00000
+    348       9.1610      0.00000
+    349       9.2319      0.00000
+    350       9.2866      0.00000
+    351       9.3732      0.00000
+    352       9.4413      0.00000
+    353       9.5352      0.00000
+    354       9.6018      0.00000
+    355       9.7147      0.00000
+    356       9.8060      0.00000
+    357       9.8715      0.00000
+    358       9.9916      0.00000
+    359      10.0968      0.00000
+    360      10.2494      0.00000
+
+ k-point     5 :       0.0000    0.0000    0.5000
+  band No.  band energies     occupation 
+      1     -63.1770      2.00000
+      2     -63.1576      2.00000
+      3     -63.1336      2.00000
+      4     -63.0842      2.00000
+      5     -63.0026      2.00000
+      6     -63.0021      2.00000
+      7     -62.9859      2.00000
+      8     -62.9508      2.00000
+      9     -62.8858      2.00000
+     10     -62.8551      2.00000
+     11     -62.8202      2.00000
+     12     -62.8025      2.00000
+     13     -56.3565      2.00000
+     14     -56.3257      2.00000
+     15     -56.2807      2.00000
+     16     -56.2467      2.00000
+     17     -56.2456      2.00000
+     18     -56.2252      2.00000
+     19     -56.1660      2.00000
+     20     -56.1207      2.00000
+     21     -56.1000      2.00000
+     22     -56.0232      2.00000
+     23     -55.9880      2.00000
+     24     -55.9328      2.00000
+     25     -45.6027      2.00000
+     26     -45.5571      2.00000
+     27     -45.5541      2.00000
+     28     -45.5234      2.00000
+     29     -45.5042      2.00000
+     30     -45.5041      2.00000
+     31     -45.4014      2.00000
+     32     -45.3915      2.00000
+     33     -45.3903      2.00000
+     34     -41.4024      2.00000
+     35     -41.2494      2.00000
+     36     -41.1016      2.00000
+     37     -40.9704      2.00000
+     38     -40.7839      2.00000
+     39     -40.7514      2.00000
+     40     -40.7319      2.00000
+     41     -40.7135      2.00000
+     42     -40.7121      2.00000
+     43     -40.6800      2.00000
+     44     -40.6228      2.00000
+     45     -40.6114      2.00000
+     46     -40.5896      2.00000
+     47     -40.5789      2.00000
+     48     -40.5533      2.00000
+     49     -40.4993      2.00000
+     50     -40.4943      2.00000
+     51     -40.4924      2.00000
+     52     -40.4603      2.00000
+     53     -39.0261      2.00000
+     54     -38.9845      2.00000
+     55     -38.8845      2.00000
+     56     -35.9478      2.00000
+     57     -35.8923      2.00000
+     58     -35.8128      2.00000
+     59     -35.8012      2.00000
+     60     -35.7856      2.00000
+     61     -35.7650      2.00000
+     62     -35.6926      2.00000
+     63     -35.6598      2.00000
+     64     -35.6339      2.00000
+     65     -34.4712      2.00000
+     66     -34.4417      2.00000
+     67     -34.3606      2.00000
+     68     -34.2353      2.00000
+     69     -34.1723      2.00000
+     70     -30.9606      2.00000
+     71     -30.8233      2.00000
+     72     -30.8156      2.00000
+     73     -30.7935      2.00000
+     74     -30.7636      2.00000
+     75     -30.7231      2.00000
+     76     -30.6757      2.00000
+     77     -30.6658      2.00000
+     78     -30.5176      2.00000
+     79     -27.8189      2.00000
+     80     -27.8078      2.00000
+     81     -27.7451      2.00000
+     82     -27.7255      2.00000
+     83     -27.6900      2.00000
+     84     -27.6204      2.00000
+     85     -24.0418      2.00000
+     86     -23.9949      2.00000
+     87     -23.9416      2.00000
+     88     -23.9371      2.00000
+     89     -23.9176      2.00000
+     90     -23.8118      2.00000
+     91     -23.7954      2.00000
+     92     -23.7636      2.00000
+     93     -23.7549      2.00000
+     94     -23.7378      2.00000
+     95     -23.7034      2.00000
+     96     -23.6764      2.00000
+     97     -23.6055      2.00000
+     98     -23.4823      2.00000
+     99     -23.3458      2.00000
+    100     -20.2540      2.00000
+    101     -19.8132      2.00000
+    102     -19.4636      2.00000
+    103     -19.4363      2.00000
+    104     -19.3153      2.00000
+    105     -19.3069      2.00000
+    106     -19.2626      2.00000
+    107     -19.2056      2.00000
+    108     -19.1501      2.00000
+    109     -19.0521      2.00000
+    110     -19.0292      2.00000
+    111     -18.7009      2.00000
+    112     -15.2391      2.00000
+    113     -14.7248      2.00000
+    114     -14.6723      2.00000
+    115     -14.6283      2.00000
+    116     -14.6155      2.00000
+    117     -14.6049      2.00000
+    118     -14.5802      2.00000
+    119     -14.5622      2.00000
+    120     -14.5211      2.00000
+    121     -14.4687      2.00000
+    122     -14.4147      2.00000
+    123     -14.3907      2.00000
+    124     -14.3757      2.00000
+    125     -14.3229      2.00000
+    126     -14.1293      2.00000
+    127      -0.2268      2.00000
+    128      -0.0457      2.00000
+    129       0.1491      2.00000
+    130       0.1565      2.00000
+    131       0.1719      2.00000
+    132       0.1836      2.00000
+    133       0.2149      2.00000
+    134       0.2790      2.00000
+    135       0.3067      2.00000
+    136       0.3271      2.00000
+    137       0.3425      2.00000
+    138       0.3639      2.00000
+    139       1.3296      2.00000
+    140       1.6412      2.00000
+    141       1.6981      2.00000
+    142       1.9497      2.00000
+    143       2.1906      2.00000
+    144       2.2252      2.00000
+    145       2.2402      2.00000
+    146       2.2849      2.00000
+    147       2.3749      2.00000
+    148       2.4131      2.00000
+    149       2.4645      2.00000
+    150       2.5357      2.00000
+    151       2.5967      2.00000
+    152       2.6572      2.00000
+    153       2.6984      2.00000
+    154       2.7547      2.00000
+    155       2.8084      2.00000
+    156       2.8776      2.00000
+    157       2.9311      2.00000
+    158       2.9856      2.00000
+    159       3.0333      2.00000
+    160       3.0588      2.00000
+    161       3.1290      2.00000
+    162       3.1434      2.00000
+    163       3.1860      2.00000
+    164       3.2160      2.00000
+    165       3.2257      2.00000
+    166       3.2880      2.00000
+    167       3.3128      2.00000
+    168       3.3985      2.00000
+    169       3.4166      2.00000
+    170       3.4575      2.00000
+    171       3.5259      2.00000
+    172       3.5439      2.00000
+    173       3.5868      2.00000
+    174       3.6203      2.00000
+    175       3.7207      2.00000
+    176       3.7358      2.00000
+    177       3.8058      2.00000
+    178       3.8164      2.00000
+    179       3.8366      2.00000
+    180       3.8669      2.00000
+    181       3.8875      2.00000
+    182       3.9000      2.00000
+    183       3.9253      2.00000
+    184       3.9616      2.00000
+    185       3.9938      2.00000
+    186       4.0268      2.00000
+    187       4.0339      2.00000
+    188       4.0585      2.00000
+    189       4.1075      2.00000
+    190       4.1521      2.00000
+    191       4.1785      2.00000
+    192       4.1827      2.00000
+    193       4.2118      2.00000
+    194       4.2400      2.00000
+    195       4.2560      2.00000
+    196       4.2951      2.00000
+    197       4.3325      2.00000
+    198       4.3521      2.00000
+    199       4.3804      2.00000
+    200       4.4276      2.00000
+    201       4.4399      2.00000
+    202       4.4568      2.00000
+    203       4.4874      2.00000
+    204       4.4969      2.00000
+    205       4.5187      2.00000
+    206       4.5895      2.00000
+    207       4.6345      2.00000
+    208       4.6706      2.00000
+    209       4.6897      2.00000
+    210       4.7222      2.00000
+    211       4.7558      2.00000
+    212       4.8086      2.00000
+    213       4.8227      2.00000
+    214       4.8529      2.00000
+    215       4.8587      2.00000
+    216       4.9185      2.00000
+    217       4.9293      2.00000
+    218       4.9567      2.00000
+    219       4.9948      2.00000
+    220       5.0238      2.00000
+    221       5.0507      2.00000
+    222       5.0895      2.00000
+    223       5.1311      2.00000
+    224       5.1604      2.00000
+    225       5.1722      2.00000
+    226       5.1977      2.00000
+    227       5.2449      2.00000
+    228       5.2625      2.00000
+    229       5.2922      2.00000
+    230       5.2969      2.00000
+    231       5.3435      2.00000
+    232       5.3567      2.00000
+    233       5.4009      2.00000
+    234       5.4297      2.00000
+    235       5.4404      2.00000
+    236       5.4691      2.00000
+    237       5.4875      2.00000
+    238       5.5004      2.00000
+    239       5.5147      2.00000
+    240       5.5443      2.00000
+    241       5.5554      2.00000
+    242       5.5781      2.00000
+    243       5.6192      2.00000
+    244       5.6473      2.00000
+    245       5.6767      2.00000
+    246       5.6827      2.00000
+    247       5.7161      2.00000
+    248       5.7461      2.00000
+    249       5.7567      2.00000
+    250       5.7831      2.00000
+    251       5.7995      2.00000
+    252       5.8312      2.00000
+    253       5.8724      2.00000
+    254       5.8781      2.00000
+    255       5.9067      2.00000
+    256       5.9211      2.00000
+    257       5.9473      2.00000
+    258       5.9836      2.00000
+    259       6.0030      2.00000
+    260       6.0176      2.00000
+    261       6.0369      2.00000
+    262       6.0616      2.00000
+    263       6.0854      2.00000
+    264       6.1114      2.00000
+    265       6.1296      2.00000
+    266       6.1518      2.00000
+    267       6.1714      2.00000
+    268       6.1770      2.00000
+    269       6.2256      2.00000
+    270       6.2327      2.00000
+    271       6.2559      2.00000
+    272       6.2572      2.00000
+    273       6.3144      2.00000
+    274       6.3475      2.00000
+    275       6.3609      2.00000
+    276       6.4151      2.00000
+    277       6.4338      2.00000
+    278       6.4484      2.00000
+    279       6.4873      2.00000
+    280       6.5269      2.00000
+    281       6.5584      2.00000
+    282       6.5725      2.00000
+    283       6.5981      2.00000
+    284       6.6219      2.00000
+    285       6.6513      2.00000
+    286       6.7230      2.00000
+    287       6.7560      2.00000
+    288       6.7768      2.00000
+    289       6.8046      2.00000
+    290       6.8207      2.00000
+    291       6.8482      2.00000
+    292       6.8816      2.00000
+    293       6.8940      2.00000
+    294       6.9226      2.00015
+    295       6.9514      2.00279
+    296       6.9725      2.01423
+    297       7.0164      2.06946
+    298       7.0518      1.68258
+    299       7.1083      0.09466
+    300       7.1181     -0.01396
+    301       7.1572     -0.04094
+    302       7.1881     -0.00595
+    303       7.2177     -0.00038
+    304       7.2374     -0.00004
+    305       7.2789     -0.00000
+    306       7.3009     -0.00000
+    307       7.3250     -0.00000
+    308       7.3616     -0.00000
+    309       7.4018     -0.00000
+    310       7.4064     -0.00000
+    311       7.4495     -0.00000
+    312       7.4805     -0.00000
+    313       7.5050     -0.00000
+    314       7.5331     -0.00000
+    315       7.5788     -0.00000
+    316       7.6297     -0.00000
+    317       7.6391     -0.00000
+    318       7.6623     -0.00000
+    319       7.6679     -0.00000
+    320       7.7068     -0.00000
+    321       7.7879     -0.00000
+    322       7.8025     -0.00000
+    323       7.8515     -0.00000
+    324       7.8706     -0.00000
+    325       7.8849     -0.00000
+    326       7.9193     -0.00000
+    327       8.0182     -0.00000
+    328       8.0547     -0.00000
+    329       8.0825     -0.00000
+    330       8.1096     -0.00000
+    331       8.1568     -0.00000
+    332       8.2064     -0.00000
+    333       8.2286     -0.00000
+    334       8.2957     -0.00000
+    335       8.3318     -0.00000
+    336       8.3636     -0.00000
+    337       8.4024     -0.00000
+    338       8.4643      0.00000
+    339       8.5177      0.00000
+    340       8.5556      0.00000
+    341       8.6301      0.00000
+    342       8.6828      0.00000
+    343       8.7011      0.00000
+    344       8.7150      0.00000
+    345       8.8527      0.00000
+    346       8.9420      0.00000
+    347       9.0332      0.00000
+    348       9.0619      0.00000
+    349       9.1259      0.00000
+    350       9.1495      0.00000
+    351       9.3108      0.00000
+    352       9.3439      0.00000
+    353       9.4158      0.00000
+    354       9.4815      0.00000
+    355       9.6074      0.00000
+    356       9.6500      0.00000
+    357       9.6917      0.00000
+    358       9.8264      0.00000
+    359       9.9656      0.00000
+    360      10.0856      0.00000
+
+ k-point     6 :       0.5000    0.0000    0.5000
+  band No.  band energies     occupation 
+      1     -63.1770      2.00000
+      2     -63.1576      2.00000
+      3     -63.1335      2.00000
+      4     -63.0842      2.00000
+      5     -63.0026      2.00000
+      6     -63.0021      2.00000
+      7     -62.9859      2.00000
+      8     -62.9508      2.00000
+      9     -62.8858      2.00000
+     10     -62.8552      2.00000
+     11     -62.8202      2.00000
+     12     -62.8025      2.00000
+     13     -56.3565      2.00000
+     14     -56.3257      2.00000
+     15     -56.2807      2.00000
+     16     -56.2467      2.00000
+     17     -56.2456      2.00000
+     18     -56.2251      2.00000
+     19     -56.1660      2.00000
+     20     -56.1207      2.00000
+     21     -56.1000      2.00000
+     22     -56.0232      2.00000
+     23     -55.9880      2.00000
+     24     -55.9328      2.00000
+     25     -45.6027      2.00000
+     26     -45.5571      2.00000
+     27     -45.5541      2.00000
+     28     -45.5234      2.00000
+     29     -45.5042      2.00000
+     30     -45.5041      2.00000
+     31     -45.4014      2.00000
+     32     -45.3915      2.00000
+     33     -45.3903      2.00000
+     34     -41.4029      2.00000
+     35     -41.2480      2.00000
+     36     -41.1024      2.00000
+     37     -40.9704      2.00000
+     38     -40.7839      2.00000
+     39     -40.7515      2.00000
+     40     -40.7319      2.00000
+     41     -40.7135      2.00000
+     42     -40.7121      2.00000
+     43     -40.6800      2.00000
+     44     -40.6227      2.00000
+     45     -40.6113      2.00000
+     46     -40.5896      2.00000
+     47     -40.5789      2.00000
+     48     -40.5533      2.00000
+     49     -40.4993      2.00000
+     50     -40.4943      2.00000
+     51     -40.4923      2.00000
+     52     -40.4603      2.00000
+     53     -39.0261      2.00000
+     54     -38.9845      2.00000
+     55     -38.8845      2.00000
+     56     -35.9478      2.00000
+     57     -35.8923      2.00000
+     58     -35.8128      2.00000
+     59     -35.8012      2.00000
+     60     -35.7856      2.00000
+     61     -35.7650      2.00000
+     62     -35.6926      2.00000
+     63     -35.6598      2.00000
+     64     -35.6338      2.00000
+     65     -34.4710      2.00000
+     66     -34.4419      2.00000
+     67     -34.3606      2.00000
+     68     -34.2354      2.00000
+     69     -34.1723      2.00000
+     70     -30.9606      2.00000
+     71     -30.8233      2.00000
+     72     -30.8156      2.00000
+     73     -30.7935      2.00000
+     74     -30.7636      2.00000
+     75     -30.7231      2.00000
+     76     -30.6757      2.00000
+     77     -30.6658      2.00000
+     78     -30.5176      2.00000
+     79     -27.8189      2.00000
+     80     -27.8078      2.00000
+     81     -27.7451      2.00000
+     82     -27.7255      2.00000
+     83     -27.6900      2.00000
+     84     -27.6204      2.00000
+     85     -24.0306      2.00000
+     86     -23.9949      2.00000
+     87     -23.9573      2.00000
+     88     -23.9394      2.00000
+     89     -23.9176      2.00000
+     90     -23.8122      2.00000
+     91     -23.7929      2.00000
+     92     -23.7693      2.00000
+     93     -23.7497      2.00000
+     94     -23.7326      2.00000
+     95     -23.7029      2.00000
+     96     -23.6792      2.00000
+     97     -23.6024      2.00000
+     98     -23.4814      2.00000
+     99     -23.3478      2.00000
+    100     -20.2538      2.00000
+    101     -19.8135      2.00000
+    102     -19.4645      2.00000
+    103     -19.4364      2.00000
+    104     -19.3133      2.00000
+    105     -19.3072      2.00000
+    106     -19.2628      2.00000
+    107     -19.2066      2.00000
+    108     -19.1508      2.00000
+    109     -19.0521      2.00000
+    110     -19.0289      2.00000
+    111     -18.7011      2.00000
+    112     -15.2312      2.00000
+    113     -14.7269      2.00000
+    114     -14.6726      2.00000
+    115     -14.6297      2.00000
+    116     -14.6133      2.00000
+    117     -14.6051      2.00000
+    118     -14.5798      2.00000
+    119     -14.5632      2.00000
+    120     -14.5203      2.00000
+    121     -14.4697      2.00000
+    122     -14.4141      2.00000
+    123     -14.3917      2.00000
+    124     -14.3755      2.00000
+    125     -14.3232      2.00000
+    126     -14.1343      2.00000
+    127       0.1011      2.00000
+    128       0.1329      2.00000
+    129       0.1691      2.00000
+    130       0.1855      2.00000
+    131       0.2139      2.00000
+    132       0.2764      2.00000
+    133       0.2790      2.00000
+    134       0.3101      2.00000
+    135       0.3223      2.00000
+    136       0.3421      2.00000
+    137       0.3631      2.00000
+    138       0.4912      2.00000
+    139       0.5657      2.00000
+    140       0.8988      2.00000
+    141       1.8304      2.00000
+    142       1.9653      2.00000
+    143       2.2175      2.00000
+    144       2.2527      2.00000
+    145       2.3524      2.00000
+    146       2.3598      2.00000
+    147       2.4354      2.00000
+    148       2.5052      2.00000
+    149       2.5825      2.00000
+    150       2.6033      2.00000
+    151       2.6653      2.00000
+    152       2.6822      2.00000
+    153       2.7160      2.00000
+    154       2.8095      2.00000
+    155       2.8389      2.00000
+    156       2.8655      2.00000
+    157       2.9145      2.00000
+    158       3.0196      2.00000
+    159       3.0552      2.00000
+    160       3.0819      2.00000
+    161       3.1034      2.00000
+    162       3.1873      2.00000
+    163       3.2190      2.00000
+    164       3.2387      2.00000
+    165       3.2641      2.00000
+    166       3.2911      2.00000
+    167       3.3356      2.00000
+    168       3.3450      2.00000
+    169       3.3869      2.00000
+    170       3.4208      2.00000
+    171       3.4443      2.00000
+    172       3.5020      2.00000
+    173       3.5268      2.00000
+    174       3.5621      2.00000
+    175       3.5858      2.00000
+    176       3.6432      2.00000
+    177       3.6706      2.00000
+    178       3.7335      2.00000
+    179       3.7493      2.00000
+    180       3.7716      2.00000
+    181       3.8528      2.00000
+    182       3.8607      2.00000
+    183       3.8896      2.00000
+    184       3.9320      2.00000
+    185       3.9667      2.00000
+    186       3.9760      2.00000
+    187       3.9913      2.00000
+    188       4.0152      2.00000
+    189       4.0472      2.00000
+    190       4.0804      2.00000
+    191       4.0977      2.00000
+    192       4.1554      2.00000
+    193       4.1595      2.00000
+    194       4.2039      2.00000
+    195       4.2237      2.00000
+    196       4.2505      2.00000
+    197       4.2550      2.00000
+    198       4.3347      2.00000
+    199       4.3890      2.00000
+    200       4.4288      2.00000
+    201       4.4632      2.00000
+    202       4.4798      2.00000
+    203       4.5051      2.00000
+    204       4.5610      2.00000
+    205       4.5980      2.00000
+    206       4.6297      2.00000
+    207       4.6505      2.00000
+    208       4.6839      2.00000
+    209       4.7072      2.00000
+    210       4.7595      2.00000
+    211       4.7899      2.00000
+    212       4.8002      2.00000
+    213       4.8655      2.00000
+    214       4.8672      2.00000
+    215       4.8792      2.00000
+    216       4.9142      2.00000
+    217       4.9506      2.00000
+    218       4.9661      2.00000
+    219       4.9855      2.00000
+    220       5.0009      2.00000
+    221       5.0287      2.00000
+    222       5.0721      2.00000
+    223       5.1155      2.00000
+    224       5.1376      2.00000
+    225       5.1669      2.00000
+    226       5.2182      2.00000
+    227       5.2422      2.00000
+    228       5.2455      2.00000
+    229       5.2679      2.00000
+    230       5.2904      2.00000
+    231       5.3079      2.00000
+    232       5.3260      2.00000
+    233       5.3508      2.00000
+    234       5.3971      2.00000
+    235       5.4119      2.00000
+    236       5.4217      2.00000
+    237       5.4581      2.00000
+    238       5.5036      2.00000
+    239       5.5353      2.00000
+    240       5.5598      2.00000
+    241       5.5819      2.00000
+    242       5.5847      2.00000
+    243       5.6123      2.00000
+    244       5.6401      2.00000
+    245       5.6629      2.00000
+    246       5.6833      2.00000
+    247       5.7237      2.00000
+    248       5.7368      2.00000
+    249       5.7697      2.00000
+    250       5.7815      2.00000
+    251       5.8072      2.00000
+    252       5.8302      2.00000
+    253       5.8791      2.00000
+    254       5.8948      2.00000
+    255       5.9221      2.00000
+    256       5.9420      2.00000
+    257       5.9587      2.00000
+    258       5.9961      2.00000
+    259       6.0203      2.00000
+    260       6.0480      2.00000
+    261       6.0626      2.00000
+    262       6.0942      2.00000
+    263       6.1253      2.00000
+    264       6.1334      2.00000
+    265       6.1669      2.00000
+    266       6.1961      2.00000
+    267       6.2249      2.00000
+    268       6.2423      2.00000
+    269       6.2835      2.00000
+    270       6.3005      2.00000
+    271       6.3437      2.00000
+    272       6.3708      2.00000
+    273       6.3815      2.00000
+    274       6.3894      2.00000
+    275       6.4034      2.00000
+    276       6.4184      2.00000
+    277       6.4556      2.00000
+    278       6.4763      2.00000
+    279       6.5127      2.00000
+    280       6.5320      2.00000
+    281       6.5704      2.00000
+    282       6.5862      2.00000
+    283       6.6260      2.00000
+    284       6.6473      2.00000
+    285       6.6650      2.00000
+    286       6.6885      2.00000
+    287       6.7126      2.00000
+    288       6.7569      2.00000
+    289       6.7657      2.00000
+    290       6.8190      2.00000
+    291       6.8627      2.00000
+    292       6.8829      2.00000
+    293       6.8891      2.00000
+    294       6.9107      2.00004
+    295       6.9376      2.00076
+    296       6.9728      2.01444
+    297       7.0142      2.07075
+    298       7.0373      1.94593
+    299       7.0679      1.21647
+    300       7.1023      0.19880
+    301       7.1091      0.08317
+    302       7.1425     -0.06600
+    303       7.1490     -0.05595
+    304       7.1701     -0.02075
+    305       7.2401     -0.00003
+    306       7.2704     -0.00000
+    307       7.2945     -0.00000
+    308       7.3397     -0.00000
+    309       7.3552     -0.00000
+    310       7.3796     -0.00000
+    311       7.3950     -0.00000
+    312       7.4592     -0.00000
+    313       7.4641     -0.00000
+    314       7.5038     -0.00000
+    315       7.5402     -0.00000
+    316       7.6120     -0.00000
+    317       7.6646     -0.00000
+    318       7.6764     -0.00000
+    319       7.7016     -0.00000
+    320       7.7720     -0.00000
+    321       7.7811     -0.00000
+    322       7.8270     -0.00000
+    323       7.8501     -0.00000
+    324       7.8876     -0.00000
+    325       7.9308     -0.00000
+    326       7.9500     -0.00000
+    327       8.0272     -0.00000
+    328       8.0680     -0.00000
+    329       8.1000     -0.00000
+    330       8.1551     -0.00000
+    331       8.1719     -0.00000
+    332       8.1744     -0.00000
+    333       8.2559     -0.00000
+    334       8.2828     -0.00000
+    335       8.3318     -0.00000
+    336       8.4263     -0.00000
+    337       8.4753      0.00000
+    338       8.5002      0.00000
+    339       8.5519      0.00000
+    340       8.5955      0.00000
+    341       8.6345      0.00000
+    342       8.6638      0.00000
+    343       8.8238      0.00000
+    344       8.8437      0.00000
+    345       8.8692      0.00000
+    346       8.9859      0.00000
+    347       9.0159      0.00000
+    348       9.0716      0.00000
+    349       9.1755      0.00000
+    350       9.2292      0.00000
+    351       9.2460      0.00000
+    352       9.3014      0.00000
+    353       9.4144      0.00000
+    354       9.4603      0.00000
+    355       9.5354      0.00000
+    356       9.6423      0.00000
+    357       9.7627      0.00000
+    358       9.9451      0.00000
+    359       9.9882      0.00000
+    360      10.1674      0.00000
+
+ k-point     7 :       0.0000    0.5000    0.5000
+  band No.  band energies     occupation 
+      1     -63.1770      2.00000
+      2     -63.1576      2.00000
+      3     -63.1336      2.00000
+      4     -63.0842      2.00000
+      5     -63.0026      2.00000
+      6     -63.0021      2.00000
+      7     -62.9859      2.00000
+      8     -62.9508      2.00000
+      9     -62.8858      2.00000
+     10     -62.8551      2.00000
+     11     -62.8202      2.00000
+     12     -62.8025      2.00000
+     13     -56.3565      2.00000
+     14     -56.3257      2.00000
+     15     -56.2807      2.00000
+     16     -56.2466      2.00000
+     17     -56.2457      2.00000
+     18     -56.2251      2.00000
+     19     -56.1660      2.00000
+     20     -56.1207      2.00000
+     21     -56.0999      2.00000
+     22     -56.0232      2.00000
+     23     -55.9880      2.00000
+     24     -55.9328      2.00000
+     25     -45.6027      2.00000
+     26     -45.5570      2.00000
+     27     -45.5541      2.00000
+     28     -45.5234      2.00000
+     29     -45.5042      2.00000
+     30     -45.5041      2.00000
+     31     -45.4014      2.00000
+     32     -45.3915      2.00000
+     33     -45.3903      2.00000
+     34     -41.4024      2.00000
+     35     -41.2494      2.00000
+     36     -41.1016      2.00000
+     37     -40.9704      2.00000
+     38     -40.7839      2.00000
+     39     -40.7514      2.00000
+     40     -40.7319      2.00000
+     41     -40.7135      2.00000
+     42     -40.7121      2.00000
+     43     -40.6800      2.00000
+     44     -40.6228      2.00000
+     45     -40.6113      2.00000
+     46     -40.5896      2.00000
+     47     -40.5789      2.00000
+     48     -40.5533      2.00000
+     49     -40.4993      2.00000
+     50     -40.4943      2.00000
+     51     -40.4923      2.00000
+     52     -40.4603      2.00000
+     53     -39.0261      2.00000
+     54     -38.9845      2.00000
+     55     -38.8845      2.00000
+     56     -35.9478      2.00000
+     57     -35.8923      2.00000
+     58     -35.8128      2.00000
+     59     -35.8011      2.00000
+     60     -35.7856      2.00000
+     61     -35.7650      2.00000
+     62     -35.6926      2.00000
+     63     -35.6598      2.00000
+     64     -35.6338      2.00000
+     65     -34.4710      2.00000
+     66     -34.4418      2.00000
+     67     -34.3607      2.00000
+     68     -34.2354      2.00000
+     69     -34.1722      2.00000
+     70     -30.9606      2.00000
+     71     -30.8234      2.00000
+     72     -30.8156      2.00000
+     73     -30.7935      2.00000
+     74     -30.7636      2.00000
+     75     -30.7231      2.00000
+     76     -30.6757      2.00000
+     77     -30.6658      2.00000
+     78     -30.5176      2.00000
+     79     -27.8189      2.00000
+     80     -27.8078      2.00000
+     81     -27.7451      2.00000
+     82     -27.7255      2.00000
+     83     -27.6900      2.00000
+     84     -27.6204      2.00000
+     85     -24.0432      2.00000
+     86     -23.9949      2.00000
+     87     -23.9414      2.00000
+     88     -23.9370      2.00000
+     89     -23.9176      2.00000
+     90     -23.8111      2.00000
+     91     -23.7963      2.00000
+     92     -23.7626      2.00000
+     93     -23.7556      2.00000
+     94     -23.7380      2.00000
+     95     -23.7027      2.00000
+     96     -23.6762      2.00000
+     97     -23.6032      2.00000
+     98     -23.4820      2.00000
+     99     -23.3483      2.00000
+    100     -20.2539      2.00000
+    101     -19.8132      2.00000
+    102     -19.4637      2.00000
+    103     -19.4364      2.00000
+    104     -19.3152      2.00000
+    105     -19.3073      2.00000
+    106     -19.2626      2.00000
+    107     -19.2055      2.00000
+    108     -19.1508      2.00000
+    109     -19.0521      2.00000
+    110     -19.0292      2.00000
+    111     -18.7010      2.00000
+    112     -15.2310      2.00000
+    113     -14.7264      2.00000
+    114     -14.6720      2.00000
+    115     -14.6302      2.00000
+    116     -14.6130      2.00000
+    117     -14.6051      2.00000
+    118     -14.5796      2.00000
+    119     -14.5629      2.00000
+    120     -14.5214      2.00000
+    121     -14.4707      2.00000
+    122     -14.4127      2.00000
+    123     -14.3927      2.00000
+    124     -14.3755      2.00000
+    125     -14.3232      2.00000
+    126     -14.1343      2.00000
+    127       0.0858      2.00000
+    128       0.1258      2.00000
+    129       0.1648      2.00000
+    130       0.1778      2.00000
+    131       0.1945      2.00000
+    132       0.2320      2.00000
+    133       0.2861      2.00000
+    134       0.3054      2.00000
+    135       0.3299      2.00000
+    136       0.3434      2.00000
+    137       0.3674      2.00000
+    138       0.4765      2.00000
+    139       0.6296      2.00000
+    140       1.0853      2.00000
+    141       1.7949      2.00000
+    142       1.9164      2.00000
+    143       2.1865      2.00000
+    144       2.2135      2.00000
+    145       2.2905      2.00000
+    146       2.3366      2.00000
+    147       2.4044      2.00000
+    148       2.4706      2.00000
+    149       2.5381      2.00000
+    150       2.5663      2.00000
+    151       2.6386      2.00000
+    152       2.7000      2.00000
+    153       2.7140      2.00000
+    154       2.7825      2.00000
+    155       2.8654      2.00000
+    156       2.8832      2.00000
+    157       2.9204      2.00000
+    158       2.9703      2.00000
+    159       3.0214      2.00000
+    160       3.0736      2.00000
+    161       3.1316      2.00000
+    162       3.1519      2.00000
+    163       3.1911      2.00000
+    164       3.2349      2.00000
+    165       3.3272      2.00000
+    166       3.3389      2.00000
+    167       3.4051      2.00000
+    168       3.4200      2.00000
+    169       3.4373      2.00000
+    170       3.4657      2.00000
+    171       3.4951      2.00000
+    172       3.5052      2.00000
+    173       3.5629      2.00000
+    174       3.6021      2.00000
+    175       3.6465      2.00000
+    176       3.6719      2.00000
+    177       3.7063      2.00000
+    178       3.7364      2.00000
+    179       3.7710      2.00000
+    180       3.7905      2.00000
+    181       3.8301      2.00000
+    182       3.8542      2.00000
+    183       3.8827      2.00000
+    184       3.9201      2.00000
+    185       3.9297      2.00000
+    186       3.9701      2.00000
+    187       3.9977      2.00000
+    188       4.0188      2.00000
+    189       4.0539      2.00000
+    190       4.0804      2.00000
+    191       4.1208      2.00000
+    192       4.1258      2.00000
+    193       4.1885      2.00000
+    194       4.2184      2.00000
+    195       4.2309      2.00000
+    196       4.2572      2.00000
+    197       4.3041      2.00000
+    198       4.3503      2.00000
+    199       4.3660      2.00000
+    200       4.3754      2.00000
+    201       4.4172      2.00000
+    202       4.4483      2.00000
+    203       4.4758      2.00000
+    204       4.5067      2.00000
+    205       4.5217      2.00000
+    206       4.5441      2.00000
+    207       4.5647      2.00000
+    208       4.6372      2.00000
+    209       4.6774      2.00000
+    210       4.7125      2.00000
+    211       4.7699      2.00000
+    212       4.8020      2.00000
+    213       4.8194      2.00000
+    214       4.8348      2.00000
+    215       4.8800      2.00000
+    216       4.9172      2.00000
+    217       4.9232      2.00000
+    218       4.9417      2.00000
+    219       4.9885      2.00000
+    220       4.9971      2.00000
+    221       5.0411      2.00000
+    222       5.0554      2.00000
+    223       5.1081      2.00000
+    224       5.1270      2.00000
+    225       5.1474      2.00000
+    226       5.1894      2.00000
+    227       5.2025      2.00000
+    228       5.2480      2.00000
+    229       5.2638      2.00000
+    230       5.3060      2.00000
+    231       5.3298      2.00000
+    232       5.3543      2.00000
+    233       5.3600      2.00000
+    234       5.4096      2.00000
+    235       5.4311      2.00000
+    236       5.4616      2.00000
+    237       5.4892      2.00000
+    238       5.5077      2.00000
+    239       5.5581      2.00000
+    240       5.5844      2.00000
+    241       5.6042      2.00000
+    242       5.6210      2.00000
+    243       5.6295      2.00000
+    244       5.6676      2.00000
+    245       5.7000      2.00000
+    246       5.7196      2.00000
+    247       5.7570      2.00000
+    248       5.7651      2.00000
+    249       5.7849      2.00000
+    250       5.8045      2.00000
+    251       5.8357      2.00000
+    252       5.8594      2.00000
+    253       5.8861      2.00000
+    254       5.8965      2.00000
+    255       5.9105      2.00000
+    256       5.9437      2.00000
+    257       5.9644      2.00000
+    258       5.9949      2.00000
+    259       6.0263      2.00000
+    260       6.0480      2.00000
+    261       6.0572      2.00000
+    262       6.0944      2.00000
+    263       6.1164      2.00000
+    264       6.1567      2.00000
+    265       6.1718      2.00000
+    266       6.1918      2.00000
+    267       6.2086      2.00000
+    268       6.2336      2.00000
+    269       6.2558      2.00000
+    270       6.2800      2.00000
+    271       6.3077      2.00000
+    272       6.3357      2.00000
+    273       6.3683      2.00000
+    274       6.3834      2.00000
+    275       6.4175      2.00000
+    276       6.4669      2.00000
+    277       6.4898      2.00000
+    278       6.5047      2.00000
+    279       6.5589      2.00000
+    280       6.5639      2.00000
+    281       6.5857      2.00000
+    282       6.6031      2.00000
+    283       6.6213      2.00000
+    284       6.6400      2.00000
+    285       6.6843      2.00000
+    286       6.6926      2.00000
+    287       6.7309      2.00000
+    288       6.7692      2.00000
+    289       6.7955      2.00000
+    290       6.8221      2.00000
+    291       6.8379      2.00000
+    292       6.8788      2.00000
+    293       6.9071      2.00002
+    294       6.9138      2.00005
+    295       6.9283      2.00029
+    296       6.9753      2.01707
+    297       7.0070      2.06707
+    298       7.0317      2.00462
+    299       7.0432      1.86006
+    300       7.0668      1.25087
+    301       7.1023      0.19782
+    302       7.1321     -0.06926
+    303       7.1604     -0.03532
+    304       7.2111     -0.00076
+    305       7.2244     -0.00019
+    306       7.2508     -0.00001
+    307       7.2747     -0.00000
+    308       7.3229     -0.00000
+    309       7.3243     -0.00000
+    310       7.3563     -0.00000
+    311       7.3629     -0.00000
+    312       7.4094     -0.00000
+    313       7.4756     -0.00000
+    314       7.4899     -0.00000
+    315       7.4983     -0.00000
+    316       7.5742     -0.00000
+    317       7.6022     -0.00000
+    318       7.6211     -0.00000
+    319       7.7093     -0.00000
+    320       7.7445     -0.00000
+    321       7.7686     -0.00000
+    322       7.8177     -0.00000
+    323       7.8279     -0.00000
+    324       7.8583     -0.00000
+    325       7.9241     -0.00000
+    326       7.9796     -0.00000
+    327       8.0123     -0.00000
+    328       8.0602     -0.00000
+    329       8.1220     -0.00000
+    330       8.1696     -0.00000
+    331       8.1759     -0.00000
+    332       8.2543     -0.00000
+    333       8.2675     -0.00000
+    334       8.3849     -0.00000
+    335       8.4087     -0.00000
+    336       8.4713      0.00000
+    337       8.5010      0.00000
+    338       8.5287      0.00000
+    339       8.5702      0.00000
+    340       8.6290      0.00000
+    341       8.6994      0.00000
+    342       8.7523      0.00000
+    343       8.8485      0.00000
+    344       8.8647      0.00000
+    345       8.9421      0.00000
+    346       8.9703      0.00000
+    347       9.0385      0.00000
+    348       9.0746      0.00000
+    349       9.1236      0.00000
+    350       9.2060      0.00000
+    351       9.2897      0.00000
+    352       9.3536      0.00000
+    353       9.3824      0.00000
+    354       9.5337      0.00000
+    355       9.6067      0.00000
+    356       9.7502      0.00000
+    357       9.8203      0.00000
+    358       9.9542      0.00000
+    359      10.1422      0.00000
+    360      10.2682      0.00000
+
+ k-point     8 :       0.5000    0.5000    0.5000
+  band No.  band energies     occupation 
+      1     -63.1770      2.00000
+      2     -63.1576      2.00000
+      3     -63.1335      2.00000
+      4     -63.0842      2.00000
+      5     -63.0026      2.00000
+      6     -63.0021      2.00000
+      7     -62.9859      2.00000
+      8     -62.9508      2.00000
+      9     -62.8858      2.00000
+     10     -62.8551      2.00000
+     11     -62.8202      2.00000
+     12     -62.8025      2.00000
+     13     -56.3565      2.00000
+     14     -56.3257      2.00000
+     15     -56.2806      2.00000
+     16     -56.2466      2.00000
+     17     -56.2456      2.00000
+     18     -56.2251      2.00000
+     19     -56.1660      2.00000
+     20     -56.1207      2.00000
+     21     -56.0999      2.00000
+     22     -56.0232      2.00000
+     23     -55.9880      2.00000
+     24     -55.9328      2.00000
+     25     -45.6027      2.00000
+     26     -45.5570      2.00000
+     27     -45.5541      2.00000
+     28     -45.5234      2.00000
+     29     -45.5042      2.00000
+     30     -45.5041      2.00000
+     31     -45.4014      2.00000
+     32     -45.3915      2.00000
+     33     -45.3903      2.00000
+     34     -41.4029      2.00000
+     35     -41.2480      2.00000
+     36     -41.1024      2.00000
+     37     -40.9704      2.00000
+     38     -40.7839      2.00000
+     39     -40.7515      2.00000
+     40     -40.7319      2.00000
+     41     -40.7135      2.00000
+     42     -40.7121      2.00000
+     43     -40.6799      2.00000
+     44     -40.6227      2.00000
+     45     -40.6113      2.00000
+     46     -40.5896      2.00000
+     47     -40.5789      2.00000
+     48     -40.5533      2.00000
+     49     -40.4993      2.00000
+     50     -40.4942      2.00000
+     51     -40.4923      2.00000
+     52     -40.4603      2.00000
+     53     -39.0261      2.00000
+     54     -38.9845      2.00000
+     55     -38.8845      2.00000
+     56     -35.9478      2.00000
+     57     -35.8923      2.00000
+     58     -35.8128      2.00000
+     59     -35.8011      2.00000
+     60     -35.7856      2.00000
+     61     -35.7650      2.00000
+     62     -35.6926      2.00000
+     63     -35.6598      2.00000
+     64     -35.6338      2.00000
+     65     -34.4709      2.00000
+     66     -34.4419      2.00000
+     67     -34.3606      2.00000
+     68     -34.2354      2.00000
+     69     -34.1722      2.00000
+     70     -30.9606      2.00000
+     71     -30.8234      2.00000
+     72     -30.8156      2.00000
+     73     -30.7935      2.00000
+     74     -30.7636      2.00000
+     75     -30.7231      2.00000
+     76     -30.6757      2.00000
+     77     -30.6658      2.00000
+     78     -30.5176      2.00000
+     79     -27.8189      2.00000
+     80     -27.8078      2.00000
+     81     -27.7451      2.00000
+     82     -27.7255      2.00000
+     83     -27.6900      2.00000
+     84     -27.6204      2.00000
+     85     -24.0281      2.00000
+     86     -23.9949      2.00000
+     87     -23.9589      2.00000
+     88     -23.9394      2.00000
+     89     -23.9176      2.00000
+     90     -23.8122      2.00000
+     91     -23.7930      2.00000
+     92     -23.7695      2.00000
+     93     -23.7494      2.00000
+     94     -23.7321      2.00000
+     95     -23.7035      2.00000
+     96     -23.6800      2.00000
+     97     -23.6047      2.00000
+     98     -23.4818      2.00000
+     99     -23.3453      2.00000
+    100     -20.2538      2.00000
+    101     -19.8136      2.00000
+    102     -19.4645      2.00000
+    103     -19.4364      2.00000
+    104     -19.3132      2.00000
+    105     -19.3071      2.00000
+    106     -19.2628      2.00000
+    107     -19.2064      2.00000
+    108     -19.1501      2.00000
+    109     -19.0521      2.00000
+    110     -19.0288      2.00000
+    111     -18.7011      2.00000
+    112     -15.2379      2.00000
+    113     -14.7248      2.00000
+    114     -14.6721      2.00000
+    115     -14.6286      2.00000
+    116     -14.6156      2.00000
+    117     -14.6048      2.00000
+    118     -14.5801      2.00000
+    119     -14.5639      2.00000
+    120     -14.5219      2.00000
+    121     -14.4695      2.00000
+    122     -14.4124      2.00000
+    123     -14.3920      2.00000
+    124     -14.3752      2.00000
+    125     -14.3231      2.00000
+    126     -14.1291      2.00000
+    127       0.1272      2.00000
+    128       0.1313      2.00000
+    129       0.1670      2.00000
+    130       0.1869      2.00000
+    131       0.2198      2.00000
+    132       0.2637      2.00000
+    133       0.2976      2.00000
+    134       0.3182      2.00000
+    135       0.3391      2.00000
+    136       0.3738      2.00000
+    137       0.5054      2.00000
+    138       0.6846      2.00000
+    139       0.9375      2.00000
+    140       1.0657      2.00000
+    141       1.3860      2.00000
+    142       1.5750      2.00000
+    143       1.7001      2.00000
+    144       1.9615      2.00000
+    145       2.1854      2.00000
+    146       2.3621      2.00000
+    147       2.3914      2.00000
+    148       2.4695      2.00000
+    149       2.4998      2.00000
+    150       2.5303      2.00000
+    151       2.6528      2.00000
+    152       2.7399      2.00000
+    153       2.7704      2.00000
+    154       2.8003      2.00000
+    155       2.8619      2.00000
+    156       2.9450      2.00000
+    157       3.0094      2.00000
+    158       3.0416      2.00000
+    159       3.0616      2.00000
+    160       3.1189      2.00000
+    161       3.1756      2.00000
+    162       3.1831      2.00000
+    163       3.2072      2.00000
+    164       3.2314      2.00000
+    165       3.2836      2.00000
+    166       3.3538      2.00000
+    167       3.3855      2.00000
+    168       3.4572      2.00000
+    169       3.4657      2.00000
+    170       3.5079      2.00000
+    171       3.5224      2.00000
+    172       3.5602      2.00000
+    173       3.5916      2.00000
+    174       3.6185      2.00000
+    175       3.6434      2.00000
+    176       3.6695      2.00000
+    177       3.7102      2.00000
+    178       3.7367      2.00000
+    179       3.7676      2.00000
+    180       3.8171      2.00000
+    181       3.8338      2.00000
+    182       3.8479      2.00000
+    183       3.8792      2.00000
+    184       3.9174      2.00000
+    185       3.9515      2.00000
+    186       3.9595      2.00000
+    187       4.0089      2.00000
+    188       4.0444      2.00000
+    189       4.0544      2.00000
+    190       4.0925      2.00000
+    191       4.1117      2.00000
+    192       4.1365      2.00000
+    193       4.1694      2.00000
+    194       4.1780      2.00000
+    195       4.2816      2.00000
+    196       4.2988      2.00000
+    197       4.3220      2.00000
+    198       4.3586      2.00000
+    199       4.3814      2.00000
+    200       4.3973      2.00000
+    201       4.4349      2.00000
+    202       4.4839      2.00000
+    203       4.5168      2.00000
+    204       4.5319      2.00000
+    205       4.5522      2.00000
+    206       4.5558      2.00000
+    207       4.5789      2.00000
+    208       4.6231      2.00000
+    209       4.6759      2.00000
+    210       4.6834      2.00000
+    211       4.7109      2.00000
+    212       4.7338      2.00000
+    213       4.7924      2.00000
+    214       4.8011      2.00000
+    215       4.8426      2.00000
+    216       4.8553      2.00000
+    217       4.8803      2.00000
+    218       4.9224      2.00000
+    219       4.9522      2.00000
+    220       4.9924      2.00000
+    221       5.0236      2.00000
+    222       5.0608      2.00000
+    223       5.1068      2.00000
+    224       5.1135      2.00000
+    225       5.1339      2.00000
+    226       5.1688      2.00000
+    227       5.1861      2.00000
+    228       5.2086      2.00000
+    229       5.2640      2.00000
+    230       5.3345      2.00000
+    231       5.3425      2.00000
+    232       5.3589      2.00000
+    233       5.3732      2.00000
+    234       5.4120      2.00000
+    235       5.4381      2.00000
+    236       5.4657      2.00000
+    237       5.5121      2.00000
+    238       5.5244      2.00000
+    239       5.5569      2.00000
+    240       5.5718      2.00000
+    241       5.5920      2.00000
+    242       5.6203      2.00000
+    243       5.6403      2.00000
+    244       5.6558      2.00000
+    245       5.6763      2.00000
+    246       5.7072      2.00000
+    247       5.7298      2.00000
+    248       5.7562      2.00000
+    249       5.7778      2.00000
+    250       5.7962      2.00000
+    251       5.8010      2.00000
+    252       5.8473      2.00000
+    253       5.8814      2.00000
+    254       5.8997      2.00000
+    255       5.9143      2.00000
+    256       5.9362      2.00000
+    257       5.9596      2.00000
+    258       6.0052      2.00000
+    259       6.0194      2.00000
+    260       6.0448      2.00000
+    261       6.0666      2.00000
+    262       6.1007      2.00000
+    263       6.1280      2.00000
+    264       6.1365      2.00000
+    265       6.1727      2.00000
+    266       6.1782      2.00000
+    267       6.2196      2.00000
+    268       6.2422      2.00000
+    269       6.2690      2.00000
+    270       6.3029      2.00000
+    271       6.3111      2.00000
+    272       6.3327      2.00000
+    273       6.3456      2.00000
+    274       6.3903      2.00000
+    275       6.3968      2.00000
+    276       6.4236      2.00000
+    277       6.4448      2.00000
+    278       6.4610      2.00000
+    279       6.4857      2.00000
+    280       6.5137      2.00000
+    281       6.5520      2.00000
+    282       6.5619      2.00000
+    283       6.5988      2.00000
+    284       6.6205      2.00000
+    285       6.6364      2.00000
+    286       6.6878      2.00000
+    287       6.7088      2.00000
+    288       6.7356      2.00000
+    289       6.7548      2.00000
+    290       6.7805      2.00000
+    291       6.8386      2.00000
+    292       6.8518      2.00000
+    293       6.8735      2.00000
+    294       6.8888      2.00000
+    295       6.9351      2.00059
+    296       6.9754      2.01716
+    297       7.0106      2.07018
+    298       7.0596      1.47518
+    299       7.0742      1.00530
+    300       7.1090      0.08414
+    301       7.1475     -0.05842
+    302       7.1548     -0.04526
+    303       7.1883     -0.00587
+    304       7.2010     -0.00200
+    305       7.2320     -0.00008
+    306       7.2443     -0.00002
+    307       7.2844     -0.00000
+    308       7.3205     -0.00000
+    309       7.3718     -0.00000
+    310       7.3923     -0.00000
+    311       7.4297     -0.00000
+    312       7.4784     -0.00000
+    313       7.5441     -0.00000
+    314       7.5611     -0.00000
+    315       7.5770     -0.00000
+    316       7.6045     -0.00000
+    317       7.6361     -0.00000
+    318       7.6574     -0.00000
+    319       7.6734     -0.00000
+    320       7.6952     -0.00000
+    321       7.7291     -0.00000
+    322       7.7507     -0.00000
+    323       7.8013     -0.00000
+    324       7.8259     -0.00000
+    325       7.8506     -0.00000
+    326       7.8943     -0.00000
+    327       7.9046     -0.00000
+    328       7.9761     -0.00000
+    329       8.0388     -0.00000
+    330       8.0921     -0.00000
+    331       8.1717     -0.00000
+    332       8.2240     -0.00000
+    333       8.2481     -0.00000
+    334       8.3435     -0.00000
+    335       8.3672     -0.00000
+    336       8.4359     -0.00000
+    337       8.5047      0.00000
+    338       8.5460      0.00000
+    339       8.5508      0.00000
+    340       8.6916      0.00000
+    341       8.7254      0.00000
+    342       8.7716      0.00000
+    343       8.8399      0.00000
+    344       8.9291      0.00000
+    345       8.9485      0.00000
+    346       9.0470      0.00000
+    347       9.1102      0.00000
+    348       9.1831      0.00000
+    349       9.2377      0.00000
+    350       9.2863      0.00000
+    351       9.3295      0.00000
+    352       9.4686      0.00000
+    353       9.5129      0.00000
+    354       9.6361      0.00000
+    355       9.6886      0.00000
+    356       9.7900      0.00000
+    357       9.9104      0.00000
+    358       9.9905      0.00000
+    359      10.0226      0.00000
+    360      10.3084      0.00000
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+ soft charge-density along one line, spin component           1
+         0         1         2         3         4         5         6         7         8         9
+ total charge-density along one line
+ 
+ pseudopotential strength for first ion, spin component:           1
+-35.817   0.008  -0.044   8.321  -0.004   0.026   0.012   0.014
+  0.008 -35.881  -0.031  -0.004   8.353   0.017   0.000  -0.007
+ -0.044  -0.031 -35.842   0.026   0.017   8.332  -0.012   0.000
+  8.321  -0.004   0.026   4.955   0.002  -0.008  -0.003  -0.004
+ -0.004   8.353   0.017   0.002   4.943  -0.004   0.000   0.002
+  0.026   0.017   8.332  -0.008  -0.004   4.950   0.003   0.000
+  0.012   0.000  -0.012  -0.003   0.000   0.003  -2.356  -0.018
+  0.014  -0.007   0.000  -0.004   0.002   0.000  -0.018  -2.376
+  0.008   0.016  -0.009  -0.002  -0.005   0.002   0.027   0.003
+  0.000   0.006   0.011   0.000  -0.002  -0.005   0.004  -0.023
+  0.009  -0.002   0.009  -0.002  -0.000  -0.003   0.001  -0.005
+  0.012   0.000  -0.012  -0.003   0.000   0.003  -2.819  -0.018
+  0.014  -0.007   0.000  -0.004   0.002   0.000  -0.018  -2.839
+  0.008   0.016  -0.009  -0.002  -0.005   0.002   0.027   0.003
+  0.000   0.006   0.011   0.000  -0.003  -0.005   0.004  -0.023
+  0.009  -0.002   0.009  -0.003  -0.000  -0.003   0.001  -0.005
+  0.004  -0.005  -0.004   0.002   0.001  -0.001   0.014  -0.002
+  0.009  -0.011  -0.008   0.004   0.003  -0.002   0.029  -0.004
+ total augmentation occupancy for first ion, spin component:           1
+  1.987   0.000  -0.001  -0.047   0.000  -0.003   0.003   0.000   0.003  -0.001  -0.002  -0.004  -0.001  -0.003   0.001   0.001
+  0.000   1.986  -0.000   0.000  -0.049  -0.001  -0.001   0.004   0.000  -0.004  -0.000   0.001  -0.003  -0.001   0.003  -0.000
+ -0.001  -0.000   1.986  -0.003  -0.001  -0.047  -0.001  -0.001  -0.003   0.001  -0.003   0.003   0.001   0.003  -0.002   0.002
+ -0.047   0.000  -0.003   0.111  -0.003   0.008  -0.001  -0.028  -0.033  -0.013  -0.015  -0.002   0.013   0.018   0.004   0.022
+  0.000  -0.049  -0.001  -0.003   0.120  -0.009  -0.009   0.036  -0.005   0.026   0.039   0.003  -0.045  -0.012  -0.011  -0.018
+ -0.003  -0.001  -0.047   0.008  -0.009   0.114   0.036  -0.001   0.014   0.029  -0.002  -0.042  -0.002  -0.007  -0.019   0.002
+  0.003  -0.001  -0.001  -0.001  -0.009   0.036   0.993   0.100   0.248  -0.120   0.072  -0.315   0.007  -0.032   0.038  -0.007
+  0.000   0.004  -0.001  -0.028   0.036  -0.001   0.100   0.746   0.083   0.135  -0.069   0.011  -0.323  -0.016  -0.015  -0.009
+  0.003   0.000  -0.003  -0.033  -0.005   0.014   0.248   0.083   0.806  -0.061   0.101  -0.037  -0.018  -0.339  -0.002  -0.042
+ -0.001  -0.004   0.001  -0.013   0.026   0.029  -0.120   0.135  -0.061   0.733  -0.045   0.036  -0.014  -0.006  -0.260  -0.015
+ -0.002  -0.000  -0.003  -0.015   0.039  -0.002   0.072  -0.069   0.101  -0.045   0.597  -0.007  -0.004  -0.043  -0.004  -0.300
+ -0.004   0.001   0.003  -0.002   0.003  -0.042  -0.315   0.011  -0.037   0.036  -0.007   0.713  -0.074  -0.044  -0.007  -0.014
+ -0.001  -0.003   0.001   0.013  -0.045  -0.002   0.007  -0.323  -0.018  -0.014  -0.004  -0.074   0.829  -0.021  -0.067   0.033
+ -0.003  -0.001   0.003   0.018  -0.012  -0.007  -0.032  -0.016  -0.339  -0.006  -0.043  -0.044  -0.021   0.658   0.002   0.004
+  0.001   0.003  -0.002   0.004  -0.011  -0.019   0.038  -0.015  -0.002  -0.260  -0.004  -0.007  -0.067   0.002   0.726   0.005
+  0.001  -0.000   0.002   0.022  -0.018   0.002  -0.007  -0.009  -0.042  -0.015  -0.300  -0.014   0.033   0.004   0.005   0.747
+ -0.037   0.026   0.030  -0.019  -0.020   0.021  -0.289  -0.006  -0.106  -0.048  -0.024  -0.017   0.019  -0.011  -0.156   0.004
+  0.018  -0.012  -0.015  -0.001   0.002   0.000   0.060   0.010   0.035   0.027   0.012   0.020  -0.018   0.007   0.039   0.002
+
+
+------------------------ aborting loop because EDIFF is reached ----------------------------------------
+
+
+    CHARGE:  cpu time      0.5894: real time      0.5951
+    FORLOC:  cpu time      0.0510: real time      0.0513
+    FORNL :  cpu time      5.1131: real time      5.1639
+    STRESS:  cpu time     14.7825: real time     14.9092
+    FORCOR:  cpu time      0.1615: real time      0.1651
+    FORHAR:  cpu time      0.0668: real time      0.0671
+    MIXING:  cpu time      0.0123: real time      0.0124
+    OFIELD:  cpu time      0.0004: real time      0.0027
+
+  FORCE on cell =-STRESS in cart. coord.  units (eV):
+  Direction    XX          YY          ZZ          XY          YZ          ZX
+  --------------------------------------------------------------------------------------
+  Alpha Z  4840.36665  4840.36665  4840.36665
+  Ewald  -20775.61769-20321.68350-20481.18833   -19.33854   109.18612   -58.79623
+  Hartree  7140.02321  7569.06727  7430.65860   -55.11559   105.97491   -66.71496
+  E(xc)   -3321.58421 -3321.43776 -3321.47210     0.52883    -0.14278    -0.24191
+  Local    2909.06056  2030.47848  2321.61453    98.58454  -221.55698   123.14775
+  n-local -1999.67298 -1999.45191 -1999.60448    -9.21793     7.29249     3.09186
+  augment  3709.14245  3707.47133  3710.67032    -7.54314     1.90519     0.03451
+  Kinetic  7473.50869  7473.63610  7477.40656     2.05932    -7.21949    -3.01585
+  Fock        0.00000     0.00000     0.00000     0.00000     0.00000     0.00000
+  -------------------------------------------------------------------------------------
+  Total     -24.77332   -21.55335   -21.54825     9.95749    -4.56054    -2.49483
+  in kB     -51.05240   -44.41674   -44.40624    20.52021    -9.39828    -5.14130
+  external pressure =      -46.63 kB  Pullay stress =        0.00 kB
+
+
+ VOLUME and BASIS-vectors are now :
+ -----------------------------------------------------------------------------
+  energy-cutoff  :      520.00
+  volume of cell :      777.46
+      direct lattice vectors                 reciprocal lattice vectors
+     8.032717050  0.000000000  0.000000000     0.124490878  0.000000000  0.000000000
+     0.000000000  8.032717050  0.000000000     0.000000000  0.124490878  0.000000000
+     0.000000000  0.000000000 12.049075575     0.000000000  0.000000000  0.082993919
+
+  length of vectors
+     8.032717050  8.032717050 12.049075575     0.124490878  0.124490878  0.082993919
+
+
+ FORCES acting on ions
+    electron-ion (+dipol)            ewald-force                    non-local-force                 convergence-correction
+ -----------------------------------------------------------------------------------------------
+   0.102E+03 0.125E+03 0.972E+02   -.101E+03 -.127E+03 -.966E+02   -.129E+01 0.130E+01 0.260E+00   -.887E-02 0.260E-02 -.234E-01
+   0.154E+03 -.276E+02 -.147E+02   -.156E+03 0.296E+02 0.160E+02   0.236E+01 -.269E+01 -.876E+00   0.100E-01 -.333E-02 0.182E-01
+   0.676E+02 0.557E+02 -.124E+03   -.677E+02 -.555E+02 0.126E+03   -.553E-01 -.308E+00 -.158E+01   0.992E-03 0.144E-01 0.153E-01
+   0.103E+03 -.169E-01 0.923E+02   -.103E+03 0.502E+00 -.911E+02   -.234E+00 -.107E+01 -.152E+01   -.121E-01 0.114E-01 -.331E-01
+   -.612E+02 -.112E+03 -.115E+03   0.585E+02 0.110E+03 0.117E+03   0.277E+01 0.147E+01 -.201E+01   -.243E-02 -.109E-01 0.648E-01
+   -.725E+02 0.479E+02 0.118E+03   0.744E+02 -.465E+02 -.117E+03   -.794E+00 -.210E+01 0.209E+00   -.308E-01 -.436E-02 -.566E-01
+   -.137E+02 -.333E+02 0.101E+03   0.184E+02 0.328E+02 -.103E+03   -.399E+01 0.461E+00 0.911E+00   -.191E-01 -.187E-01 0.340E-01
+   0.123E+03 0.775E+02 -.277E+01   -.125E+03 -.783E+02 0.138E+01   0.175E+01 0.828E+00 0.112E+01   0.722E-02 0.155E-01 -.245E-01
+   0.624E+02 -.240E+02 -.877E+02   -.653E+02 0.263E+02 0.875E+02   0.251E+01 -.186E+01 0.245E-01   -.697E-02 -.238E-01 0.403E-01
+   0.144E+03 0.694E+01 0.530E+02   -.145E+03 -.406E+01 -.525E+02   -.898E+00 -.237E+01 0.347E+00   0.281E-01 0.214E-03 -.590E-01
+   0.496E+02 0.930E+02 0.218E+02   -.501E+02 -.940E+02 -.245E+02   -.550E+00 0.941E+00 0.234E+01   -.240E-02 0.199E-01 0.512E-01
+   -.652E+02 -.127E+02 0.574E+02   0.658E+02 0.125E+02 -.575E+02   -.736E+00 0.229E+00 -.838E-02   -.378E-02 0.415E-02 -.335E-01
+   -.856E+02 0.419E+02 0.408E+02   0.852E+02 -.441E+02 -.426E+02   0.879E+00 0.245E+01 0.237E+01   0.308E-02 -.128E-01 0.444E-01
+   0.298E+02 0.158E+03 -.222E+03   -.295E+02 -.160E+03 0.221E+03   -.162E+00 0.197E+01 0.495E+00   0.128E-01 0.577E-02 0.469E-01
+   -.535E+02 -.209E+03 -.135E+03   0.555E+02 0.213E+03 0.137E+03   -.138E+01 -.279E+01 -.195E+01   -.884E-04 -.104E-01 0.617E-01
+   0.643E+02 -.751E+02 0.736E+02   -.637E+02 0.749E+02 -.724E+02   -.242E+00 -.423E+00 -.926E+00   -.392E-03 0.309E-01 -.739E-01
+   -.195E+02 0.220E+03 -.130E+03   0.172E+02 -.219E+03 0.130E+03   0.139E+01 -.855E+00 0.700E-02   -.315E-02 0.588E-02 0.147E-01
+   -.168E+03 0.523E+02 0.435E+02   0.169E+03 -.493E+02 -.435E+02   -.587E+00 -.321E+01 0.737E+00   0.115E-01 0.565E-02 -.610E-01
+   0.100E+03 0.462E+02 0.216E+03   -.104E+03 -.430E+02 -.214E+03   0.308E+01 -.275E+01 -.206E+01   0.534E-01 -.324E-01 -.525E-01
+   -.202E+03 -.102E+03 -.116E+03   0.201E+03 0.103E+03 0.115E+03   0.155E+01 -.458E+00 0.744E+00   -.607E-02 0.125E-01 -.399E-01
+   -.169E+03 0.729E+02 -.289E+02   0.170E+03 -.725E+02 0.275E+02   -.104E+01 -.283E+00 0.617E+00   -.174E-01 -.330E-02 0.381E-01
+   0.157E+03 -.808E+01 -.366E+02   -.158E+03 0.834E+01 0.359E+02   0.145E+00 0.308E+00 0.117E+01   0.222E-01 -.180E-01 0.229E-01
+   -.107E+03 0.413E+02 -.450E+02   0.109E+03 -.414E+02 0.478E+02   -.180E+01 -.287E+00 -.142E+01   -.572E-02 0.118E-02 -.208E-01
+   0.119E+03 0.158E+02 0.135E+02   -.119E+03 -.179E+02 -.105E+02   0.279E+00 0.179E+01 -.206E+01   0.464E-02 -.190E-02 -.392E-01
+   -.121E+03 0.639E+02 0.138E+03   0.120E+03 -.659E+02 -.136E+03   0.114E+01 0.155E+01 -.212E+01   0.825E-02 -.688E-02 -.193E-01
+   0.119E+03 0.822E+02 -.523E+02   -.119E+03 -.809E+02 0.510E+02   0.188E+01 0.442E+00 0.551E-01   0.152E-01 0.414E-02 0.371E-01
+   -.319E+02 -.415E+02 -.193E+03   0.313E+02 0.403E+02 0.191E+03   -.147E+01 0.371E+00 0.568E+00   -.232E-01 0.445E-02 0.528E-01
+   0.178E+03 -.102E+03 0.313E+01   -.180E+03 0.103E+03 -.463E+01   0.104E+01 -.860E+00 0.271E+01   0.177E-01 -.143E-01 -.255E-01
+   0.111E+03 -.361E+01 -.116E+03   -.113E+03 0.287E+01 0.117E+03   0.140E+01 -.518E+00 0.274E+00   0.507E-01 0.155E-01 0.466E-01
+   -.998E+02 -.515E+02 0.864E+02   0.102E+03 0.538E+02 -.870E+02   0.709E+00 -.107E+01 0.108E+01   -.249E-01 0.352E-02 -.179E-01
+   -.827E+02 0.269E+02 0.159E+03   0.827E+02 -.288E+02 -.161E+03   -.384E+00 -.824E+00 -.678E+00   0.103E-01 0.344E-02 -.842E-02
+   0.146E+03 -.133E+03 -.197E+02   -.146E+03 0.134E+03 0.183E+02   -.833E-01 -.369E+00 0.140E+01   0.580E-02 -.368E-02 -.234E-01
+   -.148E+03 -.158E+03 -.333E+02   0.149E+03 0.156E+03 0.318E+02   -.308E+00 0.924E+00 0.338E+00   0.514E-02 -.344E-02 0.115E-01
+   -.132E+03 -.170E+03 -.122E+03   0.133E+03 0.172E+03 0.121E+03   -.102E+01 -.922E+00 -.764E-01   -.657E-02 0.432E-02 0.114E-01
+   0.734E+02 -.389E+02 0.156E+03   -.757E+02 0.394E+02 -.154E+03   0.100E+01 0.287E+00 -.690E+00   0.437E-02 -.929E-02 -.319E-01
+   0.499E+02 0.926E+02 -.487E+02   -.535E+02 -.930E+02 0.484E+02   0.217E+01 0.871E+00 -.200E+00   0.167E-01 0.250E-02 0.659E-02
+   -.152E+03 -.226E+02 0.329E+02   0.154E+03 0.233E+02 -.344E+02   -.510E+00 0.769E-01 0.757E+00   -.468E-01 0.169E-01 0.489E-01
+   0.811E+02 -.219E+02 0.164E+03   -.813E+02 0.215E+02 -.164E+03   -.457E+00 -.872E-01 -.192E+00   0.260E-01 0.224E-01 -.133E-01
+   -.973E+02 -.139E+02 -.213E+02   0.991E+02 0.149E+02 0.205E+02   -.179E+01 -.117E+01 0.103E+01   0.282E-02 0.135E-01 0.371E-01
+   -.549E+02 0.159E+03 -.153E+03   0.564E+02 -.159E+03 0.153E+03   -.141E+01 0.209E+00 -.199E+00   -.158E-01 -.298E-02 0.674E-02
+   0.149E+03 -.752E+02 -.131E+03   -.148E+03 0.745E+02 0.132E+03   -.114E+01 0.887E+00 -.220E-01   -.394E-02 -.134E-01 0.162E-01
+   0.195E+02 0.258E+02 -.104E+03   -.190E+02 -.247E+02 0.104E+03   -.103E+01 -.149E+00 -.317E+00   -.510E-02 0.118E-01 0.545E-01
+   -.986E+02 -.435E+02 0.612E+01   0.973E+02 0.417E+02 -.531E+01   0.380E+00 0.186E+01 -.872E+00   -.306E-03 -.113E-02 -.418E-01
+   -.840E+02 -.181E+02 0.151E+03   0.843E+02 0.169E+02 -.151E+03   0.263E+00 0.136E+01 0.408E+00   -.428E-02 -.284E-02 -.138E-01
+   0.531E+02 0.522E+02 0.120E+03   -.527E+02 -.520E+02 -.120E+03   -.444E+00 0.809E+00 0.372E+00   -.612E-02 -.153E-01 -.435E-01
+   -.136E+03 -.429E+02 0.748E+02   0.137E+03 0.427E+02 -.759E+02   0.765E-01 0.301E+00 0.107E+01   -.141E-01 -.138E-02 -.164E-01
+   0.696E+02 -.545E+02 -.373E+02   -.703E+02 0.555E+02 0.395E+02   0.144E+01 -.182E+01 -.367E+01   0.203E-01 -.233E-02 0.465E-01
+   -.772E+02 0.460E+02 0.725E+02   0.775E+02 -.451E+02 -.722E+02   0.159E+00 -.666E+00 0.120E+01   -.296E-01 -.406E-02 -.329E-01
+ -----------------------------------------------------------------------------------------------
+   -.460E+01 0.822E+01 0.795E+00   0.242E-12 -.426E-13 0.284E-13   0.455E+01 -.821E+01 -.828E+00   0.375E-01 0.115E-01 0.231E-01
+ 
+ 
+ POSITION                                       TOTAL-FORCE (eV/Angst)
+ -----------------------------------------------------------------------------------
+      4.00924      1.98949      6.10014         0.065546     -0.556511      0.837622
+      5.97793      6.18207      4.01522         0.001551     -0.748647      0.454988
+      4.09751      3.91434      3.88923        -0.221514     -0.110723      0.393677
+      3.98259      2.06627     10.07882        -0.331151     -0.574846     -0.374817
+      3.87615      5.90361      2.03085         0.128675     -0.074095     -0.170642
+      1.97651      2.04860      8.00279         1.051241     -0.700586      0.849139
+      2.13905      6.00825      0.02187         0.755009     -0.024695     -0.694492
+      5.98585      4.14978      5.96787        -0.181246     -0.041100     -0.295329
+      3.98388      7.97535     11.87748        -0.417499      0.426001     -0.057443
+      6.17693      2.04310      7.88604        -1.640144      0.507965      0.833289
+      4.06375      4.07621      0.07787        -1.099179      0.052844     -0.288847
+      2.06242      6.13574      8.12023        -0.132922     -0.051895     -0.163275
+      7.96546      4.13265     11.96247         0.518775      0.238191      0.686160
+      7.98837      2.00300      1.95770         0.071488     -0.028687     -0.138498
+      7.91074      5.93839      1.94143         0.577300      0.589053      0.225503
+      3.97553      4.04833      8.04252         0.409365     -0.613573      0.168448
+      0.14080      4.13649      4.02928        -0.897513      0.204524     -0.817713
+      0.05866      0.04983      7.93439         0.631852     -0.190985      0.713677
+      5.99828      0.03782     10.03759        -0.443849      0.437987     -0.097039
+      8.03090      6.01314      5.98876         0.029252     -0.148284     -0.000082
+      1.94813      3.94138      2.07627        -0.108337      0.137530     -0.756977
+      6.11668      6.09621     11.90789        -0.233559      0.544124      0.499545
+      2.04575      4.05589      5.96968         0.494251     -0.345987      1.335394
+      6.03029      6.15108      8.06070         0.582913     -0.353212      0.860504
+      8.03118      2.09799      6.06572         0.710873     -0.399934      0.115283
+      5.98358      4.09186      2.09058         1.683533      1.672667     -1.222876
+      2.08571      8.00449      1.99865        -2.054226     -0.824487     -1.340272
+      6.00460      7.94972      5.97864        -0.474383      0.739040      1.189970
+      6.03296      1.99694     11.95599        -1.166611     -1.242455      1.261683
+      1.81144      4.02030      9.94361         2.499296      1.247078      0.502324
+      0.05142      2.08520     10.25352        -0.325968     -2.661868     -2.336233
+      4.05929      5.95674      6.04597        -0.705371      0.216526      0.022960
+      7.93340      7.98798      4.05306         0.639319     -0.877336     -1.199050
+      2.09287      6.01237      3.99928         0.516911      0.288550     -0.911925
+      3.97536      5.90761     10.06290        -1.271741      0.770687      0.995128
+      6.04504      2.08104      4.09016        -1.348708      0.474592     -0.503683
+      1.94620      1.87635      0.11919         1.604798      0.800514     -0.721834
+      6.07804      4.06607     10.11392        -0.580145     -0.411107     -0.583342
+      0.02846      7.93955     11.98622         0.040104     -0.122660      0.237051
+      2.07468      2.03490      3.92240        -0.007182     -0.058435      0.274850
+      4.10929      8.02648      3.96951        -0.492416      0.165010      1.257312
+      4.12316      1.87279      1.96678        -0.584261      0.975605     -0.585494
+      7.92047      4.08377      8.02836        -0.907762      0.082496     -0.109243
+      0.04762      6.01107     10.05581         0.613027      0.178227      0.001061
+      3.90828      0.03736      8.08878        -0.108712      0.972914     -0.284042
+      2.01040      7.98221      6.02465         0.980083      0.035599     -0.095104
+      6.00197      7.99108      2.10307         0.748475     -0.839800     -1.407710
+      1.96990      0.01466      9.90941         0.380764      0.244185      1.440394
+ -----------------------------------------------------------------------------------
+    total drift:                               -0.010992      0.016723     -0.009731
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+
+  FREE ENERGIE OF THE ION-ELECTRON SYSTEM (eV)
+  ---------------------------------------------------
+  free  energy   TOTEN  =      -355.37383073 eV
+
+  energy  without entropy=     -355.36813127  energy(sigma->0) =     -355.37193091
+ 
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+    POTLOK:  cpu time      0.6198: real time      0.6242
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+     LOOP+:  cpu time    875.3798: real time    885.7535
+    4ORBIT:  cpu time      0.0000: real time      0.0000
+
+ total amount of memory used by VASP MPI-rank0   153862. kBytes
+=======================================================================
+
+   base      :      30000. kBytes
+   nonlr-proj:      19725. kBytes
+   fftplans  :       8164. kBytes
+   grid      :      32576. kBytes
+   one-center:        360. kBytes
+   wavefun   :      63037. kBytes
+ 
+  
+  
+ General timing and accounting informations for this job:
+ ========================================================
+  
+                  Total CPU time used (sec):      883.393
+                            User time (sec):      870.730
+                          System time (sec):       12.663
+                         Elapsed time (sec):      894.535
+  
+                   Maximum memory used (kb):      264068.
+                   Average memory used (kb):          N/A
+  
+                          Minor page faults:        91473
+                          Major page faults:        44285
+                 Voluntary context switches:         2604

--- a/tests/test_vasp_outcar.py
+++ b/tests/test_vasp_outcar.py
@@ -132,5 +132,17 @@ class TestVaspAtomNamesV6(unittest.TestCase):
         np.testing.assert_equal(ss.get_atom_types(), [0, 0, 0, 1, 1, 0, 0, 0])
 
 
+class TestVaspOUTCARLongIonTypes(unittest.TestCase):
+    def test(self):
+        # vasp<=6.3 only print ions per type for the first 10 types of atoms
+        # raise exception when the bug is triggered.
+        with self.assertRaises(RuntimeError) as c:
+            ss = dpdata.LabeledSystem("poscars/outcar.longit/OUTCAR")
+        self.assertTrue(
+            "The number of the atom numbers per each type" in str(c.exception)
+        )
+        self.assertTrue("does not match that of the atom types" in str(c.exception))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling to detect and alert users when there is a mismatch between atom counts and types in VASP OUTCAR files, preventing silent data inconsistencies.

* **Refactor**
  * Enhanced file handling for frame extraction to ensure files are properly closed and code is more maintainable.

* **Tests**
  * Added a new test to verify correct error reporting for OUTCAR files with more than 10 atom types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->