### PR TITLE
[Fix] Include `#TOTAL ENERGY#` check in get_energy function of `abacus/[md,relax].py`

### DIFF
--- a/dpdata/abacus/md.py
+++ b/dpdata/abacus/md.py
@@ -135,7 +135,7 @@ def get_energy(outlines, ndump, dump_freq):
     energy = []
     nenergy = 0
     for line_idx, line in enumerate(outlines):
-        if "final etot is" in line:
+        if "final etot is" in line or "#TOTAL ENERGY#" in line:
             if nenergy % dump_freq == 0:
                 energy.append(float(line.split()[-2]))
             nenergy += 1

--- a/dpdata/abacus/relax.py
+++ b/dpdata/abacus/relax.py
@@ -94,7 +94,7 @@ def get_coords_from_log(loglines, natoms):
                     list(map(lambda x: float(x) * a0, loglines[i + k].split()[0:3]))
                 )
 
-        elif line[1:14] == "final etot is":
+        elif line[1:14] == "final etot is" or "#TOTAL ENERGY#" in line:
             # add the energy for previous structures whose SCF is not converged
             while len(energy) < len(coords) - 1:
                 energy.append(np.nan)


### PR DESCRIPTION
Fix #949.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved energy extraction from ABACUS MD logs to recognize additional energy markers, ensuring energy values are captured reliably across varied log formats and maintaining correct alignment with structure snapshots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->