### PR TITLE
fix(deepmd/hdf5): skip empty optional frame arrays on dump (#996)

### DIFF
--- a/dpdata/formats/deepmd/hdf5.py
+++ b/dpdata/formats/deepmd/hdf5.py
@@ -201,6 +201,13 @@ def dump(
     for dt, prop in data_types.items():
         if dt in data:
             if prop["dump"]:
+                if nframes > 0 and np.asarray(data[dt]).size == 0:
+                    # An optional frame property (e.g. forces/virials when
+                    # cal_force/cal_stress is disabled) may be empty while the
+                    # system still has frames. Skip it instead of writing a
+                    # (nframes, 0) dataset that cannot be reshaped on load. This
+                    # matches the behaviour of the deepmd/raw and deepmd/npy writers.
+                    continue
                 ddata = np.reshape(data[dt], prop["shape"])
                 if np.issubdtype(ddata.dtype, np.floating):
                     ddata = ddata.astype(comp_prec)

--- a/tests/test_deepmd_hdf5.py
+++ b/tests/test_deepmd_hdf5.py
@@ -300,3 +300,50 @@ class TestHDF5MixedIOVariants(unittest.TestCase):
         )
 
         self.assertEqual(len(systems), 0)
+
+
+class TestHDF5EmptyOptionalArray(unittest.TestCase):
+    """Regression test for #996.
+
+    An empty optional frame array (e.g. forces when they are not computed) must not
+    break the deepmd/hdf5 write/read round-trip. Previously the writer stored a
+    ``(nframes, 0)`` dataset that could not be reshaped on load.
+    """
+
+    def tearDown(self):
+        if os.path.isfile("tmp.deepmd.empty.hdf5"):
+            os.remove("tmp.deepmd.empty.hdf5")
+
+    @staticmethod
+    def _make(forces):
+        return dpdata.LabeledSystem(
+            data={
+                "atom_names": ["H"],
+                "atom_numbs": [1],
+                "atom_types": np.array([0]),
+                "cells": np.eye(3).reshape(1, 3, 3),
+                "coords": np.zeros((1, 1, 3)),
+                "energies": np.zeros(1),
+                "orig": np.zeros(3),
+                "forces": forces,
+            }
+        )
+
+    def test_empty_forces_round_trip(self):
+        system = self._make(np.zeros((1, 0, 3)))
+        system.to("deepmd/hdf5", "tmp.deepmd.empty.hdf5")
+        reloaded = dpdata.LabeledSystem("tmp.deepmd.empty.hdf5", fmt="deepmd/hdf5")
+        # The empty optional array is skipped rather than written as (nframes, 0).
+        self.assertNotIn("forces", reloaded.data)
+        np.testing.assert_allclose(reloaded["coords"], system["coords"])
+
+    def test_real_forces_preserved(self):
+        forces = np.arange(3, dtype=float).reshape(1, 1, 3)
+        system = self._make(forces)
+        system.to("deepmd/hdf5", "tmp.deepmd.empty.hdf5")
+        reloaded = dpdata.LabeledSystem("tmp.deepmd.empty.hdf5", fmt="deepmd/hdf5")
+        np.testing.assert_allclose(reloaded["forces"], forces)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #996.

The `deepmd/hdf5` writer reshapes and writes every optional frame array, so an empty optional property (e.g. `forces`/`virials` when `cal_force`/`cal_stress` is disabled) is stored as a `(nframes, 0)` dataset. On load, `to_system_data` tries to reshape that zero-width dataset back to `(nframes, natoms, 3)` and raises `ValueError: cannot reshape array of size 0`.

Reproducer (fails on current `master`):

```python
import dpdata, numpy as np
s = dpdata.LabeledSystem(data={
    "atom_names": ["H"], "atom_numbs": [1], "atom_types": np.array([0]),
    "cells": np.eye(3).reshape(1, 3, 3), "coords": np.zeros((1, 1, 3)),
    "energies": np.zeros(1), "orig": np.zeros(3),
    "forces": np.zeros((1, 0, 3)),
})
s.to("deepmd/hdf5", "t.h5")
dpdata.LabeledSystem("t.h5", fmt="deepmd/hdf5")   # ValueError before this change
```

The `deepmd/raw` and `deepmd/npy` writers already skip this case; this makes the HDF5 writer consistent with them by skipping an optional array whose size is 0 while the system still has frames. Non-empty arrays are written and reloaded exactly as before.

Added `TestHDF5EmptyOptionalArray` covering both the previously-failing empty round-trip and a non-empty round-trip to guard against regression. The `deepmd` test suites pass (`test_deepmd_hdf5`, `test_deepmd_raw`, `test_deepmd_comp`, `test_deepmd_mixed`) and `ruff` is clean.

*Disclosure: written with AI assistance; reviewed and tested before submitting.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HDF5 export/import handling for optional empty per-frame arrays, avoiding invalid data files that could fail to load.
  * Empty optional fields are now skipped during save, while valid data continues to round-trip correctly.

* **Tests**
  * Added regression coverage for empty optional array handling.
  * Added verification that real force data is still preserved after save and reload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->