### PR TITLE
fix(vasp): report frames dropped for a missing OUTCAR energy

### DIFF
--- a/dpdata/formats/vasp/outcar.py
+++ b/dpdata/formats/vasp/outcar.py
@@ -187,6 +187,17 @@ def _get_frames_lower(fp, fname, begin=0, step=1, ml=False, convergence_check=Tr
                 cc += 1
                 continue
             if energy is None:
+                # Reaching here normally just means the trailing timing report
+                # after the last ionic step. Only an interrupted run leaves a
+                # block that had started emitting step data, and nothing after
+                # it can be read either, since the block splitter keys on the
+                # energy token.
+                if len(coord) > 0 or len(cell) > 0 or len(force) > 0:
+                    warnings.warn(
+                        f"no energy found in frame {cc + 1}; it and any frame "
+                        "after it are not read. This usually means the "
+                        "calculation was interrupted before it finished writing."
+                    )
                 break
             if nwrite == 0:
                 has_label = len(force) > 0 and len(coord) > 0 and len(cell) > 0

--- a/tests/test_vasp_outcar_interrupted.py
+++ b/tests/test_vasp_outcar_interrupted.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+import unittest
+import warnings
+
+import numpy as np
+from context import dpdata
+
+SOURCE = os.path.join("poscars", "OUTCAR.h2o.md")
+
+
+class TestOutcarInterrupted(unittest.TestCase):
+    """An interrupted VASP run leaves a final ionic step without an energy."""
+
+    def setUp(self):
+        with open(SOURCE) as fp:
+            self.lines = fp.read().split("\n")
+        self.energies = [
+            i for i, ll in enumerate(self.lines) if "free  energy   TOTEN" in ll
+        ]
+        self.tmp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp_dir, ignore_errors=True)
+
+    def _load(self, lines):
+        path = os.path.join(self.tmp_dir, "OUTCAR")
+        with open(path, "w") as fp:
+            fp.write("\n".join(lines))
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            system = dpdata.LabeledSystem(path, fmt="vasp/outcar")
+        messages = [
+            str(ii.message) for ii in caught if "no energy found" in str(ii.message)
+        ]
+        return system, messages
+
+    def test_complete_file_is_silent(self):
+        system, messages = self._load(self.lines)
+        self.assertEqual(system.get_nframes(), 3)
+        self.assertEqual(messages, [])
+
+    def test_missing_final_energy_is_reported(self):
+        # Cut the file just before the last TOTEN record.
+        system, messages = self._load(self.lines[: self.energies[-1]])
+        self.assertEqual(system.get_nframes(), 2)
+        self.assertEqual(len(messages), 1)
+        self.assertIn("frame 3", messages[0])
+
+    def test_frames_before_the_cut_are_intact(self):
+        reference = dpdata.LabeledSystem(SOURCE, fmt="vasp/outcar")
+        system, _ = self._load(self.lines[: self.energies[-1]])
+        np.testing.assert_allclose(
+            system["energies"], reference["energies"][:2], atol=1e-10
+        )
+        np.testing.assert_allclose(
+            system["coords"], reference["coords"][:2], atol=1e-10
+        )
+
+    def test_energies_stay_numeric(self):
+        # The original report was np.savetxt choking on an object array after
+        # a None energy was appended.
+        system, _ = self._load(self.lines[: self.energies[-1]])
+        self.assertEqual(system["energies"].dtype, np.dtype("float64"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Ref #566.

## State of the issue

The crash in the report — `TypeError: Mismatch between array dtype ('object') and format specifier ('%.18e')` from `np.savetxt` — no longer reproduces. #844 added a `None` guard in `_get_frames_lower`, so a truncated OUTCAR now yields a clean `float64` energies array. I confirmed this by cutting `tests/poscars/OUTCAR.h2o.md` just before its last `TOTEN` record: 2 frames, `dtype('float64')`, no exception.

What #844 left behind is a bare `break`:

```python
if energy is None:
    break
```

So the damaged frame and every frame after it vanish with no diagnostic at all. A user converting an interrupted run silently gets fewer frames than the run produced, which is the half of njzjz's comment ("there should be an error, or dpdata should ignore the frame") that is still unaddressed.

## Change

Warn before breaking, naming the frame and stating that nothing after it is read either:

```
UserWarning: no energy found in frame 3; it and any frame after it are not read.
This usually means the calculation was interrupted before it finished writing.
```

The same `break` is also the **normal** loop exit — after the last ionic step, `get_outcar_block` returns the trailing timing report, which has no energy either. Warning unconditionally would fire on every well-formed OUTCAR (this is what my first attempt did, and `test_complete_file_is_silent` caught it). The warning is therefore limited to blocks that had already started emitting step data, i.e. where `coord`, `cell`, or `force` is non-empty.

No parsed data changes; this is purely diagnostic.

## Validation

- `tests/test_vasp_outcar_interrupted.py`, 4 new cases: a complete file stays silent, a file cut before the last `TOTEN` warns naming frame 3, the surviving frames keep their exact energies and coordinates, and the energies array stays `float64` (a direct regression test for the dtype in the original traceback).
- `python -m unittest discover` — 2240 passed, 28 skipped.
- `ruff format` / `ruff check` clean.

## On closing the issue

This PR says `Ref` rather than `Fixes` because #566 was filed against dpgen with `awaiting response` and the reporter never came back. The reported crash is gone as of #844 and this closes the silent-data-loss gap it left. Happy to switch to `Fixes` if you would rather close it out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)