### PR TITLE
fix(cp2k): say what is missing from an AIMD output directory

### DIFF
--- a/dpdata/plugins/cp2k.py
+++ b/dpdata/plugins/cp2k.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import glob
+import os
 
 import dpdata.formats.cp2k.output
 from dpdata.format import Format
@@ -16,11 +17,45 @@ https://robinzyb.github.io/cp2kdata/
 """
 
 
+def _find_single_file(directory, pattern, description, hint):
+    """Resolve one file inside an AIMD output directory.
+
+    ``cp2k/aimd_output`` is pointed at a directory and locates its inputs by
+    globbing. Without this, a directory missing one of them fails with a bare
+    ``IndexError`` from subscripting the empty match list, which says neither
+    what was looked for nor where.
+    """
+    matches = sorted(glob.glob(os.path.join(directory, pattern)))
+    if not matches:
+        listing = sorted(os.listdir(directory)) if os.path.isdir(directory) else None
+        found = (
+            f" The directory contains: {', '.join(listing) or '(nothing)'}."
+            if listing is not None
+            else f" {directory!r} is not a directory."
+        )
+        raise FileNotFoundError(
+            f"cp2k/aimd_output found no {description} matching {pattern!r} in "
+            f"{directory!r}.{found} {hint}"
+        )
+    return matches[0]
+
+
 @Format.register("cp2k/aimd_output")
 class CP2KAIMDOutputFormat(Format):
     def from_labeled_system(self, file_name, restart=False, **kwargs):
-        xyz_file = sorted(glob.glob(f"{file_name}/*pos*.xyz"))[0]
-        log_file = sorted(glob.glob(f"{file_name}/*.log"))[0]
+        xyz_file = _find_single_file(
+            file_name,
+            "*pos*.xyz",
+            "trajectory file",
+            "CP2K writes it as <PROJECT_NAME>-pos-1.xyz when MOTION/PRINT/TRAJECTORY "
+            "is enabled; pass the directory holding it, not a single file.",
+        )
+        log_file = _find_single_file(
+            file_name,
+            "*.log",
+            "output log",
+            "Redirect the CP2K stdout into this directory, e.g. cp2k.popt -i input.inp > cp2k.log.",
+        )
         try:
             return tuple(Cp2kSystems(log_file, xyz_file, restart))
         except (StopIteration, RuntimeError) as e:

--- a/dpdata/plugins/cp2k.py
+++ b/dpdata/plugins/cp2k.py
@@ -25,14 +25,19 @@ def _find_single_file(directory, pattern, description, hint):
     ``IndexError`` from subscripting the empty match list, which says neither
     what was looked for nor where.
     """
-    matches = sorted(glob.glob(os.path.join(directory, pattern)))
+    # Only ``pattern`` is a glob. Escaping the directory keeps valid names
+    # such as ``run[1]`` from being interpreted as character classes.
+    matches = sorted(
+        glob.glob(os.path.join(glob.escape(os.fspath(directory)), pattern))
+    )
     if not matches:
-        listing = sorted(os.listdir(directory)) if os.path.isdir(directory) else None
-        found = (
-            f" The directory contains: {', '.join(listing) or '(nothing)'}."
-            if listing is not None
-            else f" {directory!r} is not a directory."
-        )
+        if not os.path.exists(directory):
+            found = f" {directory!r} does not exist."
+        elif not os.path.isdir(directory):
+            found = f" {directory!r} is not a directory."
+        else:
+            listing = sorted(os.listdir(directory))
+            found = f" The directory contains: {', '.join(listing) or '(nothing)'}."
         raise FileNotFoundError(
             f"cp2k/aimd_output found no {description} matching {pattern!r} in "
             f"{directory!r}.{found} {hint}"

--- a/tests/test_cp2k_aimd_missing_inputs.py
+++ b/tests/test_cp2k_aimd_missing_inputs.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+import unittest
+
+from context import dpdata
+
+FIXTURE = os.path.join("cp2k", "aimd")
+
+
+class TestCp2kAimdMissingInputs(unittest.TestCase):
+    """``cp2k/aimd_output`` locates its inputs by globbing a directory.
+
+    A directory missing one of them used to fail with a bare ``IndexError``
+    from subscripting the empty match list.
+    """
+
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp()
+        self.work = os.path.join(self.tmp_dir, "aimd")
+        shutil.copytree(FIXTURE, self.work)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp_dir, ignore_errors=True)
+
+    def _remove(self, name):
+        os.remove(os.path.join(self.work, name))
+
+    def test_complete_directory_still_loads(self):
+        system = dpdata.LabeledSystem(self.work, fmt="cp2k/aimd_output")
+        self.assertGreater(system.get_nframes(), 0)
+
+    def test_missing_trajectory_names_the_pattern(self):
+        self._remove("DPGEN-pos-1.xyz")
+        with self.assertRaises(FileNotFoundError) as caught:
+            dpdata.LabeledSystem(self.work, fmt="cp2k/aimd_output")
+        message = str(caught.exception)
+        self.assertIn("*pos*.xyz", message)
+        self.assertIn("trajectory file", message)
+        # The listing tells the user what the parser did see.
+        self.assertIn("cp2k.log", message)
+
+    def test_missing_log_names_the_pattern(self):
+        self._remove("cp2k.log")
+        with self.assertRaises(FileNotFoundError) as caught:
+            dpdata.LabeledSystem(self.work, fmt="cp2k/aimd_output")
+        message = str(caught.exception)
+        self.assertIn("*.log", message)
+        self.assertIn("output log", message)
+
+    def test_pointing_at_a_file_says_so(self):
+        # A frequent mistake: passing the log file rather than its directory.
+        log = os.path.join(self.work, "cp2k.log")
+        with self.assertRaises(FileNotFoundError) as caught:
+            dpdata.LabeledSystem(log, fmt="cp2k/aimd_output")
+        self.assertIn("is not a directory", str(caught.exception))
+
+    def test_missing_directory_says_so(self):
+        absent = os.path.join(self.tmp_dir, "absent")
+        with self.assertRaises(FileNotFoundError) as caught:
+            dpdata.LabeledSystem(absent, fmt="cp2k/aimd_output")
+        self.assertIn("is not a directory", str(caught.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cp2k_aimd_missing_inputs.py
+++ b/tests/test_cp2k_aimd_missing_inputs.py
@@ -32,6 +32,12 @@ class TestCp2kAimdMissingInputs(unittest.TestCase):
         system = dpdata.LabeledSystem(self.work, fmt="cp2k/aimd_output")
         self.assertGreater(system.get_nframes(), 0)
 
+    def test_directory_glob_metacharacters_are_literal(self):
+        bracketed = os.path.join(self.tmp_dir, "aimd[1]")
+        shutil.copytree(FIXTURE, bracketed)
+        system = dpdata.LabeledSystem(bracketed, fmt="cp2k/aimd_output")
+        self.assertGreater(system.get_nframes(), 0)
+
     def test_missing_trajectory_names_the_pattern(self):
         self._remove("DPGEN-pos-1.xyz")
         with self.assertRaises(FileNotFoundError) as caught:
@@ -61,7 +67,7 @@ class TestCp2kAimdMissingInputs(unittest.TestCase):
         absent = os.path.join(self.tmp_dir, "absent")
         with self.assertRaises(FileNotFoundError) as caught:
             dpdata.LabeledSystem(absent, fmt="cp2k/aimd_output")
-        self.assertIn("is not a directory", str(caught.exception))
+        self.assertIn("does not exist", str(caught.exception))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #673.

## What the reporter's data shows

I unpacked the attached `cp2k_test.zip`. It contains `out.log`, `input`, and `model1.xyz` — and `model1.xyz` is the **input geometry**, a single 104-atom frame, not a trajectory. The input has `PROJECT_NAME MEA` and `RUN_TYPE MD`, so CP2K would have written the trajectory as `MEA-pos-1.xyz`, which is not in the archive.

So dpdata could never have parsed this directory. The problem is that it does not say so.

The original traceback (dpdata 0.2.18) came from the typo `cp2k_outputtname=` being swallowed by `**kwargs`, leaving the real argument `None` and surfacing as `TypeError: expected str, bytes or os.PathLike object, not NoneType` inside monty. That argument no longer exists — the plugin now globs the directory — but the failure is just as opaque:

```python
dpdata.LabeledSystem("cp2k_test", fmt="cp2k/aimd_output")
# IndexError: list index out of range
```

from

```python
xyz_file = sorted(glob.glob(f"{file_name}/*pos*.xyz"))[0]
log_file = sorted(glob.glob(f"{file_name}/*.log"))[0]
```

Neither the pattern nor the directory appears anywhere in that message. Answering this issue required @MoseyQAQ to read the plugin source and guess what the argument was meant to be.

## Change

Resolve both globs through a helper that raises `FileNotFoundError` with the pattern, the directory, its actual contents, and how CP2K produces the file:

```
FileNotFoundError: cp2k/aimd_output found no trajectory file matching '*pos*.xyz' in
'/tmp/cp2k673'. The directory contains: input, model1.xyz, out.log. CP2K writes it as
<PROJECT_NAME>-pos-1.xyz when MOTION/PRINT/TRAJECTORY is enabled; pass the directory
holding it, not a single file.
```

A path that is not a directory — the other recurring mistake, passing the log file itself — says exactly that.

This is a diagnostic change only; a complete directory parses as before.

## Validation

- `tests/test_cp2k_aimd_missing_inputs.py`, 5 cases built by copying the existing `cp2k/aimd` fixture and removing one file at a time: complete directory still loads, missing trajectory, missing log, a path pointing at a file, and a path that does not exist. 4 of the 5 fail on master with `IndexError`.
- `python -m unittest discover` — 2241 passed, 28 skipped, including all 110 existing cp2k cases.
- `ruff format` / `ruff check` clean.

## Note

This does not make the reporter's archive loadable — the trajectory file genuinely is not there, and no parser can recover it. What it does is turn a dead-end `IndexError` into a message that names the missing file, which is what the issue actually needed. Worth closing #673 on that basis, or leaving open if you would rather wait for the reporter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CP2K AIMD output auto-discovery when required trajectory (`*pos*.xyz`) and log (`*.log`) files are missing.
  * Error messages now clearly state the expected glob pattern, validate the input path (not a directory vs. missing), and include helpful directory context.
  * Ensures successful loading for complete AIMD output directories, including cases where the directory name contains glob metacharacters.

* **Tests**
  * Added new unit tests covering missing trajectory/log files, invalid and nonexistent paths, glob-metacharacter directory names, and successful parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->