### PR TITLE
docs: repoint jupyterlite xeus channel to prefix.dev

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,6 +1,6 @@
 name: dpdata
 channels:
-  - https://repo.mamba.pm/emscripten-forge
+  - https://prefix.dev/emscripten-forge-dev
   - conda-forge
 dependencies:
   - xeus-python


### PR DESCRIPTION
## Summary

The emscripten-forge conda channel host `repo.mamba.pm` has been decommissioned, so `jupyter lite build` can no longer fetch its repodata and **every** Read the Docs build fails at the "try dpdata online" (JupyterLite) step. This repoints the in-browser kernel environment to the current emscripten-forge channel on prefix.dev.

## Root cause

RTD build log (affects `master`/`latest`, tags, and all PRs — not any single PR):

```
critical libmamba Multiple errors occurred:
    Download error (7) Could not connect to server
    [https://repo.mamba.pm/emscripten-forge/noarch/repodata.json]
    Failed to connect to repo.mamba.pm port ...
```

It is a **time-based outage**, not a per-PR issue. RTD builds pass through Jul 14 and fail from Jul 15 onward; the same commit (`096d5d5`) built green on Jul 14 and red on Jul 15. `repo.mamba.pm` still resolves in DNS but has refused all connections on :443 for days.

## Fix

```diff
 channels:
-  - https://repo.mamba.pm/emscripten-forge
+  - https://prefix.dev/emscripten-forge-dev
   - conda-forge
```

`prefix.dev/emscripten-forge-dev` is verified reachable and serves `xeus-python`/`numpy`/`scipy` for `emscripten-wasm32`; `monty` and `wcmatch` continue to resolve from `conda-forge` noarch as before.

The RTD check on this PR is the real confirmation that the build goes green again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the conda channel URL used for the documentation environment’s Emscripten packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->