### PR TITLE
Latest support for abacus scf output

### DIFF
--- a/dpdata/abacus/scf.py
+++ b/dpdata/abacus/scf.py
@@ -45,10 +45,10 @@ def get_path_out(fname, inlines):
 def get_energy(outlines):
     Etot = None
     for line in reversed(outlines):
-        if "final etot is" in line:
+        if "final etot is" in line: # for LTS
             Etot = float(line.split()[-2])  # in eV
-        if "ETOT" in line:
-            Etot = float(line.split()[1])  # in eV
+        elif "TOTAL ENERGY" in line: # for develop
+            Etot = float(line.split()[-2])  # in eV
             return Etot, True
         elif "convergence has NOT been achieved!" in line:
             return Etot, False

--- a/dpdata/abacus/scf.py
+++ b/dpdata/abacus/scf.py
@@ -45,9 +45,9 @@ def get_path_out(fname, inlines):
 def get_energy(outlines):
     Etot = None
     for line in reversed(outlines):
-        if "final etot is" in line: # for LTS
+        if "final etot is" in line:  # for LTS
             Etot = float(line.split()[-2])  # in eV
-        elif "TOTAL ENERGY" in line: # for develop
+        elif "TOTAL ENERGY" in line:  # for develop
             Etot = float(line.split()[-2])  # in eV
             return Etot, True
         elif "convergence has NOT been achieved!" in line:

--- a/dpdata/abacus/scf.py
+++ b/dpdata/abacus/scf.py
@@ -45,8 +45,8 @@ def get_path_out(fname, inlines):
 def get_energy(outlines):
     Etot = None
     for line in reversed(outlines):
-        if "final etot is" in line:
-            Etot = float(line.split()[-2])  # in eV
+        if "ETOT" in line:
+            Etot = float(line.split()[1])  # in eV
             return Etot, True
         elif "convergence has NOT been achieved!" in line:
             return Etot, False
@@ -59,7 +59,8 @@ def get_energy(outlines):
 def collect_force(outlines):
     force = []
     for i, line in enumerate(outlines):
-        if "TOTAL-FORCE (eV/Angstrom)" in line:
+        #if "TOTAL-FORCE (eV/Angstrom)" in line:
+        if "TOTAL-FORCE" in line:
             value_pattern = re.compile(
                 r"^\s*[A-Z][a-z]?[1-9][0-9]*\s+[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?\s+[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?\s+[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?\s*$"
             )
@@ -95,7 +96,8 @@ def get_force(outlines, natoms):
 def collect_stress(outlines):
     stress = []
     for i, line in enumerate(outlines):
-        if "TOTAL-STRESS (KBAR)" in line:
+        #if "TOTAL-STRESS (KBAR)" in line:
+        if "TOTAL-STRESS" in line:
             value_pattern = re.compile(
                 r"^\s*[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?\s+[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?\s+[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?\s*$"
             )

--- a/dpdata/abacus/scf.py
+++ b/dpdata/abacus/scf.py
@@ -48,7 +48,7 @@ def get_energy(outlines):
         if "final etot is" in line:  # for LTS
             Etot = float(line.split()[-2])  # in eV
             return Etot, True
-        elif "TOTAL ENERGY" in line: # for develop
+        elif "TOTAL ENERGY" in line:  # for develop
             Etot = float(line.split()[-2])  # in eV
             return Etot, True
         elif "convergence has NOT been achieved!" in line:

--- a/dpdata/abacus/scf.py
+++ b/dpdata/abacus/scf.py
@@ -45,6 +45,8 @@ def get_path_out(fname, inlines):
 def get_energy(outlines):
     Etot = None
     for line in reversed(outlines):
+        if "final etot is" in line:
+            Etot = float(line.split()[-2])  # in eV
         if "ETOT" in line:
             Etot = float(line.split()[1])  # in eV
             return Etot, True

--- a/dpdata/abacus/scf.py
+++ b/dpdata/abacus/scf.py
@@ -47,7 +47,8 @@ def get_energy(outlines):
     for line in reversed(outlines):
         if "final etot is" in line:  # for LTS
             Etot = float(line.split()[-2])  # in eV
-        elif "TOTAL ENERGY" in line:  # for develop
+            return Etot, True
+        elif "TOTAL ENERGY" in line: # for develop
             Etot = float(line.split()[-2])  # in eV
             return Etot, True
         elif "convergence has NOT been achieved!" in line:

--- a/dpdata/abacus/scf.py
+++ b/dpdata/abacus/scf.py
@@ -59,7 +59,7 @@ def get_energy(outlines):
 def collect_force(outlines):
     force = []
     for i, line in enumerate(outlines):
-        #if "TOTAL-FORCE (eV/Angstrom)" in line:
+        # if "TOTAL-FORCE (eV/Angstrom)" in line:
         if "TOTAL-FORCE" in line:
             value_pattern = re.compile(
                 r"^\s*[A-Z][a-z]?[1-9][0-9]*\s+[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?\s+[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?\s+[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?\s*$"
@@ -96,7 +96,7 @@ def get_force(outlines, natoms):
 def collect_stress(outlines):
     stress = []
     for i, line in enumerate(outlines):
-        #if "TOTAL-STRESS (KBAR)" in line:
+        # if "TOTAL-STRESS (KBAR)" in line:
         if "TOTAL-STRESS" in line:
             value_pattern = re.compile(
                 r"^\s*[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?\s+[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?\s+[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?\s*$"


### PR DESCRIPTION
Abacus updates its output format, so these keywords were not right. I have updated them to support both eariler ones and latest one by removing the unit part. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness when reading ABACUS simulation outputs by accepting more variations of energy, force, and stress headers.
  * More permissive header matching reduces failures from minor log-format differences.
  * Preserves existing convergence and extraction behavior while improving tolerance for alternate log phrasing.
  * Reduces missed or incomplete parses, increasing reliability across ABACUS log variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->