### PR TITLE
fix: handle tuple dtype in DataType repr and error message

### DIFF
--- a/dpdata/data_type.py
+++ b/dpdata/data_type.py
@@ -32,6 +32,13 @@ class DataError(Exception):
     """Data is not correct."""
 
 
+def _dtype_name(dtype) -> str:
+    """Return a readable name for a dtype that may be a type or a tuple of types."""
+    if isinstance(dtype, tuple):
+        return ", ".join(t.__name__ for t in dtype)
+    return dtype.__name__
+
+
 class DataType:
     """DataType represents a type of data, like coordinates, energies, etc.
 
@@ -96,7 +103,7 @@ class DataType:
             string representation
         """
         return (
-            f"DataType(name='{self.name}', dtype={self.dtype.__name__}, "
+            f"DataType(name='{self.name}', dtype={_dtype_name(self.dtype)}, "
             f"shape={self.shape}, required={self.required}, "
             f"deepmd_name='{self.deepmd_name}')"
         )
@@ -145,7 +152,7 @@ class DataType:
                 pass
             elif not isinstance(data, self.dtype):
                 raise DataError(
-                    f"Type of {self.name} is {type(data).__name__}, but expected {self.dtype.__name__}"
+                    f"Type of {self.name} is {type(data).__name__}, but expected {_dtype_name(self.dtype)}"
                 )
             # check shape
             if self.shape is not None:

--- a/tests/test_custom_data_type.py
+++ b/tests/test_custom_data_type.py
@@ -7,7 +7,7 @@ import h5py  # noqa: TID253
 import numpy as np
 
 import dpdata
-from dpdata.data_type import Axis, DataType
+from dpdata.data_type import Axis, DataError, DataType
 
 
 class TestDataType(unittest.TestCase):
@@ -40,6 +40,31 @@ class TestDataType(unittest.TestCase):
             "deepmd_name='test')"
         )
         self.assertEqual(repr(dt), expected)
+
+    def test_repr_tuple_dtype(self):
+        """Regression test for #989: repr must handle a tuple dtype.
+
+        ``check`` accepts ``dtype`` as a ``type`` or a ``tuple[type]``, so repr
+        (and the type-mismatch error) must not assume ``dtype`` has ``__name__``.
+        """
+        dt = DataType("test", (list, np.ndarray), shape=(Axis.NFRAMES, 3))
+        expected = (
+            "DataType(name='test', dtype=list, ndarray, "
+            "shape=(<Axis.NFRAMES: 'nframes'>, 3), required=True, "
+            "deepmd_name='test')"
+        )
+        self.assertEqual(repr(dt), expected)
+
+    def test_check_tuple_dtype_error_message(self):
+        """Regression test for #989: a type mismatch against a tuple dtype must
+        raise a readable DataError, not AttributeError on ``tuple.__name__``.
+        """
+        dt = DataType("test", (list, np.ndarray), shape=(Axis.NFRAMES,))
+        system = dpdata.System()
+        system.data["test"] = "not a list or ndarray"
+        with self.assertRaises(DataError) as cm:
+            dt.check(system)
+        self.assertIn("expected list, ndarray", str(cm.exception))
 
     def test_register_same_data_type_no_warning(self):
         """Test registering identical DataType instances should not warn."""


### PR DESCRIPTION
## Summary

Fixes #989.

`DataType` documents and supports `dtype` as a `type` **or** a `tuple[type]` — `check()` already uses `isinstance(data, self.dtype)`, which is tuple-aware. But `__repr__` and the type-mismatch error in `check()` formatted the dtype via `self.dtype.__name__`, which raises `AttributeError: 'tuple' object has no attribute '__name__'` whenever `dtype` is a tuple. So `repr(DataType("x", (list, tuple)))` crashes instead of returning a string.

## Changes

- Added a small `_dtype_name()` helper that renders either a single type or a tuple of types.
- Used it in `__repr__` and in the `check()` error message.

## Testing

- Added regression tests: `repr` of a tuple-dtype `DataType` no longer raises and lists both type names; a type mismatch against a tuple dtype raises a readable `DataError` (not `AttributeError`). Both fail on `master` and pass with this change.
- `ruff check` clean; existing `TestDataType` tests pass.

---
*Disclosure: authored with AI assistance (Claude Code); reviewed by me and I'll shepherd it through review.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how data type information is shown in object summaries and error messages, including support for multiple allowed data types.
  * Fixed validation so mismatched data types now produce a clear, consistent error instead of an unexpected failure.
* **Tests**
  * Added regression coverage for tuple-based data type formatting and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->