### PR TITLE
Revert "CI: pin numpy to <2.3 & rdkit to <2025.3.3"

### DIFF
--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         python-version: '3.12'
     - run: pip install uv
-    - run: uv pip install --system -e .[amber,ase,pymatgen] 'rdkit<2025.3.3' openbabel-wheel
+    - run: uv pip install --system -e .[amber,ase,pymatgen] rdkit openbabel-wheel
     - uses: jakebailey/pyright-action@v2
       with:
         version: 1.1.363

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
           **/pyproject.toml
         cache-suffix: "py${{ matrix.python-version }}"
     - name: Install dependencies
-      run: uv pip install --system .[test,amber,ase,pymatgen] coverage ./tests/plugin 'rdkit<2025.3.3' openbabel-wheel 'numpy<2.3'
+      run: uv pip install --system .[test,amber,ase,pymatgen] coverage ./tests/plugin rdkit openbabel-wheel
     - name: Test
       run: cd tests && coverage run --source=../dpdata -m unittest && cd .. && coverage combine tests/.coverage && coverage report
     - name: Run codecov


### PR DESCRIPTION
Reverts deepmodeling/dpdata#837

Both issues have been fixed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed version constraints on chemistry and numeric dependencies in CI workflows (e.g., rdkit and numpy), switching to more permissive installs so the latest compatible package releases are used during automated tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->