### PR TITLE
feat: do not output spin info for lmp format

### DIFF
--- a/dpdata/lammps/lmp.py
+++ b/dpdata/lammps/lmp.py
@@ -484,7 +484,7 @@ def rotate_to_lower_triangle(
     return cell, coord
 
 
-def from_system_data(system, f_idx=0):
+def from_system_data(system, f_idx=0, output_spins=False):
     ret = ""
     ret += "\n"
     natoms = sum(system["atom_numbs"])
@@ -529,7 +529,7 @@ def from_system_data(system, f_idx=0):
         + "\n"
     )  # noqa: UP031
 
-    if "spins" in system:
+    if "spins" in system and output_spins:
         coord_fmt = (
             coord_fmt.strip("\n")
             + " "
@@ -544,7 +544,7 @@ def from_system_data(system, f_idx=0):
         )  # noqa: UP031
         spins_norm = np.linalg.norm(system["spins"][f_idx], axis=1)
     for ii in range(natoms):
-        if "spins" in system:
+        if "spins" in system and output_spins:
             if spins_norm[ii] != 0:
                 ret += coord_fmt % (
                     ii + 1,

--- a/dpdata/plugins/lammps.py
+++ b/dpdata/plugins/lammps.py
@@ -108,7 +108,7 @@ class LAMMPSLmpFormat(Format):
         register_charge(data)
         return data
 
-    def to_system(self, data, file_name: FileType, frame_idx=0, **kwargs):
+    def to_system(self, data, file_name: FileType, frame_idx=0, output_spins=False, **kwargs):
         """Dump the system in lammps data format.
 
         Parameters
@@ -119,11 +119,14 @@ class LAMMPSLmpFormat(Format):
             The output file name
         frame_idx : int
             The index of the frame to dump
+        output_spins : bool, optional
+            Whether to output spin information columns. Default is False.
+            When True, outputs additional columns for spin direction and magnitude.
         **kwargs : dict
             other parameters
         """
         assert frame_idx < len(data["coords"])
-        w_str = dpdata.lammps.lmp.from_system_data(data, frame_idx)
+        w_str = dpdata.lammps.lmp.from_system_data(data, frame_idx, output_spins=output_spins)
         with open_file(file_name, "w") as fp:
             fp.write(w_str)
 

--- a/dpdata/plugins/lammps.py
+++ b/dpdata/plugins/lammps.py
@@ -108,7 +108,9 @@ class LAMMPSLmpFormat(Format):
         register_charge(data)
         return data
 
-    def to_system(self, data, file_name: FileType, frame_idx=0, output_spins=False, **kwargs):
+    def to_system(
+        self, data, file_name: FileType, frame_idx=0, output_spins=False, **kwargs
+    ):
         """Dump the system in lammps data format.
 
         Parameters
@@ -126,7 +128,9 @@ class LAMMPSLmpFormat(Format):
             other parameters
         """
         assert frame_idx < len(data["coords"])
-        w_str = dpdata.lammps.lmp.from_system_data(data, frame_idx, output_spins=output_spins)
+        w_str = dpdata.lammps.lmp.from_system_data(
+            data, frame_idx, output_spins=output_spins
+        )
         with open_file(file_name, "w") as fp:
             fp.write(w_str)
 

--- a/dpdata/plugins/lammps.py
+++ b/dpdata/plugins/lammps.py
@@ -109,7 +109,7 @@ class LAMMPSLmpFormat(Format):
         return data
 
     def to_system(
-        self, data, file_name: FileType, frame_idx=0, output_spins=False, **kwargs
+        self, data, file_name: FileType, frame_idx=0, **kwargs
     ):
         """Dump the system in lammps data format.
 
@@ -121,13 +121,11 @@ class LAMMPSLmpFormat(Format):
             The output file name
         frame_idx : int
             The index of the frame to dump
-        output_spins : bool, optional
-            Whether to output spin information columns. Default is False.
-            When True, outputs additional columns for spin direction and magnitude.
         **kwargs : dict
             other parameters
         """
         assert frame_idx < len(data["coords"])
+        output_spins = bool(kwargs.pop("output_spins", False))
         w_str = dpdata.lammps.lmp.from_system_data(
             data, frame_idx, output_spins=output_spins
         )

--- a/dpdata/plugins/lammps.py
+++ b/dpdata/plugins/lammps.py
@@ -108,9 +108,7 @@ class LAMMPSLmpFormat(Format):
         register_charge(data)
         return data
 
-    def to_system(
-        self, data, file_name: FileType, frame_idx=0, **kwargs
-    ):
+    def to_system(self, data, file_name: FileType, frame_idx=0, **kwargs):
         """Dump the system in lammps data format.
 
         Parameters

--- a/tests/test_lammps_spin.py
+++ b/tests/test_lammps_spin.py
@@ -48,8 +48,8 @@ class TestLmp(unittest.TestCase):
     def tearDown(self):
         pass  # if os.path.isfile(self.lmp_coord_name):os.remove(self.lmp_coord_name)
 
-    def test_dump_input(self):
-        self.tmp_system.to("lammps/lmp", self.lmp_coord_name)
+    def test_dump_input(self, output_spins=False):
+        self.tmp_system.to("lammps/lmp", self.lmp_coord_name, output_spins=output_spins)
         self.assertTrue(os.path.isfile(self.lmp_coord_name))
         with open(self.lmp_coord_name) as f:
             c = f.read()
@@ -58,9 +58,9 @@ class TestLmp(unittest.TestCase):
      2      2    1.2621856000    0.7018028000    0.5513885000    0.0000000000    0.8000000000    0.6000000000    5.0000000000"""
         self.assertTrue(coord_ref in c)
 
-    def test_dump_input_zero_spin(self):
+    def test_dump_input_zero_spin(self, output_spins=True):
         self.tmp_system.data["spins"] = [[[0, 0, 0], [0, 0, 0]]]
-        self.tmp_system.to("lammps/lmp", self.lmp_coord_name)
+        self.tmp_system.to("lammps/lmp", self.lmp_coord_name, output_spins=output_spins)
         self.assertTrue(os.path.isfile(self.lmp_coord_name))
         with open(self.lmp_coord_name) as f:
             c = f.read()


### PR DESCRIPTION
fix issue #885 in dpdata and issue #312 in dpgen2

However, adding an additional parameter is not the best method. Please provide another way to fix this issue, thanks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional setting to include per-atom spin information (direction and magnitude) in exported LAMMPS data; disabled by default and only emitted when explicitly enabled and spin data exists.

* **Tests**
  * Tests updated to parameterize and verify spin output behavior (on/off) and corresponding expected file contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->