### PR TITLE
fix(abacus): omit forces when FORCE keyword absent in MD dump

### DIFF
--- a/dpdata/formats/abacus/md.py
+++ b/dpdata/formats/abacus/md.py
@@ -72,7 +72,7 @@ def get_coords_from_dump(dumplines, natoms):
     )
     cells = np.zeros([nframes_dump, 3, 3])
     stresses = np.zeros([nframes_dump, 3, 3])
-    forces = np.zeros([nframes_dump, total_natoms, 3])
+    forces = np.zeros([nframes_dump, total_natoms, 3]) if calc_force else None
     coords = np.zeros([nframes_dump, total_natoms, 3])
     iframe = 0
     for iline in range(nlines):
@@ -187,7 +187,8 @@ def get_frame(fname):
         if np.isnan(iene):
             coords = np.delete(coords, i - ndump, axis=0)
             cells = np.delete(cells, i - ndump, axis=0)
-            force = np.delete(force, i - ndump, axis=0)
+            if force is not None:
+                force = np.delete(force, i - ndump, axis=0)
             stress = np.delete(stress, i - ndump, axis=0)
             energy = np.delete(energy, i - ndump, axis=0)
             unconv_stru += "%d " % i  # noqa: UP031
@@ -207,7 +208,8 @@ def get_frame(fname):
     #    data['cells'][:, :, :] = cell
     data["coords"] = coords
     data["energies"] = energy
-    data["forces"] = force
+    if force is not None:
+        data["forces"] = force
     data["virials"] = stress
     if not isinstance(data["virials"], np.ndarray):
         del data["virials"]


### PR DESCRIPTION
## Summary

Fixes fabricated zero forces when ABACUS MD dump does not contain the FORCE keyword.

### Problem

When `dump_force=False` in ABACUS, the MD dump file omits the FORCE column. The parser (`get_coords_from_dump`) allocates a zero-filled `forces` array and always assigns it to `data["forces"]`. This produces fabricated zero forces that are indistinguishable from real zero forces, silently corrupting `LabeledSystem` output.

### Root Cause

In `dpdata/formats/abacus/md.py`:
- Line 53: `calc_force = False` (default)
- Line 61: Only set to `True` when `"FORCE"` is found in the dump header
- Line 75: `forces = np.zeros(...)` — always allocated, even when `calc_force` is False
- Line 210: `data["forces"] = force` — always assigned, even when forces are fabricated zeros

### Fix

- Return `None` from `get_coords_from_dump` when `calc_force` is False (mirrors existing virials handling)
- Only add `forces` to data dict when it is not `None`
- Guard `np.delete(force, ...)` for unconverged structures against `None`

### Verification

- All 51 ABACUS-related tests pass
- Custom verification confirms: forces is `None` when FORCE absent, ndarray when FORCE present
- Ruff lint and format checks pass

Closes #1000


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of ABACUS molecular dynamics files that do not contain force data.
  - Force information is now omitted when unavailable, preventing invalid or misleading results.
  - Frame filtering now works correctly for files without force entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->