### PR TITLE
fix(vasp): read every frame of an ML-only OUTCAR

### DIFF
--- a/dpdata/formats/vasp/outcar.py
+++ b/dpdata/formats/vasp/outcar.py
@@ -154,7 +154,10 @@ def get_frames(fname, begin=0, step=1, ml=False, convergence_check=True):
 
 
 def _get_frames_lower(fp, fname, begin=0, step=1, ml=False, convergence_check=True):
-    blk = get_outcar_block(fp)
+    # Split on the same token as every later block. An ML_ISTART=2 run writes
+    # only "free  energy ML TOTEN", so asking for the ab initio token here
+    # swallowed the whole file into one block and yielded a single frame.
+    blk = get_outcar_block(fp, ml)
 
     atom_names, atom_numbs, atom_types, nelm, nwrite = system_info(
         blk, type_idx_zero=True

--- a/tests/test_vasp_outcar_ml_only.py
+++ b/tests/test_vasp_outcar_ml_only.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+import unittest
+
+import numpy as np
+from context import dpdata
+
+HYBRID = os.path.join("poscars", "OUTCAR.ch4.ml")
+
+
+class TestVaspOutcarMLOnly(unittest.TestCase):
+    """An ``ML_ISTART = 2`` run writes no ab initio energy at all.
+
+    ``OUTCAR.ch4.ml`` is a hybrid run, so it still carries
+    ``free  energy   TOTEN`` records. Dropping them yields the pure-inference
+    layout of #828, where the ab initio token never appears.
+    """
+
+    def setUp(self):
+        with open(HYBRID) as fp:
+            lines = fp.read().split("\n")
+        self.pure_ml = [ii for ii in lines if "free  energy   TOTEN" not in ii]
+        self.tmp_dir = tempfile.mkdtemp()
+        self.path = os.path.join(self.tmp_dir, "OUTCAR")
+        with open(self.path, "w") as fp:
+            fp.write("\n".join(self.pure_ml))
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp_dir, ignore_errors=True)
+
+    def test_all_ml_frames_are_read(self):
+        # Before the fix the first block ran to the end of file, so
+        # analyze_block returned the first ML energy and the loop stopped:
+        # one frame instead of ten.
+        system = dpdata.LabeledSystem(self.path, fmt="vasp/outcar", ml=True)
+        self.assertEqual(system.get_nframes(), 10)
+
+    def test_matches_the_hybrid_run(self):
+        system = dpdata.LabeledSystem(self.path, fmt="vasp/outcar", ml=True)
+        reference = dpdata.LabeledSystem(HYBRID, fmt="vasp/outcar", ml=True)
+        self.assertEqual(system.get_nframes(), reference.get_nframes())
+        np.testing.assert_allclose(system["energies"], reference["energies"])
+        np.testing.assert_allclose(system["coords"], reference["coords"])
+        np.testing.assert_allclose(system["forces"], reference["forces"])
+        self.assertEqual(system["atom_names"], reference["atom_names"])
+
+    def test_system_info_still_parsed(self):
+        # The header must still be inside the first block once that block
+        # ends at the first ML energy instead of the end of file.
+        system = dpdata.LabeledSystem(self.path, fmt="vasp/outcar", ml=True)
+        self.assertEqual(system["atom_names"], ["H", "C"])
+        self.assertEqual(list(system["atom_types"]), [0, 0, 0, 0, 1])
+
+    def test_hybrid_run_is_unaffected(self):
+        self.assertEqual(
+            dpdata.LabeledSystem(HYBRID, fmt="vasp/outcar", ml=True).get_nframes(), 10
+        )
+        self.assertEqual(
+            dpdata.LabeledSystem(HYBRID, fmt="vasp/outcar", ml=False).get_nframes(), 4
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #828.

## Reproduction

With the OUTCAR attached to the issue (`ML_LMLFF = .TRUE.`, `ML_ISTART = 2`, five `free  energy ML TOTEN` records):

```python
dpdata.LabeledSystem("OUTCAR", fmt="vasp/outcar", ml=True).get_nframes()
# 1
```

## Cause

`_get_frames_lower` splits the OUTCAR into blocks on the energy token, and `get_outcar_block` picks the token from its `ml` argument. Every call inside the loop passes it:

```python
blk = get_outcar_block(fp, ml)
```

but the very first call, before the loop, did not:

```python
blk = get_outcar_block(fp)      # always the ab initio token
```

An `ML_ISTART = 2` run performs no ab initio steps, so `free  energy   TOTEN` never appears. That first call scanned to end of file and returned everything as one block. `analyze_block` then returned at the first ML energy it found, giving one frame, and the next `get_outcar_block` hit EOF, so the loop ended.

Passing `ml` to that call fixes it — the issue's file now reads all 5 frames with the energies in the file:

```
[-38.52662, -38.58248, -38.64202, -38.70478, -38.76965]
```

## Why existing coverage missed it

`tests/poscars/OUTCAR.ch4.ml` is a **hybrid** run: 10 ML records *and* 4 ab initio ones. Its first block terminates correctly on the ab initio token, so `TestVaspOUTCARML` passes either way. The bug only appears when the ab initio token is absent entirely.

## Test

Rather than add the reporter's OUTCAR as a fixture, the regression test derives the pure-inference layout from the fixture already in the repo by dropping its `free  energy   TOTEN` lines. That file then has the same shape as an `ML_ISTART = 2` run, and reading it must give the same 10 frames, energies, coordinates, and forces as the hybrid original. 2 of the 4 cases fail on master (1 frame instead of 10); the other two assert the hybrid run is unaffected (still 10 with `ml=True`, 4 with `ml=False`).

The header check matters here too: once the first block ends at the first ML energy instead of end of file, `system_info` must still find `TITEL`, `ions per type`, and `NELM` inside it. It does — they all precede the first ML record — and a test asserts the parsed names and types.

## Validation

- `python -m unittest discover` — 2240 passed, 28 skipped, including all 70 existing `test_vasp_outcar` cases.
- `ruff format` / `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VASP OUTCAR parsing for machine-learning-only calculations.
  * Correctly reads all available frames, energies, coordinates, forces, and system information.
  * Preserved existing parsing behavior for hybrid and standard calculations.

* **Tests**
  * Added coverage validating ML-only frame extraction and hybrid calculation compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->