### PR TITLE
fix(psi4): honor requested input method

### DIFF
--- a/dpdata/formats/psi4/input.py
+++ b/dpdata/formats/psi4/input.py
@@ -12,7 +12,7 @@ template = """molecule {{
 }}
 set basis {basis:s}
 set gradient_write on
-G, wfn = gradient("WB97M-D3BJ", return_wfn=True)
+G, wfn = gradient("{method:s}", return_wfn=True)
 wfn.energy()
 wfn.gradient().print_out()
 """

--- a/tests/test_psi4.py
+++ b/tests/test_psi4.py
@@ -95,3 +95,12 @@ class TestPsi4Input(unittest.TestCase):
             """
             ),
         )
+
+    def test_psi4_input_uses_requested_method(self):
+        system = dpdata.LabeledSystem("psi4/psi4.out", fmt="psi4/out")
+        with tempfile.NamedTemporaryFile("r") as f:
+            system.to_psi4_inp(f.name, method="hf", basis="sto-3g")
+            content = f.read()
+
+        self.assertIn('G, wfn = gradient("hf", return_wfn=True)', content)
+        self.assertNotIn('G, wfn = gradient("WB97M-D3BJ", return_wfn=True)', content)


### PR DESCRIPTION
## Summary
- Use the requested `method` argument when writing Psi4 `gradient(...)` calls instead of always writing `WB97M-D3BJ`.
- Add a regression test for non-default Psi4 input methods.

Fixes #992.

## Verification
- `python -m pytest test_psi4.py -q` (from `tests/`): `17 passed in 0.24s`
- `python -m ruff check dpdata/formats/psi4/input.py tests/test_psi4.py`: `All checks passed!`
- Direct smoke check: `write_psi4_input(..., method="hf", basis="sto-3g")` emits `gradient("hf", return_wfn=True)` and no `WB97M-D3BJ`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * PSI4 input generation now uses the method selected by the caller instead of always falling back to a default value.
  * Added coverage to confirm generated PSI4 input reflects the requested method and basis settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->