### PR TITLE
fix: build pymatgen Molecule species from atom_types order (#994)

### DIFF
--- a/dpdata/plugins/pymatgen.py
+++ b/dpdata/plugins/pymatgen.py
@@ -66,9 +66,7 @@ class PyMatgenMoleculeFormat(Format):
         except ModuleNotFoundError as e:
             raise ImportError("No module pymatgen.Molecule") from e
 
-        species = []
-        for name, numb in zip(data["atom_names"], data["atom_numbs"]):
-            species.extend([name] * numb)
+        species = [data["atom_names"][tt] for tt in data["atom_types"]]
         data = dpdata.system.remove_pbc(data)
         for ii in range(np.array(data["coords"]).shape[0]):
             molecule = Molecule(species, data["coords"][ii])

--- a/tests/test_pymatgen_molecule.py
+++ b/tests/test_pymatgen_molecule.py
@@ -36,6 +36,27 @@ class TestPOSCARCart(unittest.TestCase):
         max_dist_1 = np.max(np.linalg.norm(dist, axis=1))
         self.assertAlmostEqual(max_dist_0, max_dist_1)
 
+    def test_ungrouped_atom_types_species_match_coords(self):
+        # Regression for gh-994: species must follow atom_types order, not the
+        # grouped atom_names/atom_numbs order, otherwise sites are assigned the
+        # wrong element when atoms are not grouped by type.
+        system = dpdata.System(
+            data={
+                "atom_names": ["H", "O"],
+                "atom_numbs": [2, 1],
+                "atom_types": np.array([0, 1, 0]),
+                "orig": np.zeros(3),
+                "cells": np.eye(3).reshape(1, 3, 3) * 20,
+                "coords": np.array(
+                    [[[0.0, 0.0, 0.0], [9.0, 0.0, 0.0], [1.0, 0.0, 0.0]]]
+                ),
+            }
+        )
+        mol = system.to("pymatgen/molecule")[0]
+        self.assertEqual([str(site.specie) for site in mol], ["H", "O", "H"])
+        for site, coord in zip(mol, system["coords"][0]):
+            np.testing.assert_allclose(site.coords, coord)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #994.

## Summary

`PyMatgenMoleculeFormat.to_system()` built the `species` list by expanding grouped `atom_names`/`atom_numbs` (e.g. `H, H, O`), but passed `coords` in their `atom_types` order (e.g. `H, O, H`). When atoms are **not** grouped by type, the resulting `pymatgen.core.Molecule` assigns species to the wrong coordinates.

## Change

Build `species` per-atom from `atom_types`, matching the coordinate order — the same construction the sibling Structure exporter already uses in this file:

```python
species = [data["atom_names"][tt] for tt in data["atom_types"]]
```

This is the fix suggested in the issue.

## Testing

- Added a regression test (`test_ungrouped_atom_types_species_match_coords`) using the reporter's reproducer: species now follow the coordinate order (`H, O, H`) and each site sits on its original coordinate. It **fails on master** and passes with this change.
- All 50 pymatgen-related tests pass; `ruff check` and `ruff format --check` clean.

---
*Disclosure: authored with AI assistance (Claude Code); reviewed by me and I'll shepherd it through review.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed molecule conversion so atom species now follow the actual per-atom type order.
  * Ensured converted molecule coordinates continue to match the source structure for each frame.

* **Tests**
  * Added a regression test covering ungrouped atom types to verify species ordering and coordinate mapping during molecule conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->