### PR TITLE
chore: drop Python 3.8/3.9 support, bump minimum to 3.10

### DIFF
--- a/.github/workflows/pub-pypi.yml
+++ b/.github/workflows/pub-pypi.yml
@@ -10,10 +10,10 @@ jobs:
     steps:
     - uses: actions/checkout@master
 
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@master
       with:
-        python-version: 3.9
+        python-version: "3.10"
 
     - name: Install pypa/build
       run: >-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.8", "3.12"]
+        python-version: ["3.10", "3.13"]
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/test_import.yml
+++ b/.github/workflows/test_import.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v6
     - uses: actions/setup-python@v6
       with:
-        python-version: '3.9'
+        python-version: '3.10'
         architecture: 'x64'
     - run: python -m pip install uv
     - run: python -m uv pip install --system .

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ If you use this software, please cite the following paper:
 
 ## Installation
 
-dpdata only supports Python 3.8 and above. You can [setup a conda/pip environment](https://docs.deepmodeling.com/faq/conda.html), and then use one of the following methods to install dpdata:
+dpdata only supports Python 3.10 and above. You can [setup a conda/pip environment](https://docs.deepmodeling.com/faq/conda.html), and then use one of the following methods to install dpdata:
 
 - Install via pip: `pip install dpdata`
 - Install via conda: `conda install -c conda-forge dpdata`

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-dpdata only supports Python 3.8 and above. You can [setup a conda/pip environment](https://docs.deepmodeling.com/faq/conda.html), and then use one of the following methods to install dpdata:
+dpdata only supports Python 3.10 and above. You can [setup a conda/pip environment](https://docs.deepmodeling.com/faq/conda.html), and then use one of the following methods to install dpdata:
 
 - Install via pip: `pip install dpdata`
 - Install via conda: `conda install -c conda-forge dpdata`

--- a/dpdata/driver.py
+++ b/dpdata/driver.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Callable
+from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 from .plugin import Plugin
 

--- a/dpdata/driver.py
+++ b/dpdata/driver.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from .plugin import Plugin
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     import ase.calculators.calculator
 
 

--- a/dpdata/plugins/__init__.py
+++ b/dpdata/plugins/__init__.py
@@ -1,12 +1,8 @@
 from __future__ import annotations
 
 import importlib
+from importlib import metadata
 from pathlib import Path
-
-try:
-    from importlib import metadata
-except ImportError:  # for Python<3.8
-    import importlib_metadata as metadata
 
 PACKAGE_BASE = "dpdata.plugins"
 NOT_LOADABLE = ("__init__.py",)

--- a/dpdata/plugins/ase.py
+++ b/dpdata/plugins/ase.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import os
-from typing import TYPE_CHECKING, Generator
+from collections.abc import Generator
+from typing import TYPE_CHECKING
 
 import numpy as np
 

--- a/dpdata/plugins/ase.py
+++ b/dpdata/plugins/ase.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-from collections.abc import Generator
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -11,6 +10,8 @@ from dpdata.driver import Driver, Minimizer
 from dpdata.format import Format
 
 if TYPE_CHECKING:
+    from collections.abc import Generator
+
     import ase
     from ase.optimize.optimize import Optimizer
 

--- a/dpdata/system.py
+++ b/dpdata/system.py
@@ -6,7 +6,6 @@ import hashlib
 import numbers
 import os
 import warnings
-from collections.abc import Iterable
 from copy import deepcopy
 from typing import (
     TYPE_CHECKING,
@@ -37,6 +36,8 @@ from dpdata.utils import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     import parmed
 
 

--- a/dpdata/system.py
+++ b/dpdata/system.py
@@ -6,11 +6,11 @@ import hashlib
 import numbers
 import os
 import warnings
+from collections.abc import Iterable
 from copy import deepcopy
 from typing import (
     TYPE_CHECKING,
     Any,
-    Iterable,
     Literal,
     overload,
 )

--- a/dpdata/utils.py
+++ b/dpdata/utils.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import io
 import os
+from collections.abc import Generator
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Generator, Literal, overload
+from typing import TYPE_CHECKING, Literal, overload
 
 import numpy as np
 

--- a/dpdata/utils.py
+++ b/dpdata/utils.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import io
 import os
-from collections.abc import Generator
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Literal, overload
 
@@ -131,6 +130,7 @@ def utf8len(s: str) -> int:
 
 
 if TYPE_CHECKING:
+    from collections.abc import Generator
     FileType = io.IOBase | str | os.PathLike
 
 

--- a/dpdata/utils.py
+++ b/dpdata/utils.py
@@ -131,6 +131,7 @@ def utf8len(s: str) -> int:
 
 if TYPE_CHECKING:
     from collections.abc import Generator
+
     FileType = io.IOBase | str | os.PathLike
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,10 +12,10 @@ authors = [
 ]
 license = {file = "LICENSE"}
 classifiers = [
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
 ]
 dependencies = [
@@ -26,10 +26,8 @@ dependencies = [
     'wcmatch',
     'lmdb',
     'msgpack-numpy',
-    'importlib_metadata>=1.4; python_version < "3.8"',
-    'typing_extensions; python_version < "3.8"',
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 readme = "README.md"
 keywords = ["lammps", "vasp", "deepmd-kit"]
 
@@ -46,8 +44,7 @@ test = [
 ]
 ase = ['ase']
 amber = [
-    'parmed; python_version >= "3.8"',
-    'parmed<4; python_version < "3.8"',
+    'parmed',
 ]
 pymatgen = ['pymatgen']
 docs = [

--- a/tests/plugin/pyproject.toml
+++ b/tests/plugin/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     'dpdata',
 ]
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 
 [project.entry-points.'dpdata.plugins']
 random = "dpdata_plugin_test:ep"


### PR DESCRIPTION
Python 3.8 reached EOL in October 2024 and 3.9 in October 2025. The lmdb package is also broken on Python 3.8 CI runners. Update classifiers, requires-python, CI matrix, docs, and remove legacy Python <3.8 fallbacks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Raised minimum supported Python to 3.10 and removed older 3.8/3.9 support.
  * Added official support for newer Python versions (including 3.12/3.13).
  * Updated CI workflows and test matrix to target current Python versions.
  * Simplified compatibility markers and optional dependency declarations.
  * Adjusted internal compatibility imports to align with newer Python runtimes.

* **Documentation**
  * Updated installation docs and README to reflect Python 3.10+ requirement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->